### PR TITLE
Window title obfuscation

### DIFF
--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -54,11 +54,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     this->showMaximized();
 
-#ifdef _WIN64
-    mWindowMainTitle = tr("x64dbg");
-#else
-    mWindowMainTitle = tr("x32dbg");
-#endif
+    mWindowMainTitle = QCoreApplication::applicationName();
 
     // Set window title
     setWindowTitle(QString(mWindowMainTitle));


### PR DESCRIPTION
All the softwares search "OllyDbg" window in the system. Will x64dbg enjoy comparable fame?
![x64dbg-window-title-obfuscation](https://cloud.githubusercontent.com/assets/15761310/16139208/9b2c5736-3434-11e6-82fe-d3d7986b7cb2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/759)
<!-- Reviewable:end -->
