### PR TITLE
Fixed LabelDelRange

### DIFF
--- a/src/dbg/label.cpp
+++ b/src/dbg/label.cpp
@@ -108,6 +108,10 @@ void LabelDelRange(duint Start, duint End, bool Manual)
         if(moduleBase != ModBaseFromAddr(End))
             return;
 
+        // Virtual -> relative offset
+        Start -= moduleBase;
+        End -= moduleBase;
+
         EXCLUSIVE_ACQUIRE(LockLabels);
         for(auto itr = labels.begin(); itr != labels.end();)
         {


### PR DESCRIPTION
It compared VAs (`Start`, `End`) with RVAs (`currentLabel.addr`).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/579)
<!-- Reviewable:end -->
