### PR TITLE
DBG: Make it possible to reference segment registers using Goto

### DIFF
--- a/src/dbg/expressionparser.cpp
+++ b/src/dbg/expressionparser.cpp
@@ -195,6 +195,7 @@ void ExpressionParser::tokenize(const String & expression)
                     addOperatorToken(ch, Token::Type::OperatorOr);
                     break;
                 case ' ': //ignore spaces
+                case '\x09': //ignore tabs
                     break;
                 default:
                     _curToken += ch;


### PR DESCRIPTION
Now I can enter `gs:[30]` and jump to TEB of the thread.
![x64dbg reference gs](https://cloud.githubusercontent.com/assets/15761310/15432921/abd4c622-1e9f-11e6-8f88-331e1ddc0bba.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/644)
<!-- Reviewable:end -->
