### PR TITLE
Fix multiple issues

### DIFF
--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -47,6 +47,7 @@ public:
 
     // Constructor
     explicit AbstractTableView(QWidget* parent = 0);
+    ~AbstractTableView();
 
     // Configuration
     virtual void Initialize();
@@ -104,6 +105,13 @@ public:
     void setNbrOfLineToPrint(int parNbrOfLineToPrint);
     void setShowHeader(bool show);
     int getCharWidth();
+    bool getColumnHidden(int col);
+    void setColumnHidden(int col, bool hidden);
+
+    // UI customization
+    void loadColumnFromConfig(const QString& viewName);
+    void saveColumnToConfig();
+    static void setupColumnConfigDefaultValue(QMap<QString, duint>& map, const QString& viewName, int columnCount);
 
     // Content drawing control
     bool getDrawDebugOnly();
@@ -201,8 +209,6 @@ private:
     ScrollBar64_t mScrollBarAttributes;
 
     int getColumnDisplayIndexFromX(int x);
-    bool getColumnHidden(int col);
-    void setColumnHidden(int col, bool hidden);
     friend class ColumnReorderDialog;
 protected:
     bool mAllowPainting;
@@ -214,6 +220,7 @@ protected:
     QColor separatorColor;
     QColor headerTextColor;
     QColor selectionColor;
+    QString mViewName;
 
     // Font metrics
     CachedFontMetrics* mFontMetrics;

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -55,6 +55,7 @@ void HexDump::updateColors()
 void HexDump::updateFonts()
 {
     setFont(ConfigFont("HexDump"));
+    invalidateCachedFont();
 }
 
 void HexDump::updateShortcuts()

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -20,6 +20,7 @@ BreakpointsView::BreakpointsView(QWidget* parent) : QWidget(parent)
     mSoftBPTable->addColumnAt(8 + wCharWidth * 2, tr("Fast resume"), false);
     mSoftBPTable->addColumnAt(8 + wCharWidth * 16, tr("Command on hit"), false);
     mSoftBPTable->addColumnAt(wCharWidth * 10, tr("Comment"), false);
+    mSoftBPTable->loadColumnFromConfig("SoftwareBreakpoint");
 
     // Hardware
     mHardBPTable = new StdTable(this);
@@ -34,6 +35,7 @@ BreakpointsView::BreakpointsView(QWidget* parent) : QWidget(parent)
     mHardBPTable->addColumnAt(8 + wCharWidth * 2, tr("Fast resume"), false);
     mHardBPTable->addColumnAt(8 + wCharWidth * 16, tr("Command on hit"), false);
     mHardBPTable->addColumnAt(wCharWidth * 10, tr("Comment"), false);
+    mHardBPTable->loadColumnFromConfig("HardwareBreakpoint");
 
     // Memory
     mMemBPTable = new StdTable(this);
@@ -48,6 +50,7 @@ BreakpointsView::BreakpointsView(QWidget* parent) : QWidget(parent)
     mMemBPTable->addColumnAt(8 + wCharWidth * 2, tr("Fast resume"), false);
     mMemBPTable->addColumnAt(8 + wCharWidth * 16, tr("Command on hit"), false);
     mMemBPTable->addColumnAt(wCharWidth * 10, tr("Comment"), false);
+    mMemBPTable->loadColumnFromConfig("MemoryBreakpoint");
 
     // Splitter
     mSplitter = new QSplitter(this);

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -443,7 +443,7 @@ void CPUDisassembly::setupRightClickContextMenu()
     MenuBuilder* mSearchAllMenu = new MenuBuilder(this);
 
     // Search in Current Region menu
-    mFindCommandRegion = makeShortcutAction("C&ommand", SLOT(findCommandSlot()), "ActionFind");
+    mFindCommandRegion = makeShortcutAction(tr("C&ommand"), SLOT(findCommandSlot()), "ActionFind");
     mFindConstantRegion = makeAction(tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsRegion = makeAction(tr("&String references"), SLOT(findStringsSlot()));
     mFindCallsRegion = makeAction(tr("&Intermodular calls"), SLOT(findCallsSlot()));

--- a/src/gui/Src/Gui/CPUMultiDump.cpp
+++ b/src/gui/Src/Gui/CPUMultiDump.cpp
@@ -13,6 +13,7 @@ CPUMultiDump::CPUMultiDump(CPUDisassembly* disas, int nbCpuDumpTabs, QWidget* pa
     for(uint i = 0; i < mMaxCPUDumpTabs; i++)
     {
         CPUDump* cpuDump = new CPUDump(disas, this);
+        cpuDump->loadColumnFromConfig(QString("CPUDump%1").arg(i + 1));
         connect(cpuDump, SIGNAL(displayReferencesWidget()), this, SLOT(displayReferencesWidgetSlot()));
         this->addTabEx(cpuDump, QIcon(":/icons/images/dump.png"), tr("Dump ") + QString::number(i + 1), QString("Dump ") + QString::number(i + 1));
     }

--- a/src/gui/Src/Gui/CPUWidget.cpp
+++ b/src/gui/Src/Gui/CPUWidget.cpp
@@ -69,6 +69,10 @@ CPUWidget::CPUWidget(QWidget* parent) : QWidget(parent), ui(new Ui::CPUWidget)
 
     mStack = new CPUStack(mDump, 0); //stack widget
     ui->mBotRightFrameLayout->addWidget(mStack);
+
+    // load column config
+    mDisas->loadColumnFromConfig("CPUDisassembly");
+    mStack->loadColumnFromConfig("CPUStack");
 }
 
 CPUWidget::~CPUWidget()

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -9,6 +9,7 @@ CallStackView::CallStackView(StdTable* parent) : StdTable(parent)
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("To"), true); //return to
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("From"), true); //return from
     addColumnAt(0, tr("Comment"), true);
+    loadColumnFromConfig("CallStack");
 
     connect(Bridge::getBridge(), SIGNAL(updateCallStack()), this, SLOT(updateCallStack()));
     connect(this, SIGNAL(contextMenuSignal(QPoint)), this, SLOT(contextMenuSlot(QPoint)));

--- a/src/gui/Src/Gui/HandlesView.cpp
+++ b/src/gui/Src/Gui/HandlesView.cpp
@@ -13,6 +13,7 @@ HandlesView::HandlesView(QWidget* parent) : QWidget(parent)
     mHandlesTable->addColumnAt(8 + sizeof(duint) * 2 * wCharWidth, tr("Handle"), false);
     mHandlesTable->addColumnAt(8 + 16 * wCharWidth, tr("Access"), false);
     mHandlesTable->addColumnAt(8 + wCharWidth * 20, tr("Name"), false);
+    mHandlesTable->loadColumnFromConfig("Handle");
 
     mTcpConnectionsTable = new StdTable(this);
     mTcpConnectionsTable->setDrawDebugOnly(true);
@@ -20,12 +21,14 @@ HandlesView::HandlesView(QWidget* parent) : QWidget(parent)
     mTcpConnectionsTable->addColumnAt(8 + 64 * wCharWidth, tr("Remote address"), false);
     mTcpConnectionsTable->addColumnAt(8 + 64 * wCharWidth, tr("Local address"), false);
     mTcpConnectionsTable->addColumnAt(8 + 8 * wCharWidth, tr("State", "TcpConnection"), false);
+    mTcpConnectionsTable->loadColumnFromConfig("TcpConnection");
 
     mPrivilegesTable = new StdTable(this);
     mPrivilegesTable->setDrawDebugOnly(true);
     mPrivilegesTable->setContextMenuPolicy(Qt::CustomContextMenu);
     mPrivilegesTable->addColumnAt(8 + 32 * wCharWidth, tr("Privilege"), false);
     mPrivilegesTable->addColumnAt(8 + 16 * wCharWidth, tr("State", "Privilege"), false);
+    mPrivilegesTable->loadColumnFromConfig("Privilege");
 
     // Splitter
     mSplitter = new QSplitter(this);

--- a/src/gui/Src/Gui/MemoryMapView.cpp
+++ b/src/gui/Src/Gui/MemoryMapView.cpp
@@ -21,6 +21,7 @@ MemoryMapView::MemoryMapView(StdTable* parent) : StdTable(parent)
     addColumnAt(8 + charwidth * 11, tr("Protection"), false, tr("Current Protection")); //current protection
     addColumnAt(8 + charwidth * 8, tr("Initial"), false, tr("Allocation Protection")); //allocation protection
     addColumnAt(100, "", false);
+    loadColumnFromConfig("MemoryMap");
 
     connect(Bridge::getBridge(), SIGNAL(updateMemory()), this, SLOT(refreshMap()));
     connect(Bridge::getBridge(), SIGNAL(dbgStateChanged(DBGSTATE)), this, SLOT(stateChangedSlot(DBGSTATE)));

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -7,6 +7,7 @@
 #include "LineEditDialog.h"
 #include "EditFloatRegister.h"
 #include "SelectFields.h"
+#include "MiscUtil.h"
 
 int RegistersView::getEstimateHeight()
 {
@@ -1168,6 +1169,7 @@ void RegistersView::fontsUpdatedSlot()
     wRowsHeight = (wRowsHeight % 2) == 0 ? wRowsHeight : wRowsHeight + 1;
     mRowHeight = wRowsHeight;
     mCharWidth = QFontMetrics(this->font()).averageCharWidth();
+    setFixedHeight(getEstimateHeight());
     repaint();
 }
 
@@ -1438,7 +1440,12 @@ QString RegistersView::GetRegStringValueFromValue(REGISTER_NAME reg, char* value
     {
         SIZE_T size = GetSizeRegister(reg);
         if(size != 0)
-            valueText = QString(QByteArray(value, size).toHex()).toUpper();
+        {
+            if(ConfigBool("Gui", "FpuRegistersLittleEndian"))
+                valueText = QString(QByteArray(value, size).toHex()).toUpper();
+            else
+                valueText = QString(ByteReverse(QByteArray(value, size)).toHex()).toUpper();
+        }
         else
             valueText = QString("???");
     }

--- a/src/gui/Src/Gui/SEHChainView.cpp
+++ b/src/gui/Src/Gui/SEHChainView.cpp
@@ -12,6 +12,7 @@ SEHChainView::SEHChainView(StdTable* parent) : StdTable(parent)
     connect(Bridge::getBridge(), SIGNAL(updateSEHChain()), this, SLOT(updateSEHChain()));
     connect(this, SIGNAL(contextMenuSignal(QPoint)), this, SLOT(contextMenuSlot(QPoint)));
     connect(this, SIGNAL(doubleClickedSignal()), this, SLOT(doubleClickedSlot()));
+    loadColumnFromConfig("SEH");
     setupContextMenu();
 }
 

--- a/src/gui/Src/Gui/ScriptView.cpp
+++ b/src/gui/Src/Gui/ScriptView.cpp
@@ -17,6 +17,7 @@ ScriptView::ScriptView(StdTable* parent) : StdTable(parent)
     addColumnAt(8 + charwidth * 4, tr("Line"), false);
     addColumnAt(8 + charwidth * 60, tr("Text"), false);
     addColumnAt(8 + charwidth * 40, tr("Info"), false);
+    loadColumnFromConfig("Script");
 
     setIp(0); //no IP
 

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -175,7 +175,9 @@ void SettingsDialog::LoadSettings()
 
     //Gui tab
     GetSettingBool("Gui", "FpuRegistersLittleEndian", &settings.guiFpuRegistersLittleEndian);
+    GetSettingBool("Gui", "SaveColumnOrder", &settings.guiSaveColumnOrder);
     ui->chkFpuRegistersLittleEndian->setChecked(settings.guiFpuRegistersLittleEndian);
+    ui->chkSaveColumnOrder->setChecked(settings.guiSaveColumnOrder);
 
     //Misc tab
     if(DbgFunctions()->GetJit)
@@ -282,6 +284,7 @@ void SettingsDialog::SaveSettings()
 
     //Gui tab
     BridgeSettingSetUint("Gui", "FpuRegistersLittleEndian", settings.guiFpuRegistersLittleEndian);
+    BridgeSettingSetUint("Gui", "SaveColumnOrder", settings.guiSaveColumnOrder);
 
     //Misc tab
     if(DbgFunctions()->GetJit)
@@ -662,4 +665,12 @@ void SettingsDialog::on_chkFpuRegistersLittleEndian_stateChanged(int arg1)
         settings.guiFpuRegistersLittleEndian = false;
     else
         settings.guiFpuRegistersLittleEndian = true;
+}
+
+void SettingsDialog::on_chkSaveColumnOrder_stateChanged(int arg1)
+{
+    if(arg1 == Qt::Unchecked)
+        settings.guiSaveColumnOrder = false;
+    else
+        settings.guiSaveColumnOrder = true;
 }

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -173,6 +173,10 @@ void SettingsDialog::LoadSettings()
     ui->chkOnlyCipAutoComments->setChecked(settings.disasmOnlyCipAutoComments);
     ui->chkTabBetweenMnemonicAndArguments->setChecked(settings.disasmTabBetweenMnemonicAndArguments);
 
+    //Gui tab
+    GetSettingBool("Gui", "FpuRegistersLittleEndian", &settings.guiFpuRegistersLittleEndian);
+    ui->chkFpuRegistersLittleEndian->setChecked(settings.guiFpuRegistersLittleEndian);
+
     //Misc tab
     if(DbgFunctions()->GetJit)
     {
@@ -275,6 +279,9 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Disassembler", "Uppercase", settings.disasmUppercase);
     BridgeSettingSetUint("Disassembler", "OnlyCipAutoComments", settings.disasmOnlyCipAutoComments);
     BridgeSettingSetUint("Disassembler", "TabbedMnemonic", settings.disasmTabBetweenMnemonicAndArguments);
+
+    //Gui tab
+    BridgeSettingSetUint("Gui", "FpuRegistersLittleEndian", settings.guiFpuRegistersLittleEndian);
 
     //Misc tab
     if(DbgFunctions()->GetJit)
@@ -647,4 +654,12 @@ void SettingsDialog::on_chkSaveLoadTabOrder_stateChanged(int arg1)
         settings.miscLoadSaveTabOrder = true;
 
     emit chkSaveLoadTabOrderStateChanged((bool)arg1);
+}
+
+void SettingsDialog::on_chkFpuRegistersLittleEndian_stateChanged(int arg1)
+{
+    if(arg1 == Qt::Unchecked)
+        settings.guiFpuRegistersLittleEndian = false;
+    else
+        settings.guiFpuRegistersLittleEndian = true;
 }

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -61,6 +61,7 @@ private slots:
     void on_chkTabBetweenMnemonicAndArguments_stateChanged(int arg1);
     //Gui Tab
     void on_chkFpuRegistersLittleEndian_stateChanged(int arg1);
+    void on_chkSaveColumnOrder_stateChanged(int arg1);
     //Misc tab
     void on_chkSetJIT_stateChanged(int arg1);
     void on_chkConfirmBeforeAtt_stateChanged(int arg1);
@@ -131,6 +132,7 @@ private:
         bool disasmTabBetweenMnemonicAndArguments;
         //Gui Tab
         bool guiFpuRegistersLittleEndian;
+        bool guiSaveColumnOrder;
         //Misc Tab
         bool miscSetJIT;
         bool miscSetJITAuto;

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -59,6 +59,8 @@ private slots:
     void on_chkUppercase_stateChanged(int arg1);
     void on_chkOnlyCipAutoComments_stateChanged(int arg1);
     void on_chkTabBetweenMnemonicAndArguments_stateChanged(int arg1);
+    //Gui Tab
+    void on_chkFpuRegistersLittleEndian_stateChanged(int arg1);
     //Misc tab
     void on_chkSetJIT_stateChanged(int arg1);
     void on_chkConfirmBeforeAtt_stateChanged(int arg1);
@@ -127,6 +129,8 @@ private:
         bool disasmUppercase;
         bool disasmOnlyCipAutoComments;
         bool disasmTabBetweenMnemonicAndArguments;
+        //Gui Tab
+        bool guiFpuRegistersLittleEndian;
         //Misc Tab
         bool miscSetJIT;
         bool miscSetJITAuto;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -453,6 +453,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkSaveColumnOrder">
+         <property name="text">
+          <string>Save column order and width</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_7">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -434,6 +434,39 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabGui">
+      <attribute name="title">
+       <string>GUI</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11">
+       <item>
+        <widget class="QCheckBox" name="chkFpuRegistersLittleEndian">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Show FPU registers as little endian</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tabMisc">
       <attribute name="title">
        <string>Misc</string>

--- a/src/gui/Src/Gui/StatusLabel.cpp
+++ b/src/gui/Src/Gui/StatusLabel.cpp
@@ -34,7 +34,7 @@ void StatusLabel::debugStateChangedSlot(DBGSTATE state)
         this->setStyleSheet("QLabel { background-color : #ffff00; }");
         break;
     case running:
-        this->setText("Running");
+        this->setText(tr("Running"));
         this->setStyleSheet("QLabel { background-color : #c0c0c0; }");
         break;
     case stopped:

--- a/src/gui/Src/Gui/ThreadView.cpp
+++ b/src/gui/Src/Gui/ThreadView.cpp
@@ -203,6 +203,7 @@ ThreadView::ThreadView(StdTable* parent) : StdTable(parent)
     addColumnAt(8 + charwidth * 12, tr("Wait Reason"), false);
     addColumnAt(8 + charwidth * 11, tr("Last Error"), false);
     addColumnAt(0, "Name", false);
+    loadColumnFromConfig("Thread");
 
     //setCopyMenuOnly(true);
 

--- a/src/gui/Src/Utils/CachedFontMetrics.h
+++ b/src/gui/Src/Utils/CachedFontMetrics.h
@@ -38,9 +38,9 @@ public:
         QChar temp;
         for(const QChar & ch : text)
         {
-            if(ch.isLowSurrogate())
+            if(ch.isHighSurrogate())
                 temp = ch;
-            else if(ch.isHighSurrogate())
+            else if(ch.isLowSurrogate())
                 result += mFontMetrics.width(QString(temp) + ch);
             else
                 result += width(ch);

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -182,6 +182,10 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     miscellaneousBool.insert("LoadSaveTabOrder", false);
     defaultBools.insert("Miscellaneous", miscellaneousBool);
 
+    QMap<QString, bool> guiBool;
+    guiBool.insert("FpuRegistersLittleEndian", false);
+    defaultBools.insert("Gui", guiBool);
+
     //uint settings
     QMap<QString, duint> hexdumpUint;
     hexdumpUint.insert("DefaultView", 0);

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -3,11 +3,13 @@
 #include <QFontInfo>
 #include <QMessageBox>
 #include <QIcon>
+#include "AbstractTableView.h"
 
-Configuration* Configuration::mPtr = NULL;
+Configuration* Configuration::mPtr = nullptr;
 
 Configuration::Configuration() : QObject(), noMoreMsgbox(false)
 {
+    mPtr = this;
     //setup default color map
     defaultColors.clear();
     defaultColors.insert("AbstractTableViewSeparatorColor", QColor("#808080"));
@@ -184,7 +186,26 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
 
     QMap<QString, bool> guiBool;
     guiBool.insert("FpuRegistersLittleEndian", false);
+    guiBool.insert("SaveColumnOrder", true);
     defaultBools.insert("Gui", guiBool);
+
+    QMap<QString, duint> guiUint;
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUDisassembly", 4);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUStack", 3);
+    for(int i = 1; i <= 5; i++)
+        AbstractTableView::setupColumnConfigDefaultValue(guiUint, QString("CPUDump%1").arg(i), 4);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "SoftwareBreakpoint", 10);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "HardwareBreakpoint", 10);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "MemoryBreakpoint", 10);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "MemoryMap", 7);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CallStack", 4);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "SEH", 4);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Script", 3);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Thread", 10);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Handle", 5);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "TcpConnection", 3);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Privilege", 2);
+    defaultUints.insert("Gui", guiUint);
 
     //uint settings
     QMap<QString, duint> hexdumpUint;
@@ -339,7 +360,6 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     Shortcuts = defaultShortcuts;
 
     load();
-    mPtr = this;
 }
 
 Configuration* Config()

--- a/src/gui/Src/Utils/MiscUtil.cpp
+++ b/src/gui/Src/Utils/MiscUtil.cpp
@@ -7,3 +7,15 @@ void SetApplicationIcon(WId winId)
     SendMessageW((HWND)winId, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
     DestroyIcon(hIcon);
 }
+
+QByteArray& ByteReverse(QByteArray& array)
+{
+    int length = array.length();
+    for(int i = 0; i < length / 2; i++)
+    {
+        char temp = array[i];
+        array[i] = array[length - i - 1];
+        array[length - i - 1] = temp;
+    }
+    return array;
+}

--- a/src/gui/Src/Utils/MiscUtil.h
+++ b/src/gui/Src/Utils/MiscUtil.h
@@ -4,5 +4,6 @@
 #include <QWidget>
 
 void SetApplicationIcon(WId winId);
+QByteArray& ByteReverse(QByteArray& array);
 
 #endif // MISCUTIL_H

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -117,11 +117,12 @@ int main(int argc, char* argv[])
     Bridge::initBridge();
 
     // Start GUI
-    MainWindow mainWindow;
-    mainWindow.show();
+    MainWindow* mainWindow;
+    mainWindow = new MainWindow();
+    mainWindow->show();
 
     // Set some data
-    Bridge::getBridge()->winId = (void*)mainWindow.winId();
+    Bridge::getBridge()->winId = (void*)mainWindow->winId();
 
     // Init debugger
     const char* errormsg = DbgInit();
@@ -136,12 +137,13 @@ int main(int argc, char* argv[])
 
     //execute the application
     int result = application.exec();
-    mConfiguration->save(); //save config on exit
 #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     QAbstractEventDispatcher::instance(application.thread())->removeNativeEventFilter(filter);
 #else
     QAbstractEventDispatcher::instance(application.thread())->setEventFilter(nullptr);
 #endif
+    delete mainWindow;
+    mConfiguration->save(); //save config on exit
 
     //TODO free capstone/config/bridge and prevent use after free.
 


### PR DESCRIPTION
I add a new tab "GUI" in the settings dialog to set the new option. By default FPU registers are shown as big-endian. Edit float registers dialog is not changed by now since the byte order is explicitly stated there. The tab "GUI" will be populated with various settings such as the option to save column width or dialog positions, as well as current language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/730)
<!-- Reviewable:end -->
