### PR TITLE
GUI: fix crashing (issue #676)

### DIFF
--- a/src/gui/Src/Gui/CPUMultiDump.cpp
+++ b/src/gui/Src/Gui/CPUMultiDump.cpp
@@ -14,7 +14,7 @@ CPUMultiDump::CPUMultiDump(CPUDisassembly* disas, int nbCpuDumpTabs, QWidget* pa
     {
         CPUDump* cpuDump = new CPUDump(disas, this);
         connect(cpuDump, SIGNAL(displayReferencesWidget()), this, SLOT(displayReferencesWidgetSlot()));
-        this->addTab(cpuDump, tr("Dump ") + QString::number(i + 1));
+        this->addTabEx(cpuDump, QIcon(":/images/memory-map.png"), tr("Dump ") + QString::number(i + 1), QString("Dump ") + QString::number(i + 1));
     }
 
     mCurrentCPUDump = (CPUDump*)currentWidget();


### PR DESCRIPTION
Add a native name for these dump windows to avoid crashing, but they are not used elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/677)
<!-- Reviewable:end -->
