### PR TITLE
Fix memory alignment

### DIFF
--- a/x64_dbg_gui/Project/Src/Gui/CPUSideBar.cpp
+++ b/x64_dbg_gui/Project/Src/Gui/CPUSideBar.cpp
@@ -426,3 +426,13 @@ void CPUSideBar::drawStraightArrow(QPainter* painter, int x1, int y1, int x2, in
 
 }
 
+void* CPUSideBar::operator new(size_t size)
+{
+    return _aligned_malloc(size, 16);
+}
+
+void CPUSideBar::operator delete(void* p)
+{
+    _aligned_free(p);
+}
+

--- a/x64_dbg_gui/Project/Src/Gui/CPUSideBar.h
+++ b/x64_dbg_gui/Project/Src/Gui/CPUSideBar.h
@@ -13,6 +13,9 @@ public:
     QSize sizeHint() const;
     void drawStraightArrow(QPainter* painter, int x1, int y1, int x2, int y2);
 
+    static void* operator new(size_t size);
+    static void operator delete(void* p);
+
 public slots:
     void debugStateChangedSlot(DBGSTATE state);
     void repaint();

--- a/x64_dbg_gui/Project/Src/Gui/RegistersView.cpp
+++ b/x64_dbg_gui/Project/Src/Gui/RegistersView.cpp
@@ -1289,6 +1289,16 @@ QSize RegistersView::sizeHint() const
     return QSize(32 * mCharWidth , this->viewport()->height());
 }
 
+void* RegistersView::operator new(size_t size)
+{
+    return _aligned_malloc(size, 16);
+}
+
+void RegistersView::operator delete(void* p)
+{
+    _aligned_free(p);
+}
+
 QString RegistersView::getRegisterLabel(REGISTER_NAME register_selected)
 {
     char label_text[MAX_LABEL_SIZE] = "";

--- a/x64_dbg_gui/Project/Src/Gui/RegistersView.h
+++ b/x64_dbg_gui/Project/Src/Gui/RegistersView.h
@@ -94,6 +94,9 @@ public:
 
     QSize sizeHint() const;
 
+    static void* operator new(size_t size);
+    static void operator delete(void* p);
+
 public slots:
     void refreshShortcutsSlot();
     void updateRegistersSlot();


### PR DESCRIPTION
Fix SSE dependent classes not being properly aligned when created on the
heap. 

vc was warning about it, and it can possibly lead to bugs when SSE instructions are executed on unaligned members