### PR TITLE
GDB: fixed thread sometimes switch to other when trying pause thread

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -403,7 +403,10 @@ static bool getConditionValue(const char* expression)
 
 void cbPauseBreakpoint()
 {
-    hActiveThread = ThreadGetHandle(((DEBUG_EVENT*)GetDebugData())->dwThreadId);
+    if(hActiveThread != ThreadGetHandle(((DEBUG_EVENT*)GetDebugData())->dwThreadId))
+    {
+        return;
+    }
     auto CIP = GetContextDataEx(hActiveThread, UE_CIP);
     DeleteBPX(CIP);
     GuiSetDebugState(paused);


### PR DESCRIPTION
This often happened when current in a hardware/software interrupt. And other thread reached the breakpoint first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/726)
<!-- Reviewable:end -->
