### PR TITLE
Swig Errors (x64dbg-python)

### DIFF
--- a/x64_dbg_bridge/bridgemain.h
+++ b/x64_dbg_bridge/bridgemain.h
@@ -864,7 +864,6 @@ BRIDGE_IMPEXP void GuiUpdateSideBar();
 BRIDGE_IMPEXP void GuiRepaintTableView();
 BRIDGE_IMPEXP void GuiUpdatePatches();
 BRIDGE_IMPEXP void GuiUpdateCallStack();
-BRIDGE_IMPEXP void GuiUpdateMemoryView();
 BRIDGE_IMPEXP void GuiLoadSourceFile(const char* path, int line);
 BRIDGE_IMPEXP void GuiMenuSetIcon(int hMenu, const ICONDATA* icon);
 BRIDGE_IMPEXP void GuiMenuSetEntryIcon(int hEntry, const ICONDATA* icon);

--- a/x64_dbg_dbg/_scriptapi_module.h
+++ b/x64_dbg_dbg/_scriptapi_module.h
@@ -39,8 +39,6 @@ SCRIPT_EXPORT int SectionCountFromAddr(duint addr);
 SCRIPT_EXPORT int SectionCountFromName(const char* name);
 SCRIPT_EXPORT bool SectionFromAddr(duint addr, int number, ModuleSectionInfo* section);
 SCRIPT_EXPORT bool SectionFromName(const char* name, int number, ModuleSectionInfo* section);
-SCRIPT_EXPORT bool SectionListFromAddr(duint addr, ListOf(ModuleSectionInfo) listInfo);
-SCRIPT_EXPORT bool SectionListFromName(const char* name, ListOf(ModuleSectionInfo) listInfo);
 SCRIPT_EXPORT bool GetMainModuleInfo(ModuleInfo* info);
 SCRIPT_EXPORT duint GetMainModuleBase();
 SCRIPT_EXPORT duint GetMainModuleSize();
@@ -48,8 +46,12 @@ SCRIPT_EXPORT duint GetMainModuleEntry();
 SCRIPT_EXPORT int GetMainModuleSectionCount();
 SCRIPT_EXPORT bool GetMainModuleName(char* name); //name[MAX_MODULE_SIZE]
 SCRIPT_EXPORT bool GetMainModulePath(char* path); //path[MAX_PATH]
+#ifndef SWIG
+SCRIPT_EXPORT bool SectionListFromAddr(duint addr, ListOf(ModuleSectionInfo) listInfo);
+SCRIPT_EXPORT bool SectionListFromName(const char* name, ListOf(ModuleSectionInfo) listInfo);
 SCRIPT_EXPORT bool GetMainModuleSectionList(ListOf(ModuleSectionInfo) listInfo); //caller has the responsibility to free the list
 SCRIPT_EXPORT bool GetList(ListOf(ModuleInfo) listInfo); //caller has the responsibility to free the list
+#endif
 }; //Module
 }; //Script
 


### PR DESCRIPTION
Fix syntax error in swig with ListOf + remove a copy of the declaration GuiUpdateMemoryView