### PR TITLE
Added api to supress gui message + add set breakpoint on every command in reference view

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -13,6 +13,11 @@ static HINSTANCE hInst;
 static Utf8Ini settings;
 static wchar_t szIniFile[MAX_PATH] = L"";
 static CRITICAL_SECTION csIni;
+static bool bDisableGUIUpdate;
+
+#define CHEKC_GUI_UPDATE_DISABLED \
+    if (bDisableGUIUpdate) \
+        return;
 
 #ifdef _WIN64
 #define dbg_lib "x64dbg.dll"
@@ -898,8 +903,27 @@ BRIDGE_IMPEXP void GuiLogClear()
     _gui_sendmessage(GUI_CLEAR_LOG, 0, 0);
 }
 
+BRIDGE_IMPEXP void GuiUpdateEnable(bool updateNow)
+{
+    bDisableGUIUpdate = false;
+    if(updateNow)
+        DbgCmdExec("disasm");
+}
+
+BRIDGE_IMPEXP void GuiUpdateDisable()
+{
+    bDisableGUIUpdate = true;
+}
+
+BRIDGE_IMPEXP bool GuiIsUpdateDisabled()
+{
+    return bDisableGUIUpdate;
+}
+
+
 BRIDGE_IMPEXP void GuiUpdateAllViews()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     GuiUpdateRegisterView();
     GuiUpdateDisassemblyView();
     GuiUpdateBreakpointsView();
@@ -915,17 +939,20 @@ BRIDGE_IMPEXP void GuiUpdateAllViews()
 
 BRIDGE_IMPEXP void GuiUpdateRegisterView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_REGISTER_VIEW, 0, 0);
 }
 
 BRIDGE_IMPEXP void GuiUpdateDisassemblyView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_DISASSEMBLY_VIEW, 0, 0);
 }
 
 
 BRIDGE_IMPEXP void GuiUpdateBreakpointsView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_BREAKPOINTS_VIEW, 0, 0);
 }
 
@@ -1112,18 +1139,21 @@ BRIDGE_IMPEXP void GuiStackDumpAt(duint addr, duint csp)
 
 BRIDGE_IMPEXP void GuiUpdateDumpView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_DUMP_VIEW, 0, 0);
 }
 
 
 BRIDGE_IMPEXP void GuiUpdateMemoryView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_MEMORY_VIEW, 0, 0);
 }
 
 
 BRIDGE_IMPEXP void GuiUpdateThreadView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_THREAD_VIEW, 0, 0);
 }
 
@@ -1214,29 +1244,34 @@ BRIDGE_IMPEXP void GuiAddStatusBarMessage(const char* msg)
 
 BRIDGE_IMPEXP void GuiUpdateSideBar()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_SIDEBAR, 0, 0);
 }
 
 
 BRIDGE_IMPEXP void GuiRepaintTableView()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_REPAINT_TABLE_VIEW, 0, 0);
 }
 
 
 BRIDGE_IMPEXP void GuiUpdatePatches()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_PATCHES, 0, 0);
 }
 
 
 BRIDGE_IMPEXP void GuiUpdateCallStack()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_CALLSTACK, 0, 0);
 }
 
 BRIDGE_IMPEXP void GuiUpdateSEHChain()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_SEHCHAIN, 0, 0);
 }
 
@@ -1327,6 +1362,7 @@ BRIDGE_IMPEXP void GuiUnregisterScriptLanguage(int id)
 
 BRIDGE_IMPEXP void GuiUpdateArgumentWidget()
 {
+    CHEKC_GUI_UPDATE_DISABLED
     _gui_sendmessage(GUI_UPDATE_ARGUMENT_VIEW, nullptr, nullptr);
 }
 

--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -907,12 +907,16 @@ BRIDGE_IMPEXP void GuiUpdateEnable(bool updateNow)
 {
     bDisableGUIUpdate = false;
     if(updateNow)
-        DbgCmdExec("disasm");
+        DbgCmdExecDirect("guiupdateenable");
+    else
+        DbgCmdExecDirect("guiupdateenable 0");
+
 }
 
 BRIDGE_IMPEXP void GuiUpdateDisable()
 {
     bDisableGUIUpdate = true;
+    DbgCmdExecDirect("guimsgdisable");
 }
 
 BRIDGE_IMPEXP bool GuiIsUpdateDisabled()

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -969,6 +969,10 @@ BRIDGE_IMPEXP void GuiRegisterScriptLanguage(SCRIPTTYPEINFO* info);
 BRIDGE_IMPEXP void GuiUnregisterScriptLanguage(int id);
 BRIDGE_IMPEXP void GuiUpdateArgumentWidget();
 BRIDGE_IMPEXP void GuiFocusView(int hWindow);
+BRIDGE_IMPEXP bool GuiIsUpdateDisabled();
+BRIDGE_IMPEXP void GuiUpdateEnable(bool updateNow);
+BRIDGE_IMPEXP void GuiUpdateDisable();
+
 
 #ifdef __cplusplus
 }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -227,6 +227,8 @@ DWORD WINAPI updateSEHChainThread(void* ptr)
 
 void DebugUpdateGui(duint disasm_addr, bool stack)
 {
+    if(GuiIsUpdateDisabled())
+        return;
     duint cip = GetContextDataEx(hActiveThread, UE_CIP);
     if(MemIsValidReadPtr(disasm_addr))
     {
@@ -264,6 +266,8 @@ void DebugUpdateGui(duint disasm_addr, bool stack)
 
 void DebugUpdateStack(duint dumpAddr, duint csp, bool forceDump)
 {
+    if(GuiIsUpdateDisabled())
+        return;
     if(!forceDump && bFreezeStack)
     {
         SELECTIONDATA selection;

--- a/src/dbg/debugger_commands.cpp
+++ b/src/dbg/debugger_commands.cpp
@@ -1231,6 +1231,10 @@ CMDRESULT cbDebugDisasm(int argc, char* argv[])
         if(!valfromstring(argv[1], &addr))
             addr = GetContextDataEx(hActiveThread, UE_CIP);
     }
+    else
+    {
+        addr = GetContextDataEx(hActiveThread, UE_CIP);
+    }
     if(!MemIsValidReadPtr(addr))
         return STATUS_CONTINUE;
     DebugUpdateGui(addr, false);

--- a/src/dbg/instruction.cpp
+++ b/src/dbg/instruction.cpp
@@ -2559,3 +2559,25 @@ CMDRESULT cbInstrBriefcheck(int argc, char* argv[])
     }
     return STATUS_CONTINUE;
 }
+
+
+CMDRESULT cbInstrDisableGuiUpdate(int argc, char* argv[])
+{
+    if(!GuiIsUpdateDisabled())
+        GuiUpdateDisable();
+    return STATUS_CONTINUE;
+}
+
+CMDRESULT cbInstrEnableGuiUpdate(int argc, char* argv[])
+{
+    if(GuiIsUpdateDisabled())
+        GuiUpdateEnable(false);
+    duint value;
+    //default: update gui
+    if(argc > 1 && valfromstring(argv[1], &value) && value == 0)
+        return STATUS_CONTINUE;
+    duint cip = GetContextDataEx(hActiveThread, UE_CIP);
+    DebugUpdateGui(cip, false);
+    return STATUS_CONTINUE;
+}
+

--- a/src/dbg/instruction.h
+++ b/src/dbg/instruction.h
@@ -90,4 +90,7 @@ CMDRESULT cbDisablePrivilege(int argc, char* argv[]);
 CMDRESULT cbHandleClose(int argc, char* argv[]);
 CMDRESULT cbInstrBriefcheck(int argc, char* argv[]);
 
+CMDRESULT cbInstrDisableGuiUpdate(int argc, char* argv[]);
+CMDRESULT cbInstrEnableGuiUpdate(int argc, char* argv[]);
+
 #endif // _INSTRUCTION_H

--- a/src/dbg/x64_dbg.cpp
+++ b/src/dbg/x64_dbg.cpp
@@ -275,6 +275,8 @@ static void registercommands()
     dbgcmdnew("briefcheck", cbInstrBriefcheck, true); //check if mnemonic briefs are missing
     dbgcmdnew("analrecur\1analr", cbInstrAnalrecur, true); //analyze a single function
     dbgcmdnew("analxrefs\1analx", cbInstrAnalxrefs, true); //analyze xrefs
+    dbgcmdnew("guiupdatedisable", cbInstrDisableGuiUpdate, true); //disable gui message
+    dbgcmdnew("guiupdateenable", cbInstrEnableGuiUpdate, true); //enable gui message
 }
 
 static bool cbCommandProvider(char* cmd, int maxlen)

--- a/src/gui/Src/BasicView/ReferenceView.h
+++ b/src/gui/Src/BasicView/ReferenceView.h
@@ -27,6 +27,10 @@ private slots:
     void followApiAddress();
     void followGenericAddress();
     void toggleBreakpoint();
+    void setBreakpointOnAllCommands();
+    void removeBreakpointOnAllCommands();
+    void setBreakpointOnAllApiCalls();
+    void removeBreakpointOnAllApiCalls();
     void toggleBookmark();
     void refreshShortcutsSlot();
     void referenceSetProgressSlot(int progress);
@@ -43,9 +47,23 @@ private:
     QAction* mFollowApiAddress;
     QAction* mToggleBreakpoint;
     QAction* mToggleBookmark;
-    bool mFollowDumpDefault;
+    QAction* mSetBreakpointOnAllCommands;
+    QAction* mRemoveBreakpointOnAllCommands;
+    QAction* mSetBreakpointOnAllApiCalls;
+    QAction* mRemoveBreakpointOnAllApiCalls;
     QLabel* mCountTotalLabel;
 
+    bool mFollowDumpDefault;
+
+    enum BPSetAction
+    {
+        Enable,
+        Disable,
+        Toggle,
+        Remove
+    };
+
+    void setBreakpointAt(int row, BPSetAction action);
     dsint apiAddressFromString(const QString & s);
 };
 


### PR DESCRIPTION
I implemented feature I mentioned in #669. After disabling gui messages, scripts and plugin commands that sets a lot breakpoints should run at least 5x faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/710)
<!-- Reviewable:end -->
