### PR TITLE
Resolve UI bug (#715) and do not require restart on settings change

### DIFF
--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -53,6 +53,7 @@ Disassembly::Disassembly(QWidget* parent) : AbstractTableView(parent)
     connect(Bridge::getBridge(), SIGNAL(updateDump()), this, SLOT(reloadData()));
     connect(Bridge::getBridge(), SIGNAL(dbgStateChanged(DBGSTATE)), this, SLOT(debugStateChangedSlot(DBGSTATE)));
     connect(this, SIGNAL(selectionChanged(dsint)), this, SLOT(selectionChangedSlot(dsint)));
+    connect(Config(), SIGNAL(tokenizerConfigUpdated()), this, SLOT(tokenizerConfigUpdatedSlot()));
 
     Initialize();
 }
@@ -115,6 +116,11 @@ void Disassembly::updateColors()
 void Disassembly::updateFonts()
 {
     setFont(ConfigFont("Disassembly"));
+}
+
+void Disassembly::tokenizerConfigUpdatedSlot()
+{
+    mDisasm->UpdateConfig();
 }
 
 /************************************************************************************

--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -105,6 +105,7 @@ public slots:
     void disassembleAt(dsint parVA, dsint parCIP);
     void debugStateChangedSlot(DBGSTATE state);
     void selectionChangedSlot(dsint parVA);
+    void tokenizerConfigUpdatedSlot();
 
 private:
     enum GuiState_t {NoState, MultiRowsSelectionState};

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -12,8 +12,8 @@ SettingsDialog::SettingsDialog(QWidget* parent) :
     ui->setupUi(this);
     //set window flags
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::MSWindowsFixedSizeDialogHint);
-    setFixedSize(this->size()); //fixed size
     setModal(true);
+    adjustSize();
     bTokenizerConfigUpdated = false;
     LoadSettings(); //load settings from file
     connect(Bridge::getBridge(), SIGNAL(setLastException(uint)), this, SLOT(setLastException(uint)));

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -14,6 +14,7 @@ SettingsDialog::SettingsDialog(QWidget* parent) :
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::MSWindowsFixedSizeDialogHint);
     setFixedSize(this->size()); //fixed size
     setModal(true);
+    bTokenizerConfigUpdated = false;
     LoadSettings(); //load settings from file
     connect(Bridge::getBridge(), SIGNAL(setLastException(uint)), this, SLOT(setLastException(uint)));
     lastException = 0;
@@ -303,6 +304,11 @@ void SettingsDialog::SaveSettings()
 
     BridgeSettingFlush();
     Config()->load();
+    if(bTokenizerConfigUpdated)
+    {
+        Config()->emitTokenizerConfigUpdated();
+        bTokenizerConfigUpdated = false;
+    }
     DbgSettingsUpdated();
     GuiUpdateAllViews();
 }
@@ -582,6 +588,7 @@ void SettingsDialog::on_btnAddLast_clicked()
 
 void SettingsDialog::on_chkArgumentSpaces_stateChanged(int arg1)
 {
+    bTokenizerConfigUpdated = true;
     if(arg1 == Qt::Unchecked)
         settings.disasmArgumentSpaces = false;
     else
@@ -590,6 +597,7 @@ void SettingsDialog::on_chkArgumentSpaces_stateChanged(int arg1)
 
 void SettingsDialog::on_chkMemorySpaces_stateChanged(int arg1)
 {
+    bTokenizerConfigUpdated = true;
     if(arg1 == Qt::Unchecked)
         settings.disasmMemorySpaces = false;
     else
@@ -598,6 +606,7 @@ void SettingsDialog::on_chkMemorySpaces_stateChanged(int arg1)
 
 void SettingsDialog::on_chkUppercase_stateChanged(int arg1)
 {
+    bTokenizerConfigUpdated = true;
     if(arg1 == Qt::Unchecked)
         settings.disasmUppercase = false;
     else
@@ -614,6 +623,7 @@ void SettingsDialog::on_chkOnlyCipAutoComments_stateChanged(int arg1)
 
 void SettingsDialog::on_chkTabBetweenMnemonicAndArguments_stateChanged(int arg1)
 {
+    bTokenizerConfigUpdated = true;
     settings.disasmTabBetweenMnemonicAndArguments = arg1 == Qt::Checked;
 }
 

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -141,6 +141,7 @@ private:
     QList<RangeStruct> realExceptionRanges;
     bool bJitOld;
     bool bJitAutoOld;
+    bool bTokenizerConfigUpdated;
 
     //functions
     void GetSettingBool(const char* section, const char* name, bool* set);

--- a/src/gui/Src/Utils/CachedFontMetrics.h
+++ b/src/gui/Src/Utils/CachedFontMetrics.h
@@ -13,6 +13,7 @@ public:
         : QObject(parent),
           mFontMetrics(font)
     {
+        memset(mWidths, 0, sizeof(mWidths));
     }
 
     int width(const QChar & ch)

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -388,6 +388,11 @@ void Configuration::emitColorsUpdated()
     emit colorsUpdated();
 }
 
+void Configuration::emitTokenizerConfigUpdated()
+{
+    emit tokenizerConfigUpdated();
+}
+
 void Configuration::readBools()
 {
     Bools = defaultBools;

--- a/src/gui/Src/Utils/Configuration.h
+++ b/src/gui/Src/Utils/Configuration.h
@@ -44,6 +44,7 @@ public:
     void readColors();
     void writeColors();
     void emitColorsUpdated();
+    void emitTokenizerConfigUpdated();
     void readBools();
     void writeBools();
     void readUints();
@@ -83,6 +84,7 @@ signals:
     void colorsUpdated();
     void fontsUpdated();
     void shortcutsUpdated();
+    void tokenizerConfigUpdated();
 
 private:
     QColor colorFromConfig(const QString id);


### PR DESCRIPTION
Now we don't need to restart the program to apply new disassembly settings.
And fix #715 (The disassembly interface is too messy)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/717)
<!-- Reviewable:end -->
