### PR TITLE
Update prebuildStep.bat

### DIFF
--- a/x64_dbg_gui/Project/prebuildStep.bat
+++ b/x64_dbg_gui/Project/prebuildStep.bat
@@ -2,8 +2,8 @@
 rem Working directory: '%{sourceDir}'
 rem argument1: architecture 'x32' or 'x64'
 set result=1
-copy ..\..\bin\%1\lib%1bridge.a Src\Bridge\
+copy ..\..\bin\%1\lib%1_bridge.a Src\Bridge\
 if %ERRORLEVEL%==0 set result=0
-copy ..\..\bin\%1\%1bridge.lib Src\Bridge\
+copy ..\..\bin\%1\%1_bridge.lib Src\Bridge\
 if %ERRORLEVEL%==0 set result=0
 exit %result%


### PR DESCRIPTION
The files when built have an underscore . I think that this is because despite having the file target name set to x32bridge.lib in MSC++2013 , it will place an underscore in the name. So I altered the  prebuild script when I realized the files weren't being copped over.