### PR TITLE
Fix inline string concatenation

### DIFF
--- a/x64_dbg_dbg/_global.cpp
+++ b/x64_dbg_dbg/_global.cpp
@@ -50,7 +50,7 @@ void* emalloc(size_t size, const char* reason)
     emalloc_count++;
     /*
     FILE* file = fopen(alloctrace, "a+");
-    fprintf(file, "DBG%.5d:  alloc:"fhex":%s:"fhex"\n", emalloc_count, a, reason, size);
+    fprintf(file, "DBG%.5d:  alloc:" fhex ":%s:" fhex "\n", emalloc_count, a, reason, size);
     fclose(file);
     */
     return a;
@@ -76,7 +76,7 @@ void* erealloc(void* ptr, size_t size, const char* reason)
     memset(a, 0, size);
     /*
     FILE* file = fopen(alloctrace, "a+");
-    fprintf(file, "DBG%.5d:realloc:"fhex":%s:"fhex"\n", emalloc_count, a, reason, size);
+    fprintf(file, "DBG%.5d:realloc:" fhex ":%s:" fhex "\n", emalloc_count, a, reason, size);
     fclose(file);
     */
     return a;
@@ -92,7 +92,7 @@ void efree(void* ptr, const char* reason)
     emalloc_count--;
     /*
     FILE* file = fopen(alloctrace, "a+");
-    fprintf(file, "DBG%.5d:   free:"fhex":%s\n", emalloc_count, ptr, reason);
+    fprintf(file, "DBG%.5d:   free:" fhex ":%s\n", emalloc_count, ptr, reason);
     fclose(file);
     */
     GlobalFree(ptr);

--- a/x64_dbg_dbg/capstone_wrapper.cpp
+++ b/x64_dbg_dbg/capstone_wrapper.cpp
@@ -86,9 +86,9 @@ String Capstone::OperandText(int opindex) const
     case X86_OP_IMM:
     {
         if(InGroup(CS_GRP_JUMP) || InGroup(CS_GRP_CALL) || IsLoop())
-            sprintf_s(temp, "%"fext"X", op.imm + mInstr->size);
+            sprintf_s(temp, "%" fext "X", op.imm + mInstr->size);
         else
-            sprintf_s(temp, "%"fext"X", op.imm);
+            sprintf_s(temp, "%" fext "X", op.imm);
         result = temp;
     }
     break;
@@ -98,7 +98,7 @@ String Capstone::OperandText(int opindex) const
         const auto & mem = op.mem;
         if(op.mem.base == X86_REG_RIP)  //rip-relative
         {
-            sprintf_s(temp, "%"fext"X", mInstr->address + op.mem.disp + mInstr->size);
+            sprintf_s(temp, "%" fext "X", mInstr->address + op.mem.disp + mInstr->size);
             result += temp;
         }
         else //normal
@@ -124,10 +124,10 @@ String Capstone::OperandText(int opindex) const
                 if(mem.disp < 0)
                 {
                     operatorText = '-';
-                    sprintf_s(temp, "%"fext"X", mem.disp * -1);
+                    sprintf_s(temp, "%" fext "X", mem.disp * -1);
                 }
                 else
-                    sprintf_s(temp, "%"fext"X", mem.disp);
+                    sprintf_s(temp, "%" fext "X", mem.disp);
                 if(prependPlus)
                     result += operatorText;
                 result += temp;

--- a/x64_dbg_dbg/debugger.cpp
+++ b/x64_dbg_dbg/debugger.cpp
@@ -270,16 +270,16 @@ void cbUserBreakpoint()
         if(symbolicname)
         {
             if(*bp.name)
-                dprintf("%s breakpoint \"%s\" at %s ("fhex")!\n", bptype, bp.name, symbolicname, bp.addr);
+                dprintf("%s breakpoint \"%s\" at %s (" fhex ")!\n", bptype, bp.name, symbolicname, bp.addr);
             else
-                dprintf("%s breakpoint at %s ("fhex")!\n", bptype, symbolicname, bp.addr);
+                dprintf("%s breakpoint at %s (" fhex ")!\n", bptype, symbolicname, bp.addr);
         }
         else
         {
             if(*bp.name)
-                dprintf("%s breakpoint \"%s\" at "fhex"!\n", bptype, bp.name, bp.addr);
+                dprintf("%s breakpoint \"%s\" at " fhex "!\n", bptype, bp.name, bp.addr);
             else
-                dprintf("%s breakpoint at "fhex"!\n", bptype, bp.addr);
+                dprintf("%s breakpoint at " fhex "!\n", bptype, bp.addr);
         }
         if(bp.singleshoot)
             BpDelete(bp.addr, BPNORMAL);
@@ -347,16 +347,16 @@ void cbHardwareBreakpoint(void* ExceptionAddress)
         if(symbolicname)
         {
             if(*bp.name)
-                dprintf("Hardware breakpoint (%s%s) \"%s\" at %s ("fhex")!\n", bpsize, bptype, bp.name, symbolicname, bp.addr);
+                dprintf("Hardware breakpoint (%s%s) \"%s\" at %s (" fhex ")!\n", bpsize, bptype, bp.name, symbolicname, bp.addr);
             else
-                dprintf("Hardware breakpoint (%s%s) at %s ("fhex")!\n", bpsize, bptype, symbolicname, bp.addr);
+                dprintf("Hardware breakpoint (%s%s) at %s (" fhex ")!\n", bpsize, bptype, symbolicname, bp.addr);
         }
         else
         {
             if(*bp.name)
-                dprintf("Hardware breakpoint (%s%s) \"%s\" at "fhex"!\n", bpsize, bptype, bp.name, bp.addr);
+                dprintf("Hardware breakpoint (%s%s) \"%s\" at " fhex "!\n", bpsize, bptype, bp.name, bp.addr);
             else
-                dprintf("Hardware breakpoint (%s%s) at "fhex"!\n", bpsize, bptype, bp.addr);
+                dprintf("Hardware breakpoint (%s%s) at " fhex "!\n", bpsize, bptype, bp.addr);
         }
         BpToBridge(&bp, &pluginBp);
         bpInfo.breakpoint = &pluginBp;
@@ -408,16 +408,16 @@ void cbMemoryBreakpoint(void* ExceptionAddress)
         if(symbolicname)
         {
             if(*bp.name)
-                dprintf("Memory breakpoint%s \"%s\" at %s ("fhex", "fhex")!\n", bptype, bp.name, symbolicname, bp.addr, ExceptionAddress);
+                dprintf("Memory breakpoint%s \"%s\" at %s (" fhex ", " fhex ")!\n", bptype, bp.name, symbolicname, bp.addr, ExceptionAddress);
             else
-                dprintf("Memory breakpoint%s at %s ("fhex", "fhex")!\n", bptype, symbolicname, bp.addr, ExceptionAddress);
+                dprintf("Memory breakpoint%s at %s (" fhex ", " fhex ")!\n", bptype, symbolicname, bp.addr, ExceptionAddress);
         }
         else
         {
             if(*bp.name)
-                dprintf("Memory breakpoint%s \"%s\" at "fhex" ("fhex")!\n", bptype, bp.name, bp.addr, ExceptionAddress);
+                dprintf("Memory breakpoint%s \"%s\" at " fhex " (" fhex ")!\n", bptype, bp.name, bp.addr, ExceptionAddress);
             else
-                dprintf("Memory breakpoint%s at "fhex" ("fhex")!\n", bptype, bp.addr, ExceptionAddress);
+                dprintf("Memory breakpoint%s at " fhex " (" fhex ")!\n", bptype, bp.addr, ExceptionAddress);
         }
         BpToBridge(&bp, &pluginBp);
         bpInfo.breakpoint = &pluginBp;
@@ -521,7 +521,7 @@ bool cbSetModuleBreakpoints(const BREAKPOINT* bp)
     case BPNORMAL:
     {
         if(!SetBPX(bp->addr, bp->titantype, (void*)cbUserBreakpoint))
-            dprintf("Could not set breakpoint "fhex"! (SetBPX)\n", bp->addr);
+            dprintf("Could not set breakpoint " fhex "! (SetBPX)\n", bp->addr);
     }
     break;
 
@@ -530,7 +530,7 @@ bool cbSetModuleBreakpoints(const BREAKPOINT* bp)
         uint size = 0;
         MemFindBaseAddr(bp->addr, &size);
         if(!SetMemoryBPXEx(bp->addr, size, bp->titantype, !bp->singleshoot, (void*)cbMemoryBreakpoint))
-            dprintf("Could not set memory breakpoint "fhex"! (SetMemoryBPXEx)\n", bp->addr);
+            dprintf("Could not set memory breakpoint " fhex "! (SetMemoryBPXEx)\n", bp->addr);
     }
     break;
 
@@ -546,7 +546,7 @@ bool cbSetModuleBreakpoints(const BREAKPOINT* bp)
         TITANSETDRX(titantype, drx);
         BpSetTitanType(bp->addr, BPHARDWARE, titantype);
         if(!SetHardwareBreakPoint(bp->addr, drx, TITANGETTYPE(bp->titantype), TITANGETSIZE(bp->titantype), (void*)cbHardwareBreakpoint))
-            dprintf("Could not set hardware breakpoint "fhex"! (SetHardwareBreakPoint)\n", bp->addr);
+            dprintf("Could not set hardware breakpoint " fhex "! (SetHardwareBreakPoint)\n", bp->addr);
     }
     break;
 
@@ -564,15 +564,15 @@ static bool cbRemoveModuleBreakpoints(const BREAKPOINT* bp)
     {
     case BPNORMAL:
         if(!DeleteBPX(bp->addr))
-            dprintf("Could not delete breakpoint "fhex"! (DeleteBPX)\n", bp->addr);
+            dprintf("Could not delete breakpoint " fhex "! (DeleteBPX)\n", bp->addr);
         break;
     case BPMEMORY:
         if(!RemoveMemoryBPX(bp->addr, 0))
-            dprintf("Could not delete memory breakpoint "fhex"! (RemoveMemoryBPX)\n", bp->addr);
+            dprintf("Could not delete memory breakpoint " fhex "! (RemoveMemoryBPX)\n", bp->addr);
         break;
     case BPHARDWARE:
         if(!DeleteHardwareBreakPoint(TITANGETDRX(bp->titantype)))
-            dprintf("Could not delete hardware breakpoint "fhex"! (DeleteHardwareBreakPoint)\n", bp->addr);
+            dprintf("Could not delete hardware breakpoint " fhex "! (DeleteHardwareBreakPoint)\n", bp->addr);
         break;
     default:
         break;
@@ -638,7 +638,7 @@ static void cbCreateProcess(CREATE_PROCESS_DEBUG_INFO* CreateProcessInfo)
     char DebugFileName[deflen] = "";
     if(!GetFileNameFromHandle(CreateProcessInfo->hFile, DebugFileName))
         strcpy_s(DebugFileName, "??? (GetFileNameFromHandle failed!)");
-    dprintf("Process Started: "fhex" %s\n", base, DebugFileName);
+    dprintf("Process Started: " fhex " %s\n", base, DebugFileName);
 
     //update memory map
     dbggetprivateusage(fdProcessInfo->hProcess, true);
@@ -715,7 +715,7 @@ static void cbCreateProcess(CREATE_PROCESS_DEBUG_INFO* CreateProcessInfo)
                         uint callbackVA = TLSCallBacks()[i] - ImageBase + pDebuggedBase;
                         if(MemIsValidReadPtr(callbackVA))
                         {
-                            sprintf(command, "bp "fhex",\"TLS Callback %d\",ss", callbackVA, i + 1);
+                            sprintf(command, "bp " fhex ",\"TLS Callback %d\",ss", callbackVA, i + 1);
                             cmddirectexec(dbggetcommandlist(), command);
                         }
                         else
@@ -729,7 +729,7 @@ static void cbCreateProcess(CREATE_PROCESS_DEBUG_INFO* CreateProcessInfo)
 
         if(settingboolget("Events", "EntryBreakpoint"))
         {
-            sprintf(command, "bp "fhex",\"entry breakpoint\",ss", (uint)CreateProcessInfo->lpStartAddress);
+            sprintf(command, "bp " fhex ",\"entry breakpoint\",ss", (uint)CreateProcessInfo->lpStartAddress);
             cmddirectexec(dbggetcommandlist(), command);
         }
     }
@@ -770,7 +770,7 @@ static void cbCreateThread(CREATE_THREAD_DEBUG_INFO* CreateThread)
     if(settingboolget("Events", "ThreadEntry"))
     {
         char command[256] = "";
-        sprintf(command, "bp "fhex",\"Thread %X\",ss", (uint)CreateThread->lpStartAddress, dwThreadId);
+        sprintf(command, "bp " fhex ",\"Thread %X\",ss", (uint)CreateThread->lpStartAddress, dwThreadId);
         cmddirectexec(dbggetcommandlist(), command);
     }
 
@@ -895,7 +895,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
         if(settingboolget("Events", "EntryBreakpoint"))
         {
             bAlreadySetEntry = true;
-            sprintf(command, "bp "fhex",\"entry breakpoint\",ss", pDebuggedBase + pDebuggedEntry);
+            sprintf(command, "bp " fhex ",\"entry breakpoint\",ss", pDebuggedBase + pDebuggedEntry);
             cmddirectexec(dbggetcommandlist(), command);
         }
     }
@@ -921,9 +921,9 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
                     if(MemIsValidReadPtr(callbackVA))
                     {
                         if(bIsDebuggingThis)
-                            sprintf(command, "bp "fhex",\"TLS Callback %d\",ss", callbackVA, i + 1);
+                            sprintf(command, "bp " fhex ",\"TLS Callback %d\",ss", callbackVA, i + 1);
                         else
-                            sprintf(command, "bp "fhex",\"TLS Callback %d (%s)\",ss", callbackVA, i + 1, modname);
+                            sprintf(command, "bp " fhex ",\"TLS Callback %d (%s)\",ss", callbackVA, i + 1, modname);
                         cmddirectexec(dbggetcommandlist(), command);
                     }
                     else
@@ -941,12 +941,12 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
         if(oep)
         {
             char command[256] = "";
-            sprintf(command, "bp "fhex",\"DllMain (%s)\",ss", oep + (uint)base, modname);
+            sprintf(command, "bp " fhex ",\"DllMain (%s)\",ss", oep + (uint)base, modname);
             cmddirectexec(dbggetcommandlist(), command);
         }
     }
 
-    dprintf("DLL Loaded: "fhex" %s\n", base, DLLDebugFileName);
+    dprintf("DLL Loaded: " fhex " %s\n", base, DLLDebugFileName);
 
     //plugin callback
     PLUG_CB_LOADDLL callbackInfo;
@@ -984,7 +984,7 @@ static void cbUnloadDll(UNLOAD_DLL_DEBUG_INFO* UnloadDll)
         BpEnumAll(cbRemoveModuleBreakpoints, modname);
     GuiUpdateBreakpointsView();
     SafeSymUnloadModule64(fdProcessInfo->hProcess, (DWORD64)base);
-    dprintf("DLL Unloaded: "fhex" %s\n", base, modname);
+    dprintf("DLL Unloaded: " fhex " %s\n", base, modname);
 
     if(bBreakOnNextDll || settingboolget("Events", "DllUnload"))
     {
@@ -1114,9 +1114,9 @@ static void cbException(EXCEPTION_DEBUG_INFO* ExceptionData)
     if(ExceptionData->dwFirstChance) //first chance exception
     {
         if(exceptionName)
-            dprintf("First chance exception on "fhex" (%.8X, %s)!\n", addr, ExceptionCode, exceptionName);
+            dprintf("First chance exception on " fhex " (%.8X, %s)!\n", addr, ExceptionCode, exceptionName);
         else
-            dprintf("First chance exception on "fhex" (%.8X)!\n", addr, ExceptionCode);
+            dprintf("First chance exception on " fhex " (%.8X)!\n", addr, ExceptionCode);
         SetNextDbgContinueStatus(DBG_EXCEPTION_NOT_HANDLED);
         if(bSkipExceptions || dbgisignoredexception(ExceptionCode))
             return;
@@ -1124,9 +1124,9 @@ static void cbException(EXCEPTION_DEBUG_INFO* ExceptionData)
     else //lock the exception
     {
         if(exceptionName)
-            dprintf("Last chance exception on "fhex" (%.8X, %s)!\n", addr, ExceptionCode, exceptionName);
+            dprintf("Last chance exception on " fhex " (%.8X, %s)!\n", addr, ExceptionCode, exceptionName);
         else
-            dprintf("Last chance exception on "fhex" (%.8X)!\n", addr, ExceptionCode);
+            dprintf("Last chance exception on " fhex " (%.8X)!\n", addr, ExceptionCode);
         SetNextDbgContinueStatus(DBG_CONTINUE);
     }
 
@@ -1252,12 +1252,12 @@ bool cbDeleteAllBreakpoints(const BREAKPOINT* bp)
 {
     if(!BpDelete(bp->addr, BPNORMAL))
     {
-        dprintf("Delete breakpoint failed (BpDelete): "fhex"\n", bp->addr);
+        dprintf("Delete breakpoint failed (BpDelete): " fhex "\n", bp->addr);
         return false;
     }
     if(!bp->enabled || DeleteBPX(bp->addr))
         return true;
-    dprintf("Delete breakpoint failed (DeleteBPX): "fhex"\n", bp->addr);
+    dprintf("Delete breakpoint failed (DeleteBPX): " fhex "\n", bp->addr);
     return false;
 }
 
@@ -1268,12 +1268,12 @@ bool cbEnableAllBreakpoints(const BREAKPOINT* bp)
 
     if(!BpEnable(bp->addr, BPNORMAL, true))
     {
-        dprintf("Could not enable breakpoint "fhex" (BpEnable)\n", bp->addr);
+        dprintf("Could not enable breakpoint " fhex " (BpEnable)\n", bp->addr);
         return false;
     }
     if(!SetBPX(bp->addr, bp->titantype, (void*)cbUserBreakpoint))
     {
-        dprintf("Could not enable breakpoint "fhex" (SetBPX)\n", bp->addr);
+        dprintf("Could not enable breakpoint " fhex " (SetBPX)\n", bp->addr);
         return false;
     }
     return true;
@@ -1286,12 +1286,12 @@ bool cbDisableAllBreakpoints(const BREAKPOINT* bp)
 
     if(!BpEnable(bp->addr, BPNORMAL, false))
     {
-        dprintf("Could not disable breakpoint "fhex" (BpEnable)\n", bp->addr);
+        dprintf("Could not disable breakpoint " fhex " (BpEnable)\n", bp->addr);
         return false;
     }
     if(!DeleteBPX(bp->addr))
     {
-        dprintf("Could not disable breakpoint "fhex" (DeleteBPX)\n", bp->addr);
+        dprintf("Could not disable breakpoint " fhex " (DeleteBPX)\n", bp->addr);
         return false;
     }
     return true;
@@ -1304,7 +1304,7 @@ bool cbEnableAllHardwareBreakpoints(const BREAKPOINT* bp)
     DWORD drx = 0;
     if(!GetUnusedHardwareBreakPointRegister(&drx))
     {
-        dprintf("Did not enable hardware breakpoint "fhex" (all slots full)\n", bp->addr);
+        dprintf("Did not enable hardware breakpoint " fhex " (all slots full)\n", bp->addr);
         return true;
     }
     int titantype = bp->titantype;
@@ -1312,12 +1312,12 @@ bool cbEnableAllHardwareBreakpoints(const BREAKPOINT* bp)
     BpSetTitanType(bp->addr, BPHARDWARE, titantype);
     if(!BpEnable(bp->addr, BPHARDWARE, true))
     {
-        dprintf("Could not enable hardware breakpoint "fhex" (BpEnable)\n", bp->addr);
+        dprintf("Could not enable hardware breakpoint " fhex " (BpEnable)\n", bp->addr);
         return false;
     }
     if(!SetHardwareBreakPoint(bp->addr, drx, TITANGETTYPE(bp->titantype), TITANGETSIZE(bp->titantype), (void*)cbHardwareBreakpoint))
     {
-        dprintf("Could not enable hardware breakpoint "fhex" (SetHardwareBreakPoint)\n", bp->addr);
+        dprintf("Could not enable hardware breakpoint " fhex " (SetHardwareBreakPoint)\n", bp->addr);
         return false;
     }
     return true;
@@ -1329,12 +1329,12 @@ bool cbDisableAllHardwareBreakpoints(const BREAKPOINT* bp)
         return true;
     if(!BpEnable(bp->addr, BPHARDWARE, false))
     {
-        dprintf("Could not disable hardware breakpoint "fhex" (BpEnable)\n", bp->addr);
+        dprintf("Could not disable hardware breakpoint " fhex " (BpEnable)\n", bp->addr);
         return false;
     }
     if(!DeleteHardwareBreakPoint(TITANGETDRX(bp->titantype)))
     {
-        dprintf("Could not disable hardware breakpoint "fhex" (DeleteHardwareBreakPoint)\n", bp->addr);
+        dprintf("Could not disable hardware breakpoint " fhex " (DeleteHardwareBreakPoint)\n", bp->addr);
         return false;
     }
     return true;
@@ -1348,12 +1348,12 @@ bool cbEnableAllMemoryBreakpoints(const BREAKPOINT* bp)
     MemFindBaseAddr(bp->addr, &size);
     if(!BpEnable(bp->addr, BPMEMORY, true))
     {
-        dprintf("Could not enable memory breakpoint "fhex" (BpEnable)\n", bp->addr);
+        dprintf("Could not enable memory breakpoint " fhex " (BpEnable)\n", bp->addr);
         return false;
     }
     if(!SetMemoryBPXEx(bp->addr, size, bp->titantype, !bp->singleshoot, (void*)cbMemoryBreakpoint))
     {
-        dprintf("Could not enable memory breakpoint "fhex" (SetMemoryBPXEx)\n", bp->addr);
+        dprintf("Could not enable memory breakpoint " fhex " (SetMemoryBPXEx)\n", bp->addr);
         return false;
     }
     return true;
@@ -1365,12 +1365,12 @@ bool cbDisableAllMemoryBreakpoints(const BREAKPOINT* bp)
         return true;
     if(!BpEnable(bp->addr, BPMEMORY, false))
     {
-        dprintf("Could not disable memory breakpoint "fhex" (BpEnable)\n", bp->addr);
+        dprintf("Could not disable memory breakpoint " fhex " (BpEnable)\n", bp->addr);
         return false;
     }
     if(!RemoveMemoryBPX(bp->addr, 0))
     {
-        dprintf("Could not disable memory breakpoint "fhex" (RemoveMemoryBPX)\n", bp->addr);
+        dprintf("Could not disable memory breakpoint " fhex " (RemoveMemoryBPX)\n", bp->addr);
         return false;
     }
     return true;
@@ -1392,9 +1392,9 @@ bool cbBreakpointList(const BREAKPOINT* bp)
         type = "GP";
     bool enabled = bp->enabled;
     if(*bp->name)
-        dprintf("%d:%s:"fhex":\"%s\"\n", enabled, type, bp->addr, bp->name);
+        dprintf("%d:%s:" fhex ":\"%s\"\n", enabled, type, bp->addr, bp->name);
     else
-        dprintf("%d:%s:"fhex"\n", enabled, type, bp->addr);
+        dprintf("%d:%s:" fhex "\n", enabled, type, bp->addr);
     return true;
 }
 
@@ -1406,12 +1406,12 @@ bool cbDeleteAllMemoryBreakpoints(const BREAKPOINT* bp)
     MemFindBaseAddr(bp->addr, &size);
     if(!BpDelete(bp->addr, BPMEMORY))
     {
-        dprintf("Delete memory breakpoint failed (BpDelete): "fhex"\n", bp->addr);
+        dprintf("Delete memory breakpoint failed (BpDelete): " fhex "\n", bp->addr);
         return false;
     }
     if(!RemoveMemoryBPX(bp->addr, size))
     {
-        dprintf("Delete memory breakpoint failed (RemoveMemoryBPX): "fhex"\n", bp->addr);
+        dprintf("Delete memory breakpoint failed (RemoveMemoryBPX): " fhex "\n", bp->addr);
         return false;
     }
     return true;
@@ -1423,12 +1423,12 @@ bool cbDeleteAllHardwareBreakpoints(const BREAKPOINT* bp)
         return true;
     if(!BpDelete(bp->addr, BPHARDWARE))
     {
-        dprintf("Delete hardware breakpoint failed (BpDelete): "fhex"\n", bp->addr);
+        dprintf("Delete hardware breakpoint failed (BpDelete): " fhex "\n", bp->addr);
         return false;
     }
     if(!DeleteHardwareBreakPoint(TITANGETDRX(bp->titantype)))
     {
-        dprintf("Delete hardware breakpoint failed (DeleteHardwareBreakPoint): "fhex"\n", bp->addr);
+        dprintf("Delete hardware breakpoint failed (DeleteHardwareBreakPoint): " fhex "\n", bp->addr);
         return false;
     }
     return true;

--- a/x64_dbg_dbg/debugger_commands.cpp
+++ b/x64_dbg_dbg/debugger_commands.cpp
@@ -235,25 +235,25 @@ CMDRESULT cbDebugSetBPX(int argc, char* argv[]) //bp addr [,name [,type]]
     }
     if(IsBPXEnabled(addr))
     {
-        dprintf("Error setting breakpoint at "fhex"! (IsBPXEnabled)\n", addr);
+        dprintf("Error setting breakpoint at " fhex "! (IsBPXEnabled)\n", addr);
         return STATUS_ERROR;
     }
     else if(!MemRead(addr, &oldbytes, sizeof(short)))
     {
-        dprintf("Error setting breakpoint at "fhex"! (memread)\n", addr);
+        dprintf("Error setting breakpoint at " fhex "! (memread)\n", addr);
         return STATUS_ERROR;
     }
     else if(!BpNew(addr, true, singleshoot, oldbytes, BPNORMAL, type, bpname))
     {
-        dprintf("Error setting breakpoint at "fhex"! (bpnew)\n", addr);
+        dprintf("Error setting breakpoint at " fhex "! (bpnew)\n", addr);
         return STATUS_ERROR;
     }
     else if(!SetBPX(addr, type, (void*)cbUserBreakpoint))
     {
-        dprintf("Error setting breakpoint at "fhex"! (SetBPX)\n", addr);
+        dprintf("Error setting breakpoint at " fhex "! (SetBPX)\n", addr);
         return STATUS_ERROR;
     }
-    dprintf("Breakpoint at "fhex" set!\n", addr);
+    dprintf("Breakpoint at " fhex " set!\n", addr);
     GuiUpdateAllViews();
     return STATUS_CONTINUE;
 }
@@ -281,12 +281,12 @@ CMDRESULT cbDebugDeleteBPX(int argc, char* argv[])
     {
         if(!BpDelete(found.addr, BPNORMAL))
         {
-            dprintf("Delete breakpoint failed (bpdel): "fhex"\n", found.addr);
+            dprintf("Delete breakpoint failed (bpdel): " fhex "\n", found.addr);
             return STATUS_ERROR;
         }
         else if(found.enabled && !DeleteBPX(found.addr))
         {
-            dprintf("Delete breakpoint failed (DeleteBPX): "fhex"\n", found.addr);
+            dprintf("Delete breakpoint failed (DeleteBPX): " fhex "\n", found.addr);
             GuiUpdateAllViews();
             return STATUS_ERROR;
         }
@@ -300,12 +300,12 @@ CMDRESULT cbDebugDeleteBPX(int argc, char* argv[])
     }
     if(!BpDelete(found.addr, BPNORMAL))
     {
-        dprintf("Delete breakpoint failed (bpdel): "fhex"\n", found.addr);
+        dprintf("Delete breakpoint failed (bpdel): " fhex "\n", found.addr);
         return STATUS_ERROR;
     }
     else if(found.enabled && !DeleteBPX(found.addr))
     {
-        dprintf("Delete breakpoint failed (DeleteBPX): "fhex"\n", found.addr);
+        dprintf("Delete breakpoint failed (DeleteBPX): " fhex "\n", found.addr);
         GuiUpdateAllViews();
         return STATUS_ERROR;
     }
@@ -334,12 +334,12 @@ CMDRESULT cbDebugEnableBPX(int argc, char* argv[])
     {
         if(!BpEnable(found.addr, BPNORMAL, true))
         {
-            dprintf("Could not enable breakpoint "fhex" (BpEnable)\n", found.addr);
+            dprintf("Could not enable breakpoint " fhex " (BpEnable)\n", found.addr);
             return STATUS_ERROR;
         }
         if(!SetBPX(found.addr, found.titantype, (void*)cbUserBreakpoint))
         {
-            dprintf("Could not enable breakpoint "fhex" (SetBPX)\n", found.addr);
+            dprintf("Could not enable breakpoint " fhex " (SetBPX)\n", found.addr);
             return STATUS_ERROR;
         }
         GuiUpdateAllViews();
@@ -359,12 +359,12 @@ CMDRESULT cbDebugEnableBPX(int argc, char* argv[])
     }
     if(!BpEnable(found.addr, BPNORMAL, true))
     {
-        dprintf("Could not enable breakpoint "fhex" (BpEnable)\n", found.addr);
+        dprintf("Could not enable breakpoint " fhex " (BpEnable)\n", found.addr);
         return STATUS_ERROR;
     }
     if(!SetBPX(found.addr, found.titantype, (void*)cbUserBreakpoint))
     {
-        dprintf("Could not enable breakpoint "fhex" (SetBPX)\n", found.addr);
+        dprintf("Could not enable breakpoint " fhex " (SetBPX)\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Breakpoint enabled!");
@@ -392,12 +392,12 @@ CMDRESULT cbDebugDisableBPX(int argc, char* argv[])
     {
         if(!BpEnable(found.addr, BPNORMAL, false))
         {
-            dprintf("Could not disable breakpoint "fhex" (BpEnable)\n", found.addr);
+            dprintf("Could not disable breakpoint " fhex " (BpEnable)\n", found.addr);
             return STATUS_ERROR;
         }
         if(!DeleteBPX(found.addr))
         {
-            dprintf("Could not disable breakpoint "fhex" (DeleteBPX)\n", found.addr);
+            dprintf("Could not disable breakpoint " fhex " (DeleteBPX)\n", found.addr);
             return STATUS_ERROR;
         }
         GuiUpdateAllViews();
@@ -416,12 +416,12 @@ CMDRESULT cbDebugDisableBPX(int argc, char* argv[])
     }
     if(!BpEnable(found.addr, BPNORMAL, false))
     {
-        dprintf("Could not disable breakpoint "fhex" (BpEnable)\n", found.addr);
+        dprintf("Could not disable breakpoint " fhex " (BpEnable)\n", found.addr);
         return STATUS_ERROR;
     }
     if(!DeleteBPX(found.addr))
     {
-        dprintf("Could not disable breakpoint "fhex" (DeleteBPX)\n", found.addr);
+        dprintf("Could not disable breakpoint " fhex " (DeleteBPX)\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Breakpoint disabled!");
@@ -567,7 +567,7 @@ CMDRESULT cbDebugSetMemoryBpx(int argc, char* argv[])
         dputs("Error setting memory breakpoint! (SetMemoryBPXEx)");
         return STATUS_ERROR;
     }
-    dprintf("Memory breakpoint at "fhex" set!\n", addr);
+    dprintf("Memory breakpoint at " fhex " set!\n", addr);
     GuiUpdateAllViews();
     return STATUS_CONTINUE;
 }
@@ -594,12 +594,12 @@ CMDRESULT cbDebugDeleteMemoryBreakpoint(int argc, char* argv[])
         MemFindBaseAddr(found.addr, &size);
         if(!BpDelete(found.addr, BPMEMORY))
         {
-            dprintf("Delete memory breakpoint failed: "fhex" (BpDelete)\n", found.addr);
+            dprintf("Delete memory breakpoint failed: " fhex " (BpDelete)\n", found.addr);
             return STATUS_ERROR;
         }
         if(!RemoveMemoryBPX(found.addr, size))
         {
-            dprintf("Delete memory breakpoint failed: "fhex" (RemoveMemoryBPX)\n", found.addr);
+            dprintf("Delete memory breakpoint failed: " fhex " (RemoveMemoryBPX)\n", found.addr);
             return STATUS_ERROR;
         }
         return STATUS_CONTINUE;
@@ -614,12 +614,12 @@ CMDRESULT cbDebugDeleteMemoryBreakpoint(int argc, char* argv[])
     MemFindBaseAddr(found.addr, &size);
     if(!BpDelete(found.addr, BPMEMORY))
     {
-        dprintf("Delete memory breakpoint failed: "fhex" (BpDelete)\n", found.addr);
+        dprintf("Delete memory breakpoint failed: " fhex " (BpDelete)\n", found.addr);
         return STATUS_ERROR;
     }
     if(!RemoveMemoryBPX(found.addr, size))
     {
-        dprintf("Delete memory breakpoint failed: "fhex" (RemoveMemoryBPX)\n", found.addr);
+        dprintf("Delete memory breakpoint failed: " fhex " (RemoveMemoryBPX)\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Memory breakpoint deleted!");
@@ -727,7 +727,7 @@ CMDRESULT cbDebugSetHardwareBreakpoint(int argc, char* argv[])
         dputs("Error setting hardware breakpoint (TitanEngine)!");
         return STATUS_ERROR;
     }
-    dprintf("Hardware breakpoint at "fhex" set!\n", addr);
+    dprintf("Hardware breakpoint at " fhex " set!\n", addr);
     GuiUpdateAllViews();
     return STATUS_CONTINUE;
 }
@@ -752,12 +752,12 @@ CMDRESULT cbDebugDeleteHardwareBreakpoint(int argc, char* argv[])
     {
         if(!BpDelete(found.addr, BPHARDWARE))
         {
-            dprintf("Delete hardware breakpoint failed: "fhex" (BpDelete)\n", found.addr);
+            dprintf("Delete hardware breakpoint failed: " fhex " (BpDelete)\n", found.addr);
             return STATUS_ERROR;
         }
         if(!DeleteHardwareBreakPoint(TITANGETDRX(found.titantype)))
         {
-            dprintf("Delete hardware breakpoint failed: "fhex" (DeleteHardwareBreakPoint)\n", found.addr);
+            dprintf("Delete hardware breakpoint failed: " fhex " (DeleteHardwareBreakPoint)\n", found.addr);
             return STATUS_ERROR;
         }
         return STATUS_CONTINUE;
@@ -770,12 +770,12 @@ CMDRESULT cbDebugDeleteHardwareBreakpoint(int argc, char* argv[])
     }
     if(!BpDelete(found.addr, BPHARDWARE))
     {
-        dprintf("Delete hardware breakpoint failed: "fhex" (BpDelete)\n", found.addr);
+        dprintf("Delete hardware breakpoint failed: " fhex " (BpDelete)\n", found.addr);
         return STATUS_ERROR;
     }
     if(!DeleteHardwareBreakPoint(TITANGETDRX(found.titantype)))
     {
-        dprintf("Delete hardware breakpoint failed: "fhex" (DeleteHardwareBreakPoint)\n", found.addr);
+        dprintf("Delete hardware breakpoint failed: " fhex " (DeleteHardwareBreakPoint)\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Hardware breakpoint deleted!");
@@ -867,7 +867,7 @@ CMDRESULT cbDebugMemset(int argc, char* argv[])
     if(!Fill((void*)addr, size & 0xFFFFFFFF, &fi))
         dputs("Memset failed");
     else
-        dprintf("Memory "fhex" (size: %.8X) set to %.2X\n", addr, size & 0xFFFFFFFF, value & 0xFF);
+        dprintf("Memory " fhex " (size: %.8X) set to %.2X\n", addr, size & 0xFFFFFFFF, value & 0xFF);
     return STATUS_CONTINUE;
 }
 
@@ -1318,7 +1318,7 @@ CMDRESULT cbDebugEnableHardwareBreakpoint(int argc, char* argv[])
     BpSetTitanType(found.addr, BPHARDWARE, found.titantype);
     if(!BpEnable(found.addr, BPHARDWARE, true) || !SetHardwareBreakPoint(found.addr, drx, TITANGETTYPE(found.titantype), TITANGETSIZE(found.titantype), (void*)cbHardwareBreakpoint))
     {
-        dprintf("Could not enable hardware breakpoint "fhex"\n", found.addr);
+        dprintf("Could not enable hardware breakpoint " fhex "\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Hardware breakpoint enabled!");
@@ -1355,7 +1355,7 @@ CMDRESULT cbDebugDisableHardwareBreakpoint(int argc, char* argv[])
     }
     if(!BpEnable(found.addr, BPHARDWARE, false) || !DeleteHardwareBreakPoint(TITANGETDRX(found.titantype)))
     {
-        dprintf("Could not disable hardware breakpoint "fhex"\n", found.addr);
+        dprintf("Could not disable hardware breakpoint " fhex "\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Hardware breakpoint disabled!");
@@ -1395,7 +1395,7 @@ CMDRESULT cbDebugEnableMemoryBreakpoint(int argc, char* argv[])
     MemFindBaseAddr(found.addr, &size);
     if(!BpEnable(found.addr, BPMEMORY, true) || !SetMemoryBPXEx(found.addr, size, found.titantype, !found.singleshoot, (void*)cbMemoryBreakpoint))
     {
-        dprintf("Could not enable memory breakpoint "fhex"\n", found.addr);
+        dprintf("Could not enable memory breakpoint " fhex "\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Memory breakpoint enabled!");
@@ -1434,7 +1434,7 @@ CMDRESULT cbDebugDisableMemoryBreakpoint(int argc, char* argv[])
     MemFindBaseAddr(found.addr, &size);
     if(!BpEnable(found.addr, BPMEMORY, false) || !RemoveMemoryBPX(found.addr, size))
     {
-        dprintf("Could not disable memory breakpoint "fhex"\n", found.addr);
+        dprintf("Could not disable memory breakpoint " fhex "\n", found.addr);
         return STATUS_ERROR;
     }
     dputs("Memory breakpoint disabled!");
@@ -1838,7 +1838,7 @@ CMDRESULT cbDebugGetPageRights(int argc, char* argv[])
         return STATUS_ERROR;
     }
 
-    dprintf("Page: "fhex", Rights: %s\n", addr, rights);
+    dprintf("Page: " fhex ", Rights: %s\n", addr, rights);
 
     return STATUS_CONTINUE;
 }
@@ -1856,7 +1856,7 @@ CMDRESULT cbDebugSetPageRights(int argc, char* argv[])
 
     if(!MemSetPageRights(addr, argv[2]))
     {
-        dprintf("Error: Set rights of "fhex" with Rights: %s\n", addr, argv[2]);
+        dprintf("Error: Set rights of " fhex " with Rights: %s\n", addr, argv[2]);
         return STATUS_ERROR;
     }
 
@@ -1871,7 +1871,7 @@ CMDRESULT cbDebugSetPageRights(int argc, char* argv[])
     MemUpdateMap();
     GuiUpdateMemoryView();
 
-    dprintf("New rights of "fhex": %s\n", addr, rights);
+    dprintf("New rights of " fhex ": %s\n", addr, rights);
 
     return STATUS_CONTINUE;
 }
@@ -1918,21 +1918,21 @@ CMDRESULT cbDebugLoadLib(int argc, char* argv[])
 
     // Arch specific asm code
 #ifdef _WIN64
-    sprintf(command, "mov rcx, "fhex, (uint)DLLNameMem);
+    sprintf(command, "mov rcx, " fhex, (uint)DLLNameMem);
 #else
-    sprintf(command, "push "fhex, DLLNameMem);
+    sprintf(command, "push " fhex, DLLNameMem);
 #endif // _WIN64
 
     assembleat((uint)ASMAddr, command, &size, error, true);
     counter += size;
 
 #ifdef _WIN64
-    sprintf(command, "mov rax, "fhex, LoadLibraryA);
+    sprintf(command, "mov rax, " fhex, LoadLibraryA);
     assembleat((uint)ASMAddr + counter, command, &size, error, true);
     counter += size;
     sprintf(command, "call rax");
 #else
-    sprintf(command, "call "fhex, LoadLibraryA);
+    sprintf(command, "call " fhex, LoadLibraryA);
 #endif // _WIN64
 
     assembleat((uint)ASMAddr + counter, command, &size, error, true);
@@ -2032,7 +2032,7 @@ void showcommandlineerror(cmdline_error_t* cmdline_error)
     if(!unkown)
     {
         if(cmdline_error->addr != 0)
-            dprintf(" (Address: "fhex")", cmdline_error->addr);
+            dprintf(" (Address: " fhex ")", cmdline_error->addr);
         dputs("");
     }
 }

--- a/x64_dbg_dbg/disasm_helper.cpp
+++ b/x64_dbg_dbg/disasm_helper.cpp
@@ -232,7 +232,7 @@ void disasmprint(uint addr)
     disasmget(addr, &instr);
     dprintf(">%d:\"%s\":\n", instr.type, instr.instruction);
     for(int i = 0; i < instr.argcount; i++)
-        dprintf(" %d:%d:%"fext"X:%"fext"X:%"fext"X\n", i, instr.arg[i].type, instr.arg[i].constant, instr.arg[i].value, instr.arg[i].memvalue);
+        dprintf(" %d:%d:%" fext "X:%" fext "X:%" fext "X\n", i, instr.arg[i].type, instr.arg[i].constant, instr.arg[i].value, instr.arg[i].memvalue);
 }
 
 static bool isasciistring(const unsigned char* data, int maxlen)

--- a/x64_dbg_dbg/instruction.cpp
+++ b/x64_dbg_dbg/instruction.cpp
@@ -53,14 +53,14 @@ CMDRESULT cbBadCmd(int argc, char* argv[])
             if(value > 15 && !hexonly)
             {
                 if(!valuesignedcalc()) //signed numbers
-                    sprintf(format_str, "%%s=%%.%d"fext"X (%%"fext"ud)\n", valsize);
+                    sprintf(format_str, "%%s=%%.%d" fext "X (%%" fext "ud)\n", valsize);
                 else
-                    sprintf(format_str, "%%s=%%.%d"fext"X (%%"fext"d)\n", valsize);
+                    sprintf(format_str, "%%s=%%.%d" fext "X (%%" fext "d)\n", valsize);
                 dprintf(format_str, *argv, value, value);
             }
             else
             {
-                sprintf(format_str, "%%s=%%.%d"fext"X\n", valsize);
+                sprintf(format_str, "%%s=%%.%d" fext "X\n", valsize);
                 dprintf(format_str, *argv, value);
             }
         }
@@ -69,15 +69,15 @@ CMDRESULT cbBadCmd(int argc, char* argv[])
             if(value > 15 && !hexonly)
             {
                 if(!valuesignedcalc()) //signed numbers
-                    sprintf(format_str, "%%s=%%.%d"fext"X (%%"fext"ud)\n", valsize);
+                    sprintf(format_str, "%%s=%%.%d" fext "X (%%" fext "ud)\n", valsize);
                 else
-                    sprintf(format_str, "%%s=%%.%d"fext"X (%%"fext"d)\n", valsize);
-                sprintf(format_str, "%%.%d"fext"X (%%"fext"ud)\n", valsize);
+                    sprintf(format_str, "%%s=%%.%d" fext "X (%%" fext "d)\n", valsize);
+                sprintf(format_str, "%%.%d" fext "X (%%" fext "ud)\n", valsize);
                 dprintf(format_str, value, value);
             }
             else
             {
-                sprintf(format_str, "%%.%d"fext"X\n", valsize);
+                sprintf(format_str, "%%.%d" fext "X\n", valsize);
                 dprintf(format_str, value);
             }
         }
@@ -122,9 +122,9 @@ CMDRESULT cbInstrVar(int argc, char* argv[])
     else
     {
         if(value > 15)
-            dprintf("%s=%"fext"X (%"fext"ud)\n", argv[1], value, value);
+            dprintf("%s=%" fext "X (%" fext "ud)\n", argv[1], value, value);
         else
-            dprintf("%s=%"fext"X\n", argv[1], value);
+            dprintf("%s=%" fext "X\n", argv[1], value);
     }
     return STATUS_CONTINUE;
 }
@@ -191,7 +191,7 @@ CMDRESULT cbInstrMov(int argc, char* argv[])
         //Move data to destination
         if(!MemWrite(dest, data(), data.size()))
         {
-            dprintf("failed to write to "fhex"\n", dest);
+            dprintf("failed to write to " fhex "\n", dest);
             return STATUS_ERROR;
         }
         GuiUpdateAllViews(); //refresh disassembly/dump/etc
@@ -265,17 +265,17 @@ CMDRESULT cbInstrVarList(int argc, char* argv[])
                 if(variables()[i].type == filter)
                 {
                     if(value > 15)
-                        dprintf("%s=%"fext"X (%"fext"ud)\n", name, value, value);
+                        dprintf("%s=%" fext "X (%" fext "ud)\n", name, value, value);
                     else
-                        dprintf("%s=%"fext"X\n", name, value);
+                        dprintf("%s=%" fext "X\n", name, value);
                 }
             }
             else
             {
                 if(value > 15)
-                    dprintf("%s=%"fext"X (%"fext"ud)\n", name, value, value);
+                    dprintf("%s=%" fext "X (%" fext "ud)\n", name, value, value);
                 else
-                    dprintf("%s=%"fext"X\n", name, value);
+                    dprintf("%s=%" fext "X\n", name, value);
             }
         }
     }
@@ -439,7 +439,7 @@ CMDRESULT cbInstrAssemble(int argc, char* argv[])
     }
     if(!DbgMemIsValidReadPtr(addr))
     {
-        dprintf("invalid address: "fhex"!\n", addr);
+        dprintf("invalid address: " fhex "!\n", addr);
         return STATUS_ERROR;
     }
     bool fillnop = false;
@@ -937,9 +937,9 @@ CMDRESULT cbInstrRefFindRange(int argc, char* argv[])
     uint ticks = GetTickCount();
     char title[256] = "";
     if(range.start == range.end)
-        sprintf_s(title, "Constant: %"fext"X", range.start);
+        sprintf_s(title, "Constant: %" fext "X", range.start);
     else
-        sprintf_s(title, "Range: %"fext"X-%"fext"X", range.start, range.end);
+        sprintf_s(title, "Range: %" fext "X-%" fext "X", range.start, range.end);
     int found = RefFind(addr, size, cbRefFind, &range, false, title);
     dprintf("%u reference(s) in %ums\n", found, GetTickCount() - ticks);
     varset("$result", found, false);
@@ -1138,7 +1138,7 @@ CMDRESULT cbInstrFind(int argc, char* argv[])
     uint base = MemFindBaseAddr(addr, &size, true);
     if(!base)
     {
-        dprintf("invalid memory address "fhex"!\n", addr);
+        dprintf("invalid memory address " fhex "!\n", addr);
         return STATUS_ERROR;
     }
     Memory<unsigned char*> data(size, "cbInstrFind:data");
@@ -1190,7 +1190,7 @@ CMDRESULT cbInstrFindAll(int argc, char* argv[])
     uint base = MemFindBaseAddr(addr, &size, true);
     if(!base)
     {
-        dprintf("invalid memory address "fhex"!\n", addr);
+        dprintf("invalid memory address " fhex "!\n", addr);
         return STATUS_ERROR;
     }
     Memory<unsigned char*> data(size, "cbInstrFindAll:data");
@@ -1669,7 +1669,7 @@ static int yaraScanCallback(int message, void* message_data, void* user_data)
                 else
                     pattern = yara_print_string(match->data, match->length);
                 uint addr = (uint)(base + match->base + match->offset);
-                //dprintf("[YARA] String \"%s\" : %s on 0x%"fext"X\n", string->identifier, pattern.c_str(), addr);
+                //dprintf("[YARA] String \"%s\" : %s on 0x%" fext "X\n", string->identifier, pattern.c_str(), addr);
 
                 //update references
                 int index = scanInfo->index;

--- a/x64_dbg_dbg/stackinfo.cpp
+++ b/x64_dbg_dbg/stackinfo.cpp
@@ -97,7 +97,7 @@ bool stackcommentget(uint addr, STACK_COMMENT* comment)
         if(*label) //+label
             sprintf(comment->comment, "%s.%s", module, label);
         else //module only
-            sprintf(comment->comment, "%s."fhex, module, data);
+            sprintf(comment->comment, "%s." fhex, module, data);
         return true;
     }
     else if(*label) //label only
@@ -228,7 +228,7 @@ void stackgetcallstack(uint csp, CALLSTACK* callstack)
         {
             //CALLSTACKENTRY curEntry;
             //memcpy(&curEntry, &callstackVector.at(i), sizeof(CALLSTACKENTRY));
-            //dprintf(fhex":"fhex":"fhex":%s\n", curEntry.addr, curEntry.to, curEntry.from, curEntry.comment);
+            //dprintf(fhex":" fhex ":" fhex ":%s\n", curEntry.addr, curEntry.to, curEntry.from, curEntry.comment);
             memcpy(&callstack->entries[i], &callstackVector.at(i), sizeof(CALLSTACKENTRY));
         }
     }

--- a/x64_dbg_dbg/stringformat.cpp
+++ b/x64_dbg_dbg/stringformat.cpp
@@ -26,19 +26,19 @@ static String printValue(FormatValueType value, ValueType::ValueType type)
         break;
     case ValueType::SignedDecimal:
         if(validval)
-            sprintf_s(result, "%"fext"d", valuint);
+            sprintf_s(result, "%" fext "d", valuint);
         break;
     case ValueType::UnsignedDecimal:
         if(validval)
-            sprintf_s(result, "%"fext"u", valuint);
+            sprintf_s(result, "%" fext "u", valuint);
         break;
     case ValueType::Hex:
         if(validval)
-            sprintf_s(result, "%"fext"X", valuint);
+            sprintf_s(result, "%" fext "X", valuint);
         break;
     case ValueType::Pointer:
         if(validval)
-            sprintf_s(result, "0x%"fhex, valuint);
+            sprintf_s(result, "0x%" fhex, valuint);
         break;
     case ValueType::String:
         if(validval)

--- a/x64_dbg_dbg/symbolinfo.cpp
+++ b/x64_dbg_dbg/symbolinfo.cpp
@@ -155,19 +155,19 @@ void SymDownloadAllSymbols(const char* SymbolStore)
         wchar_t modulePath[MAX_PATH];
         if(!GetModuleFileNameExW(fdProcessInfo->hProcess, (HMODULE)module.base, modulePath, MAX_PATH))
         {
-            dprintf("GetModuleFileNameExW("fhex") failed!\n", module.base);
+            dprintf("GetModuleFileNameExW(" fhex ") failed!\n", module.base);
             continue;
         }
 
         if(!SafeSymUnloadModule64(fdProcessInfo->hProcess, (DWORD64)module.base))
         {
-            dprintf("SymUnloadModule64("fhex") failed!\n", module.base);
+            dprintf("SymUnloadModule64(" fhex ") failed!\n", module.base);
             continue;
         }
 
         if(!SafeSymLoadModuleEx(fdProcessInfo->hProcess, 0, StringUtils::Utf16ToUtf8(modulePath).c_str(), 0, (DWORD64)module.base, 0, 0, 0))
         {
-            dprintf("SymLoadModuleEx("fhex") failed!\n", module.base);
+            dprintf("SymLoadModuleEx(" fhex ") failed!\n", module.base);
             continue;
         }
     }

--- a/x64_dbg_dbg/value.cpp
+++ b/x64_dbg_dbg/value.cpp
@@ -1310,7 +1310,7 @@ bool valapifromstring(const char* name, uint* value, int* value_size, bool print
         if(!GetModuleFileNameExW(fdProcessInfo->hProcess, (HMODULE)modbase, szModName, MAX_PATH))
         {
             if(!silent)
-                dprintf("could not get filename of module "fhex"\n", modbase);
+                dprintf("could not get filename of module " fhex "\n", modbase);
         }
         else
         {
@@ -1610,7 +1610,7 @@ bool valfromstring_noexpr(const char* string, uint* value, bool silent, bool bas
             *value_size = 0;
         if(isvar)
             *isvar = false;
-        sscanf(string + 1, "%"fext"u", value);
+        sscanf(string + 1, "%" fext "u", value);
         return true;
     }
     else if(ishexnumber(string))  //then hex numbers
@@ -1623,7 +1623,7 @@ bool valfromstring_noexpr(const char* string, uint* value, bool silent, bool bas
         int inc = 0;
         if(*string == 'x')
             inc = 1;
-        sscanf(string + inc, "%"fext"x", value);
+        sscanf(string + inc, "%" fext "x", value);
         return true;
     }
     if(baseonly)


### PR DESCRIPTION
so it compiles with vc14. (Inline concatenation needs a space in between)

```cpp
//its
char* a = "ASD" "ASD"
//and not 
char* b = "ASD""ASD"
```
looks like vc12 is fine with it, vc14 not.