### PR TITLE
GUI: Apply unique color to unusual instructions

### DIFF
--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -463,6 +463,7 @@ QString Disassembly::paintContent(QPainter* painter, dsint rowBase, int rowOffse
         }
 
         char comment[MAX_COMMENT_SIZE] = "";
+        char label[MAX_LABEL_SIZE] = "";
         if(DbgGetCommentAt(cur_addr, comment))
         {
             QString commentText;
@@ -486,6 +487,20 @@ QString Disassembly::paintContent(QPainter* painter, dsint rowBase, int rowOffse
             if(width)
                 painter->fillRect(QRect(x + argsize + 2, y, width, h), QBrush(backgroundColor)); //fill comment color
             painter->drawText(QRect(x + argsize + 4, y , w - 4 , h), Qt::AlignVCenter | Qt::AlignLeft, commentText);
+        }
+        else if(DbgGetLabelAt(cur_addr, SEG_DEFAULT, label)) // label but no comment
+        {
+            QString labelText(label);
+            QColor backgroundColor;
+            painter->setPen(mLabelColor);
+            backgroundColor = mLabelBackgroundColor;
+
+            int width = getCharWidth() * labelText.length() + 4;
+            if (width > w)
+                width = w;
+            if(width)
+                painter->fillRect(QRect(x + argsize + 2, y, width, h), QBrush(backgroundColor)); //fill comment color
+            painter->drawText(QRect(x + argsize + 4, y, w - 4, h), Qt::AlignVCenter | Qt::AlignLeft, labelText);
         }
     }
     break;

--- a/src/gui/Src/Disassembler/capstone_gui.cpp
+++ b/src/gui/Src/Disassembler/capstone_gui.cpp
@@ -40,6 +40,7 @@ void CapstoneTokenizer::UpdateColors()
     addColorName(TokenType::MnemonicNop, "InstructionNopColor", "InstructionNopBackgroundColor");
     addColorName(TokenType::MnemonicFar, "InstructionFarColor", "InstructionFarBackgroundColor");
     addColorName(TokenType::MnemonicInt3, "InstructionInt3Color", "InstructionInt3BackgroundColor");
+    addColorName(TokenType::MnemonicUnusual, "InstructionUnusualColor", "InstructionUnusualBackgroundColor");
     //memory
     addColorName(TokenType::MemorySize, "InstructionMemorySizeColor", "InstructionMemorySizeBackgroundColor");
     addColorName(TokenType::MemorySegment, "InstructionMemorySegmentColor", "InstructionMemorySegmentBackgroundColor");
@@ -313,12 +314,24 @@ bool CapstoneTokenizer::tokenizeMnemonic()
         type = TokenType::MnemonicNop;
     else if(_cp.IsInt3())
         type = TokenType::MnemonicInt3;
+    else if(_cp.InGroup(CS_GRP_PRIVILEGE) || _cp.InGroup(CS_GRP_IRET) || _cp.InGroup(CS_GRP_INVALID))
+        type = TokenType::MnemonicUnusual;
     else
     {
         switch(id)
         {
         case X86_INS_PUSH:
+        case X86_INS_PUSHF:
+        case X86_INS_PUSHFD:
+        case X86_INS_PUSHFQ:
+        case X86_INS_PUSHAL:
+        case X86_INS_PUSHAW:
         case X86_INS_POP:
+        case X86_INS_POPF:
+        case X86_INS_POPFD:
+        case X86_INS_POPFQ:
+        case X86_INS_POPAL:
+        case X86_INS_POPAW:
             type = TokenType::MnemonicPushPop;
             break;
         default:

--- a/src/gui/Src/Disassembler/capstone_gui.h
+++ b/src/gui/Src/Disassembler/capstone_gui.h
@@ -32,6 +32,7 @@ public:
         MnemonicNop,
         MnemonicFar,
         MnemonicInt3,
+        MnemonicUnusual,
         //memory
         MemorySize,
         MemorySegment,

--- a/src/gui/Src/Gui/AppearanceDialog.cpp
+++ b/src/gui/Src/Gui/AppearanceDialog.cpp
@@ -482,6 +482,7 @@ void AppearanceDialog::colorInfoListInit()
     colorInfoListAppend("NOPs", "InstructionNopColor", "InstructionNopBackgroundColor");
     colorInfoListAppend("FAR", "InstructionFarColor", "InstructionFarBackgroundColor");
     colorInfoListAppend("INT3s", "InstructionInt3Color", "InstructionInt3BackgroundColor");
+    colorInfoListAppend("Unusual Instructions", "InstructionUnusualColor", "InstructionUnusualBackgroundColor");
     colorInfoListAppend("General Registers", "InstructionGeneralRegisterColor", "InstructionGeneralRegisterBackgroundColor");
     colorInfoListAppend("FPU Registers", "InstructionFpuRegisterColor", "InstructionFpuRegisterBackgroundColor");
     colorInfoListAppend("MMX Registers", "InstructionMmxRegisterColor", "InstructionMmxRegisterBackgroundColor");

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -123,7 +123,7 @@ void CPUDisassembly::setupFollowReferenceMenu(dsint wVA, QMenu* menu, bool isRef
         if(isReferences)
             menu->addAction(mReferenceSelectedAddressAction);
         else
-            addFollowReferenceMenuItem("&Selected Address", wVA, menu, isReferences, isFollowInCPU);
+            addFollowReferenceMenuItem(tr("&Selected Address"), wVA, menu, isReferences, isFollowInCPU);
     }
 
     //add follow actions
@@ -146,15 +146,15 @@ void CPUDisassembly::setupFollowReferenceMenu(dsint wVA, QMenu* menu, bool isRef
                     segment = "fs:";
 #endif //_WIN64
                 if(DbgMemIsValidReadPtr(arg.value))
-                    addFollowReferenceMenuItem("&Address: " + segment + QString(arg.mnemonic).toUpper().trimmed(), arg.value, menu, isReferences, isFollowInCPU);
+                    addFollowReferenceMenuItem(tr("&Address: ") + segment + QString(arg.mnemonic).toUpper().trimmed(), arg.value, menu, isReferences, isFollowInCPU);
                 if(arg.value != arg.constant)
                 {
                     QString constant = QString("%1").arg(arg.constant, 1, 16, QChar('0')).toUpper();
                     if(DbgMemIsValidReadPtr(arg.constant))
-                        addFollowReferenceMenuItem("&Constant: " + constant, arg.constant, menu, isReferences, isFollowInCPU);
+                        addFollowReferenceMenuItem(tr("&Constant: ") + constant, arg.constant, menu, isReferences, isFollowInCPU);
                 }
                 if(DbgMemIsValidReadPtr(arg.memvalue))
-                    addFollowReferenceMenuItem("&Value: " + segment + "[" + QString(arg.mnemonic) + "]", arg.memvalue, menu, isReferences, isFollowInCPU);
+                    addFollowReferenceMenuItem(tr("&Value: ") + segment + "[" + QString(arg.mnemonic) + "]", arg.memvalue, menu, isReferences, isFollowInCPU);
             }
             else //arg_normal
             {
@@ -170,9 +170,9 @@ void CPUDisassembly::setupFollowReferenceMenu(dsint wVA, QMenu* menu, bool isRef
             const DISASM_ARG arg = instr.arg[i];
             QString constant = QString("%1").arg(arg.constant, 1, 16, QChar('0')).toUpper();
             if(DbgMemIsValidReadPtr(arg.constant))
-                addFollowReferenceMenuItem("Address: " + constant, arg.constant, menu, isReferences, isFollowInCPU);
+                addFollowReferenceMenuItem(tr("Address: ") + constant, arg.constant, menu, isReferences, isFollowInCPU);
             else if(arg.constant)
-                addFollowReferenceMenuItem("Constant: " + constant, arg.constant, menu, isReferences, isFollowInCPU);
+                addFollowReferenceMenuItem(tr("Constant: ") + constant, arg.constant, menu, isReferences, isFollowInCPU);
         }
     }
 }

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -88,6 +88,8 @@ Configuration::Configuration() : QObject()
     defaultColors.insert("InstructionConditionalJumpBackgroundColor", QColor("#FFFF00"));
     defaultColors.insert("InstructionUnconditionalJumpColor", QColor("#000000"));
     defaultColors.insert("InstructionUnconditionalJumpBackgroundColor", QColor("#FFFF00"));
+    defaultColors.insert("InstructionUnusualColor", QColor("#808080"));
+    defaultColors.insert("InstructionUnusualBackgroundColor", Qt::transparent);
     defaultColors.insert("InstructionNopColor", QColor("#808080"));
     defaultColors.insert("InstructionNopBackgroundColor", Qt::transparent);
     defaultColors.insert("InstructionFarColor", QColor("#000000"));


### PR DESCRIPTION
**GUI: Apply unique color to unusual instructions**
Unusual instructions are privileged, unknown or IRET.

**PUSHF is recognised as push instructions.**

**GUI: Show label on comment area if no comments**
Labels in address columns are often hidden to save screen space. Allowing these labels to shown in comment area when nothing else needs to be shown improves working efficiency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/650)
<!-- Reviewable:end -->
