### PR TITLE
Continue running MemFindInMap even if unreadable pages exist

### DIFF
--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -610,7 +610,7 @@ bool MemFindInMap(const std::vector<SimplePage> & pages, const std::vector<Patte
     for(const auto page : pages)
     {
         if(!MemFindInPage(page, 0, pattern, results, maxresults))
-            return false;
+            continue;
         if(progress)
             GuiReferenceSetProgress(int(floor((float(count) / float(total)) * 100.0f)));
         if(results.size() >= maxresults)


### PR DESCRIPTION
It would be optimal to log the failures, but I'm not sure whether it's OK to call `dputs` in there. Otherwise the code needs some reordering.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/581)
<!-- Reviewable:end -->
