### PR TITLE
Allow resize of goto dialog

### DIFF
--- a/src/gui/Src/Gui/GotoDialog.cpp
+++ b/src/gui/Src/Gui/GotoDialog.cpp
@@ -10,9 +10,8 @@ GotoDialog::GotoDialog(QWidget* parent, bool allowInvalidExpression)
     ui->setupUi(this);
     setModal(true);
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
-    setWindowFlags(Qt::Dialog | Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::MSWindowsFixedSizeDialogHint);
+    setWindowFlags(Qt::Dialog | Qt::WindowSystemMenuHint | Qt::WindowTitleHint);
 #endif
-    setFixedSize(this->size()); //fixed size
     //initialize stuff
     if(!DbgIsDebugging()) //not debugging
         ui->labelError->setText(tr("<font color='red'><b>Not debugging...</b></font>"));

--- a/src/gui/Src/Gui/GotoDialog.ui
+++ b/src/gui/Src/Gui/GotoDialog.ui
@@ -57,6 +57,12 @@
        </item>
        <item>
         <widget class="QPushButton" name="buttonOk">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>&amp;OK</string>
          </property>
@@ -64,6 +70,12 @@
        </item>
        <item>
         <widget class="QPushButton" name="buttonCancel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>&amp;Cancel</string>
          </property>


### PR DESCRIPTION
The dialog can already be resized automatically, but resizing was disabled before. Allowing resizing partially solves HIDPI problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/698)
<!-- Reviewable:end -->
