### PR TITLE
add new API: GuiGetFocusedCPUWindow

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1236,3 +1236,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     hInst = hinstDLL;
     return TRUE;
 }
+
+BRIDGE_IMPEXP int GuiGetFocusedCPUWindow()
+{
+    return (int)(duint)_gui_sendmessage(GUI_GET_FOCUSED_CPUWINDOW, nullptr, nullptr);
+}

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -779,7 +779,8 @@ typedef enum
     GUI_SET_GLOBAL_NOTES,           // param1=const char* text,     param2=unused
     GUI_GET_GLOBAL_NOTES,           // param1=char** text,          param2=unused
     GUI_SET_DEBUGGEE_NOTES,         // param1=const char* text,     param2=unused
-    GUI_GET_DEBUGGEE_NOTES          // param1=char** text,          param2=unused
+    GUI_GET_DEBUGGEE_NOTES,         // param1=char** text,          param2=unused
+    GUI_GET_FOCUSED_CPUWINDOW       // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -877,6 +878,7 @@ BRIDGE_IMPEXP void GuiSetGlobalNotes(const char* text);
 BRIDGE_IMPEXP void GuiGetGlobalNotes(char** text);
 BRIDGE_IMPEXP void GuiSetDebuggeeNotes(const char* text);
 BRIDGE_IMPEXP void GuiGetDebuggeeNotes(char** text);
+BRIDGE_IMPEXP int GuiGetFocusedCPUWindow();
 
 #ifdef __cplusplus
 }

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -518,6 +518,15 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         result.Wait();
     }
     break;
+
+    case GUI_GET_FOCUSED_CPUWINDOW:
+    {
+        BridgeResult result;
+        emit getFocusedCPUWindow();
+        result.Wait();
+    }
+    break;
+
     }
     return nullptr;
 }

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -113,7 +113,7 @@ signals:
     void getGlobalNotes(void* text);
     void setDebuggeeNotes(const QString text);
     void getDebuggeeNotes(void* text);
-
+    void getFocusedCPUWindow();
 private:
     QMutex* mBridgeMutex;
     dsint bridgeResult;

--- a/src/gui/Src/Gui/CPUWidget.cpp
+++ b/src/gui/Src/Gui/CPUWidget.cpp
@@ -13,6 +13,7 @@ CPUWidget::CPUWidget(QWidget* parent) : QWidget(parent), ui(new Ui::CPUWidget)
     connect(mDisas, SIGNAL(selectionChanged(dsint)), mSideBar, SLOT(setSelection(dsint)));
     connect(Bridge::getBridge(), SIGNAL(dbgStateChanged(DBGSTATE)), mSideBar, SLOT(debugStateChangedSlot(DBGSTATE)));
     connect(Bridge::getBridge(), SIGNAL(updateSideBar()), mSideBar, SLOT(repaint()));
+    connect(Bridge::getBridge(), SIGNAL(getFocusedCPUWindow()), this, SLOT(getFocusedCPUWindow()));
 
     QSplitter* splitter = new QSplitter(this);
     splitter->addWidget(mSideBar);
@@ -145,4 +146,23 @@ CPUDump* CPUWidget::getDumpWidget()
 CPUStack* CPUWidget::getStackWidget()
 {
     return mStack;
+}
+
+void CPUWidget::getFocusedCPUWindow()
+{
+    QWidget* w = QApplication::focusWidget();
+    int r = -1;
+    if(w == mDisas)
+    {
+        r = GUI_DISASSEMBLY;
+    }
+    else if(w == mDump)
+    {
+        r = GUI_DUMP;
+    }
+    else if(w == mStack)
+    {
+        r = GUI_STACK;
+    }
+    Bridge::getBridge()->setResult(r);
 }

--- a/src/gui/Src/Gui/CPUWidget.h
+++ b/src/gui/Src/Gui/CPUWidget.h
@@ -47,7 +47,8 @@ protected:
     CPUStack* mStack;
     RegistersView* mGeneralRegs;
     CPUInfoBox* mInfo;
-
+private slots:
+    void getFocusedCPUWindow();
 private:
     Ui::CPUWidget* ui;
 };


### PR DESCRIPTION
I need this API to write a plugin to navigate back or forward in dump and stack window. Although this feature should be added in the main gui project, but there has a lot of work to do.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/512)
<!-- Reviewable:end -->
