### PR TITLE
db corruption is greatly reduced

### DIFF
--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -299,6 +299,7 @@ void TraceRecordManager::saveToDb(JSON root)
         json_array_append_new(jsonTraceRecords, jsonObj);
     }
     json_object_set_new(root, "tracerecord", jsonTraceRecords);
+    json_decref(jsonTraceRecords);
 }
 
 void TraceRecordManager::loadFromDb(JSON root)

--- a/src/dbg/_dbgfunctions.h
+++ b/src/dbg/_dbgfunctions.h
@@ -80,6 +80,7 @@ typedef struct
     unsigned int GrantedAccess;
 } HANDLEINFO;
 
+// The longest ip address is 1234:6789:1234:6789:1234:6789:123.567.901.345 (46 bytes)
 #define TCP_ADDR_SIZE 50
 
 typedef struct

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1783,6 +1783,7 @@ duint dbggetdebuggedbase()
 static void debugLoopFunction(void* lpParameter, bool attach)
 {
     //we are running
+    EXCLUSIVE_ACQUIRE(LockDebugStartStop);
     lock(WAITID_STOP);
 
     //initialize variables

--- a/src/dbg/threading.h
+++ b/src/dbg/threading.h
@@ -56,6 +56,7 @@ enum SectionLock
     LockSehCache,
     LockMnemonicHelp,
     LockTraceRecord,
+    LockDebugStartStop,
 
     // Number of elements in this enumeration. Must always be the last
     // index.


### PR DESCRIPTION
In the crash dump I noticed multiple debug threads. This is quite strange since It's assumed only one process can be debuggged at a time. So I added a mutex locking the debug function.
Now if you holds CTRL+F2 down, the debugger will enter a wrong state, but the DB should not corrupt, and the program crashes less often.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/688)
<!-- Reviewable:end -->
