### PR TITLE
GUI: Fixed HexEditDialog behavior

### DIFF
--- a/src/gui/Src/Gui/HexEditDialog.cpp
+++ b/src/gui/Src/Gui/HexEditDialog.cpp
@@ -96,6 +96,21 @@ void HexEditDialog::on_btnUnicode2Hex_clicked()
 void HexEditDialog::on_chkKeepSize_toggled(bool checked)
 {
     mHexEdit->setKeepSize(checked);
+    QByteArray data = mHexEdit->data();
+    if(checked)
+    {
+        int dataSize = data.size();
+        QString asciiMask = QString("x").repeated(dataSize / sizeof(char));
+        QString unicodeMask = QString("x").repeated(dataSize / sizeof(wchar_t));
+        ui->lineEditAscii->setInputMask(asciiMask);
+        ui->lineEditUnicode->setInputMask(unicodeMask);
+    }
+    else
+    {
+        ui->lineEditAscii->setInputMask("");
+        ui->lineEditUnicode->setInputMask("");
+        mHexEdit->setData(data);
+    }
 }
 
 void HexEditDialog::dataChangedSlot()
@@ -126,11 +141,15 @@ void HexEditDialog::dataChangedSlot()
 void HexEditDialog::on_lineEditAscii_textEdited(const QString & arg1)
 {
     Q_UNUSED(arg1);
+    int cursorPosition = ui->lineEditAscii->cursorPosition();
     on_btnAscii2Hex_clicked();
+    ui->lineEditAscii->setCursorPosition(cursorPosition);
 }
 
 void HexEditDialog::on_lineEditUnicode_textEdited(const QString & arg1)
 {
     Q_UNUSED(arg1);
+    int cursorPosition = ui->lineEditUnicode->cursorPosition();
     on_btnUnicode2Hex_clicked();
+    ui->lineEditUnicode->setCursorPosition(cursorPosition);
 }


### PR DESCRIPTION
I changed the behavior of the binary edit dialog slightly to make it less painful to edit text with it.

1. Prevented the position cursor from jumping to the end of the line when inserting / deleting text.
2. 'Keep size' will set the ASCII / Unicode text box to overwrite mode. This prevents characters from getting pushed out of the text boxes.

Fixes #367 .

A cleaned solution would be to create a custom QLineEdit widget that displays a QByteArray as ASCII or Unicode and supports overwrite mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/670)
<!-- Reviewable:end -->
