### PR TITLE
Removing a label/comment which didn't exist shouldn't be an error

### DIFF
--- a/src/dbg/comment.cpp
+++ b/src/dbg/comment.cpp
@@ -19,7 +19,10 @@ bool CommentSet(duint Address, const char* Text, bool Manual)
 
     // Delete the comment if no text was supplied
     if(Text[0] == '\0')
-        return CommentDelete(Address);
+    {
+        CommentDelete(Address);
+        return true;
+    }
 
     // Fill out the structure
     COMMENTSINFO comment;

--- a/src/dbg/label.cpp
+++ b/src/dbg/label.cpp
@@ -23,7 +23,10 @@ bool LabelSet(duint Address, const char* Text, bool Manual)
 
     // Delete the label if no text was supplied
     if(Text[0] == '\0')
-        return LabelDelete(Address);
+    {
+        LabelDelete(Address);
+        return true;
+    }
 
     // Fill out the structure data
     LABELSINFO labelInfo;


### PR DESCRIPTION
Fixes an error message box which was displayed if the label/comment was changed from empty to empty

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/582)
<!-- Reviewable:end -->
