### PR TITLE
Plugin database storage

### DIFF
--- a/src/dbg/_plugin_types.h
+++ b/src/dbg/_plugin_types.h
@@ -19,6 +19,7 @@
 
 #include "bridgemain.h"
 #include "_dbgfunctions.h"
+#include "jansson/jansson.h"
 
 #endif // BUILD_DBG
 

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -25,6 +25,9 @@
 //defines
 #define PLUG_SDKVERSION 1
 
+#define PLUG_DB_LOADSAVE_DATA 1
+#define PLUG_DB_LOADSAVE_ALL 2
+
 //structures
 typedef struct
 {
@@ -167,6 +170,12 @@ typedef struct
     bool retval;
 } PLUG_CB_WINEVENTGLOBAL;
 
+typedef struct
+{
+    JSON root;
+    int loadSaveType;
+} PLUG_CB_LOADSAVEDB;
+
 //enums
 typedef enum
 {
@@ -190,7 +199,9 @@ typedef enum
     CB_DEBUGEVENT, //PLUG_CB_DEBUGEVENT (called on any debug event)
     CB_MENUENTRY, //PLUG_CB_MENUENTRY
     CB_WINEVENT, //PLUG_CB_WINEVENT
-    CB_WINEVENTGLOBAL //PLUG_CB_WINEVENTGLOBAL
+    CB_WINEVENTGLOBAL, //PLUG_CB_WINEVENTGLOBAL
+    CB_LOADDB, //PLUG_CB_LOADSAVEDB
+    CB_SAVEDB //PLUG_CB_LOADSAVEDB
 } CBTYPE;
 
 //typedefs

--- a/src/dbg/database.cpp
+++ b/src/dbg/database.cpp
@@ -210,9 +210,7 @@ void DbLoad(DbLoadSaveType loadType)
                 pluginLoadDb.loadSaveType = 0;
                 break;
             }
-            //TODO: We have to increment the reference count before every callback invoke.
             plugincbcall(CB_LOADDB, &pluginLoadDb);
-            json_decref(pluginRoot);
         }
     }
 

--- a/src/dbg/database.cpp
+++ b/src/dbg/database.cpp
@@ -19,6 +19,7 @@
 #include "filehelper.h"
 #include "xrefs.h"
 #include "TraceRecord.h"
+#include "plugin_loader.h"
 
 /**
 \brief Directory where program databases are stored (usually in \db). UTF-8 encoding.
@@ -34,7 +35,7 @@ void DbSave(DbLoadSaveType saveType)
 {
     EXCLUSIVE_ACQUIRE(LockDatabase);
 
-    dprintf("Saving database...");
+    dputs("Saving database...");
     DWORD ticks = GetTickCount();
     JSON root = json_object();
 
@@ -63,6 +64,27 @@ void DbSave(DbLoadSaveType saveType)
             json_object_set_new(root, "notes", json_string(text));
             BridgeFree(text);
         }
+
+        //plugin data
+        PLUG_CB_LOADSAVEDB pluginSaveDb;
+        // Some plugins may wish to change this value so that all plugins after his or her plugin will save data into plugin-supplied storage instead of the system's.
+        // We back up this value so that the debugger is not fooled by such plugins.
+        JSON pluginRoot = json_object();
+        pluginSaveDb.root = pluginRoot;
+        switch(saveType)
+        {
+        case DbLoadSaveType::DebugData:
+            pluginSaveDb.loadSaveType = PLUG_DB_LOADSAVE_DATA;
+            break;
+        case DbLoadSaveType::All:
+            pluginSaveDb.loadSaveType = PLUG_DB_LOADSAVE_ALL;
+            break;
+        default:
+            pluginSaveDb.loadSaveType = 0;
+            break;
+        }
+        plugincbcall(CBTYPE::CB_SAVEDB, &pluginSaveDb);
+        json_object_set_new(root, "plugins", pluginRoot);
     }
 
     auto wdbpath = StringUtils::Utf8ToUtf16(dbpath);
@@ -166,10 +188,32 @@ void DbLoad(DbLoadSaveType loadType)
         TraceRecord.loadFromDb(root);
         BpCacheLoad(root);
 
-
         // Load notes
         const char* text = json_string_value(json_object_get(root, "notes"));
         GuiSetDebuggeeNotes(text);
+
+        // Plugins
+        JSON pluginRoot = json_object_get(root, "plugins");
+        if(pluginRoot)
+        {
+            PLUG_CB_LOADSAVEDB pluginLoadDb;
+            pluginLoadDb.root = pluginRoot;
+            switch(loadType)
+            {
+            case DbLoadSaveType::DebugData:
+                pluginLoadDb.loadSaveType = PLUG_DB_LOADSAVE_DATA;
+                break;
+            case DbLoadSaveType::All:
+                pluginLoadDb.loadSaveType = PLUG_DB_LOADSAVE_ALL;
+                break;
+            default:
+                pluginLoadDb.loadSaveType = 0;
+                break;
+            }
+            //TODO: We have to increment the reference count before every callback invoke.
+            plugincbcall(CB_LOADDB, &pluginLoadDb);
+            json_decref(pluginRoot);
+        }
     }
 
     // Free root


### PR DESCRIPTION
This is the code for #763 
All plugin data is stored inside "plugins" object.
This branch has not been tested. It needs to be tested with a working plugin.

CB_LOADDB/CB_SAVEDB callback types are introduced with argument type PLUG_CB_LOADSAVEDB.

_Since all the plugin callbacks are supplied with a JSON object, should we increment its reference count before every plugin callback, or left that as a responsibility of the plugin?_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/766)
<!-- Reviewable:end -->
