### PR TITLE
watchdog and script controlled conditional breakpoint

### DIFF
--- a/src/dbg/database.cpp
+++ b/src/dbg/database.cpp
@@ -15,6 +15,7 @@
 #include "loop.h"
 #include "commandline.h"
 #include "database.h"
+#include "watch.h"
 #include "threading.h"
 #include "filehelper.h"
 #include "xrefs.h"
@@ -54,6 +55,7 @@ void DbSave(DbLoadSaveType saveType)
         XrefCacheSave(root);
         TraceRecord.saveToDb(root);
         BpCacheSave(root);
+        WatchCacheSave(root);
 
         //save notes
         char* text = nullptr;
@@ -165,7 +167,7 @@ void DbLoad(DbLoadSaveType loadType)
         XrefCacheLoad(root);
         TraceRecord.loadFromDb(root);
         BpCacheLoad(root);
-
+        WatchCacheLoad(root);
 
         // Load notes
         const char* text = json_string_value(json_object_get(root, "notes"));

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -24,6 +24,7 @@
 #include "stackinfo.h"
 #include "stringformat.h"
 #include "TraceRecord.h"
+#include "watch.h"
 
 struct TraceCondition
 {
@@ -582,7 +583,7 @@ static void cbGenericBreakpoint(BP_TYPE bptype, void* ExceptionAddress = nullptr
     if(*bp.commandText && commandCondition)  //command
     {
         //TODO: commands like run/step etc will fuck up your shit
-        DbgCmdExec(bp.commandText);
+        _dbg_dbgcmddirectexec(bp.commandText);
     }
     if(breakCondition)  //break the debugger
     {
@@ -2116,6 +2117,7 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     DbClose();
     ModClear();
     ThreadClear();
+    WatchClear();
     TraceRecord.clear();
     GuiSetDebugState(stopped);
     GuiUpdateAllViews();

--- a/src/dbg/threading.h
+++ b/src/dbg/threading.h
@@ -58,6 +58,7 @@ enum SectionLock
     LockTraceRecord,
     LockCrossReferences,
     LockDebugStartStop,
+    LockWatch,
     LockArguments,
     LockCallstackCache,
 

--- a/src/dbg/variable.cpp
+++ b/src/dbg/variable.cpp
@@ -73,6 +73,8 @@ void varinit()
     varnew("$result3\1$res3", 0, VAR_SYSTEM);
     varnew("$result4\1$res4", 0, VAR_SYSTEM);
 
+    varnew("$breakcondition", 0, VAR_SYSTEM);
+
     // InitDebug variables
     varnew("$hProcess\1$hp", 0, VAR_READONLY);  // Process handle
     varnew("$pid", 0, VAR_READONLY);            // Process ID

--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -1,0 +1,375 @@
+#include "watch.h"
+#include "console.h"
+#include "variable.h"
+#include "value.h"
+#include "threading.h"
+#include "debugger.h"
+#include "symbolinfo.h"
+#include <Windows.h>
+
+std::map<unsigned int, WatchExpr*> watchexpr;
+unsigned int idCounter = 1;
+
+WatchExpr::WatchExpr(const char* expression, WatchVarType type) : expr(expression), varType(type), currValue(0), haveCurrValue(false)
+{
+    if(!expr.IsValidExpression())
+        varType = WatchVarType::TYPE_INVALID;
+}
+
+duint WatchExpr::getIntValue()
+{
+    if(varType == WatchVarType::TYPE_UINT || varType == WatchVarType::TYPE_INT)
+    {
+        duint val;
+        bool ok = expr.Calculate(val, varType == WatchVarType::TYPE_INT);
+        if(ok)
+        {
+            currValue = val;
+            haveCurrValue = true;
+            return val;
+        }
+    }
+    currValue = 0;
+    haveCurrValue = false;
+    return 0;
+}
+
+bool WatchExpr::modifyExpr(const char* expression, WatchVarType type)
+{
+    ExpressionParser b(expression);
+    if(b.IsValidExpression())
+    {
+        expr = b;
+        varType = type;
+        currValue = 0;
+        haveCurrValue = false;
+        return true;
+    }
+    else
+        return false;
+}
+
+// Global functions
+// Clear all watch
+void WatchClear()
+{
+    if(!watchexpr.empty())
+    {
+        for(auto i : watchexpr)
+            delete i.second;
+        watchexpr.clear();
+    }
+}
+
+unsigned int WatchAddExprUnlocked(const char* expr, WatchVarType type)
+{
+    unsigned int newid = InterlockedExchangeAdd(&idCounter, 1);
+    auto temp = watchexpr.emplace(std::make_pair(newid, new WatchExpr(expr, type)));
+    return temp.second ? newid : 0;
+}
+
+unsigned int WatchAddExpr(const char* expr, WatchVarType type)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    return WatchAddExprUnlocked(expr, type);
+}
+
+bool WatchModifyExpr(unsigned int id, const char* expr, WatchVarType type)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    auto obj = watchexpr.find(id);
+    if(obj != watchexpr.end())
+    {
+        return obj->second->modifyExpr(expr, type);
+    }
+    else
+        return false;
+}
+
+void WatchDelete(unsigned int id)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    auto x = watchexpr.find(id);
+    if(x != watchexpr.end())
+    {
+        delete x->second;
+        watchexpr.erase(x);
+    }
+}
+
+void WatchSetWatchdogModeUnlocked(unsigned int id, WatchdogMode mode)
+{
+    auto obj = watchexpr.find(id);
+    if(obj != watchexpr.end())
+        obj->second->setWatchdogMode(mode);
+}
+
+void WatchSetWatchdogMode(unsigned int id, WatchdogMode mode)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    WatchSetWatchdogModeUnlocked(id, mode);
+}
+
+WatchdogMode WatchGetWatchdogEnabled(unsigned int id)
+{
+    SHARED_ACQUIRE(LockWatch);
+    auto obj = watchexpr.find(id);
+    if(obj != watchexpr.end())
+        return obj->second->getWatchdogMode();
+    else
+        return WatchdogMode::MODE_DISABLED;
+}
+
+duint WatchGetUnsignedValue(unsigned int id)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    auto obj = watchexpr.find(id);
+    if(obj != watchexpr.end())
+        return obj->second->getIntValue();
+    else
+        return 0;
+}
+
+WatchVarType WatchGetType(unsigned int id)
+{
+    SHARED_ACQUIRE(LockWatch);
+    auto obj = watchexpr.find(id);
+    if(obj != watchexpr.end())
+        return obj->second->getType();
+    else
+        return WatchVarType::TYPE_INVALID;
+}
+
+// Initialize id counter so that it begin with a unused value
+void WatchInitIdCounter()
+{
+    idCounter = 1;
+    for(auto i : watchexpr)
+        if(i.first > idCounter)
+            idCounter = i.first + 1;
+}
+
+void WatchCacheSave(JSON root)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    JSON watchroot = json_array();
+    for(auto i : watchexpr)
+    {
+        if(i.second->getType() == WatchVarType::TYPE_INVALID)
+            continue;
+        JSON watchitem = json_object();
+        json_object_set_new(watchitem, "Expression", json_string(i.second->getExpr().c_str()));
+        switch(i.second->getType())
+        {
+        case WatchVarType::TYPE_INT:
+            json_object_set_new(watchitem, "DataType", json_string("int"));
+            break;
+        case WatchVarType::TYPE_UINT:
+            json_object_set_new(watchitem, "DataType", json_string("uint"));
+            break;
+        case WatchVarType::TYPE_FLOAT:
+            json_object_set_new(watchitem, "DataType", json_string("float"));
+            break;
+        default:
+            break;
+        }
+        switch(i.second->getWatchdogMode())
+        {
+        case WatchdogMode::MODE_DISABLED:
+            json_object_set_new(watchitem, "WatchdogMode", json_string("Disabled"));
+            break;
+        case WatchdogMode::MODE_CHANGED:
+            json_object_set_new(watchitem, "WatchdogMode", json_string("Changed"));
+            break;
+        case WatchdogMode::MODE_UNCHANGED:
+            json_object_set_new(watchitem, "WatchdogMode", json_string("Unchanged"));
+            break;
+        case WatchdogMode::MODE_ISTRUE:
+            json_object_set_new(watchitem, "WatchdogMode", json_string("IsTrue"));
+            break;
+        case WatchdogMode::MODE_ISFALSE:
+            json_object_set_new(watchitem, "WatchdogMode", json_string("IsFalse"));
+            break;
+        default:
+            break;
+        }
+        json_array_append_new(watchroot, watchitem);
+    }
+    json_object_set_new(root, "Watch", watchroot);
+}
+
+void WatchCacheLoad(JSON root)
+{
+    WatchClear();
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    JSON watchroot = json_object_get(root, "Watch");
+    unsigned int i;
+    JSON val;
+    if(!watchroot)
+        return;
+
+    json_array_foreach(watchroot, i, val)
+    {
+        const char* expr = json_string_value(json_object_get(val, "Expression"));
+        if(!expr)
+            continue;
+        const char* datatype = json_string_value(json_object_get(val, "DataType"));
+        if(!datatype)
+            continue;
+        const char* watchdogmode = json_string_value(json_object_get(val, "WatchdogMode"));
+        if(!watchdogmode)
+            continue;
+        WatchVarType varType;
+        WatchdogMode watchdogMode;
+        if(strcmp(datatype, "int") == 0)
+            varType = WatchVarType::TYPE_INT;
+        else if(strcmp(datatype, "uint") == 0)
+            varType = WatchVarType::TYPE_UINT;
+        else if(strcmp(datatype, "float") == 0)
+            varType = WatchVarType::TYPE_FLOAT;
+        else
+            continue;
+        if(strcmp(watchdogmode, "Disabled") == 0)
+            watchdogMode = WatchdogMode::MODE_DISABLED;
+        else if(strcmp(watchdogmode, "Changed") == 0)
+            watchdogMode = WatchdogMode::MODE_CHANGED;
+        else if(strcmp(watchdogmode, "Unchanged") == 0)
+            watchdogMode = WatchdogMode::MODE_UNCHANGED;
+        else if(strcmp(watchdogmode, "IsTrue") == 0)
+            watchdogMode = WatchdogMode::MODE_ISTRUE;
+        else if(strcmp(watchdogmode, "IsFalse") == 0)
+            watchdogMode = WatchdogMode::MODE_ISFALSE;
+        else
+            continue;
+        unsigned int id = WatchAddExprUnlocked(expr, varType);
+        WatchSetWatchdogModeUnlocked(id, watchdogMode);
+    }
+    WatchInitIdCounter(); // Initialize id counter so that it begin with a unused value
+}
+
+CMDRESULT cbWatchdog(int argc, char* argv[])
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    duint watchdogTriggered = 0;
+    auto lbl = SymGetSymbolicName(GetContextDataEx(hActiveThread, UE_CIP));
+    for(auto j = watchexpr.begin(); j != watchexpr.end(); j++)
+    {
+        std::pair<unsigned int, WatchExpr*> i = *j ;
+        if(i.second->getType() != WatchVarType::TYPE_INVALID)
+        {
+            duint origVal = i.second->getCurrIntValue();
+            duint newVal = i.second->getIntValue();
+            switch(i.second->getWatchdogMode())
+            {
+            default:
+            case WatchdogMode::MODE_DISABLED:
+                break;
+            case WatchdogMode::MODE_ISTRUE:
+                if(newVal != 0)
+                {
+                    dprintf("Watchdog " fhex " (expression \"%s\") is triggered at %s ! Original value: " fhex ", New value: " fhex "\n", i.first, i.second->getExpr().c_str(), lbl.c_str(), origVal, newVal);
+                    watchdogTriggered = 1;
+                }
+                break;
+            case WatchdogMode::MODE_ISFALSE:
+                if(newVal == 0)
+                {
+                    dprintf("Watchdog " fhex " (expression \"%s\") is triggered at %s ! Original value: " fhex ", New value: " fhex "\n", i.first, i.second->getExpr().c_str(), lbl.c_str(), origVal, newVal);
+                    watchdogTriggered = 1;
+                }
+                break;
+            case WatchdogMode::MODE_CHANGED:
+                if(newVal != origVal || !i.second->HaveCurrentValue())
+                {
+                    dprintf("Watchdog " fhex " (expression \"%s\") is triggered at %s ! Original value: " fhex ", New value: " fhex "\n", i.first, i.second->getExpr().c_str(), lbl.c_str(), origVal, newVal);
+                    watchdogTriggered = 1;
+                }
+                break;
+            case WatchdogMode::MODE_UNCHANGED:
+                if(newVal == origVal || !i.second->HaveCurrentValue())
+                {
+                    dprintf("Watchdog " fhex " (expression \"%s\") is triggered at %s ! Original value: " fhex ", New value: " fhex "\n", i.first, i.second->getExpr().c_str(), lbl.c_str(), origVal, newVal);
+                    watchdogTriggered = 1;
+                }
+                break;
+            }
+        }
+    }
+    varset("$result", watchdogTriggered, false);
+    return STATUS_CONTINUE;
+}
+
+CMDRESULT cbAddWatch(int argc, char* argv[])
+{
+    if(argc < 2)
+    {
+        dputs("No enough arguments for addwatch\n");
+        return STATUS_ERROR;
+    }
+    WatchVarType newtype = WatchVarType::TYPE_INT;
+    if(argc > 2)
+    {
+        if(_stricmp(argv[2], "unsigned"))
+            newtype = WatchVarType::TYPE_UINT;
+    }
+    unsigned int newid = WatchAddExpr(argv[1], newtype);
+    varset("$result", newid, false);
+    return STATUS_CONTINUE;
+}
+
+CMDRESULT cbDelWatch(int argc, char* argv[])
+{
+    if(argc < 2)
+    {
+        dputs("No enough arguments for delwatch\n");
+        return STATUS_ERROR;
+    }
+    duint id;
+    bool ok = valfromstring(argv[1], &id);
+    if(!ok)
+    {
+        dputs("Error expression in argument 1.\n");
+        return STATUS_ERROR;
+    }
+    WatchDelete(id);
+    return STATUS_CONTINUE;
+}
+
+CMDRESULT cbSetWatchdog(int argc, char* argv[])
+{
+    if(argc < 2)
+    {
+        dputs("No enough arguments for delwatch\n");
+        return STATUS_ERROR;
+    }
+    duint id;
+    bool ok = valfromstring(argv[1], &id);
+    if(!ok)
+    {
+        dputs("Error expression in argument 1.\n");
+        return STATUS_ERROR;
+    }
+    WatchdogMode mode;
+    if(argc > 2)
+    {
+        if(_stricmp(argv[2], "disabled") == 0)
+            mode = WatchdogMode::MODE_DISABLED;
+        else if(_stricmp(argv[2], "changed") == 0)
+            mode = WatchdogMode::MODE_CHANGED;
+        else if(_stricmp(argv[2], "unchanged") == 0)
+            mode = WatchdogMode::MODE_UNCHANGED;
+        else if(_stricmp(argv[2], "istrue") == 0)
+            mode = WatchdogMode::MODE_ISTRUE;
+        else if(_stricmp(argv[2], "isfalse") == 0)
+            mode = WatchdogMode::MODE_ISFALSE;
+        else
+        {
+            dputs("Unknown watchdog mode.\n");
+            return STATUS_ERROR;
+        }
+    }
+    else
+        mode = (WatchGetWatchdogEnabled(id) == WatchdogMode::MODE_DISABLED) ? WatchdogMode::MODE_CHANGED : WatchdogMode::MODE_DISABLED;
+    WatchSetWatchdogMode(id, mode);
+    return STATUS_CONTINUE;
+}

--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -296,7 +296,8 @@ CMDRESULT cbWatchdog(int argc, char* argv[])
         }
     }
     varset("$result", watchdogTriggered, false);
-    varset("$breakcondition", watchdogTriggered, false);
+    if(watchdogTriggered)
+        varset("$breakcondition", 1, false);
     return STATUS_CONTINUE;
 }
 

--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -296,6 +296,7 @@ CMDRESULT cbWatchdog(int argc, char* argv[])
         }
     }
     varset("$result", watchdogTriggered, false);
+    varset("$breakcondition", watchdogTriggered, false);
     return STATUS_CONTINUE;
 }
 

--- a/src/dbg/watch.h
+++ b/src/dbg/watch.h
@@ -1,0 +1,81 @@
+#include "_global.h"
+#include "command.h"
+#include "expressionparser.h"
+#include "jansson\jansson.h"
+
+enum WatchVarType
+{
+    TYPE_UINT, // unsigned integer
+    TYPE_INT,  // signed integer
+    TYPE_FLOAT,// single precision floating point value
+    TYPE_INVALID // invalid watch expression or data type
+};
+
+enum WatchdogMode
+{
+    MODE_DISABLED, // watchdog is disabled
+    MODE_ISTRUE,   // alert if expression is not 0
+    MODE_ISFALSE,  // alert if expression is 0
+    MODE_CHANGED,  // alert if expression is changed
+    MODE_UNCHANGED // alert if expression is not changed
+};
+
+class WatchExpr
+{
+protected:
+    ExpressionParser expr;
+    WatchdogMode watchdogMode;
+    bool haveCurrValue;
+    WatchVarType varType;
+    duint currValue; // last result of getIntValue()
+
+public:
+    WatchExpr(const char* expression, WatchVarType type);
+    ~WatchExpr() {};
+    duint getIntValue(); // evaluate the expression as integer
+    bool modifyExpr(const char* expression, WatchVarType type); // modify the expression and data type
+
+    inline WatchdogMode getWatchdogMode()
+    {
+        return watchdogMode;
+    };
+    inline void setWatchdogMode(WatchdogMode mode)
+    {
+        watchdogMode = mode;
+    };
+    inline WatchVarType getType()
+    {
+        return varType;
+    };
+    inline duint getCurrIntValue()
+    {
+        return currValue;
+    };
+    inline const String & getExpr()
+    {
+        return expr.GetExpression();
+    }
+    inline const bool HaveCurrentValue()
+    {
+        return haveCurrValue;
+    };
+};
+
+extern std::map<unsigned int, WatchExpr*> watchexpr;
+
+void WatchClear();
+unsigned int WatchAddExpr(const char* expr, WatchVarType type);
+bool WatchModifyExpr(unsigned int id, const char* expr, WatchVarType type);
+void WatchDelete(unsigned int id);
+void WatchSetWatchdogMode(unsigned int id, bool isEnabled);
+WatchdogMode WatchGetWatchdogMode(unsigned int id);
+duint WatchGetUnsignedValue(unsigned int id);
+WatchVarType WatchGetType(unsigned int id);
+void WatchCacheSave(JSON root); // Save watch data to database
+void WatchCacheLoad(JSON root); // Load watch data from database
+
+CMDRESULT cbWatchdog(int argc, char* argv[]);
+CMDRESULT cbAddWatch(int argc, char* argv[]);
+CMDRESULT cbDelWatch(int argc, char* argv[]);
+CMDRESULT cbSetWatchdog(int argc, char* argv[]);
+

--- a/src/dbg/x64_dbg.cpp
+++ b/src/dbg/x64_dbg.cpp
@@ -22,6 +22,7 @@
 #include "filehelper.h"
 #include "database.h"
 #include "mnemonichelp.h"
+#include "watch.h"
 
 static MESSAGE_STACK* gMsgStack = 0;
 static HANDLE hCommandLoopThread = 0;
@@ -154,6 +155,12 @@ static void registercommands()
     dbgcmdnew("SetMemoryBreakpointFastResume", cbDebugSetBPXMemoryFastResume, true); //set breakpoint fast resume
     dbgcmdnew("SetMemoryGetBreakpointHitCount", cbDebugGetBPXMemoryHitCount, true); //get breakpoint hit count
     dbgcmdnew("ResetMemoryBreakpointHitCount", cbDebugResetBPXMemoryHitCount, true); //reset breakpoint hit count
+
+    //watch
+    dbgcmdnew("addwatch", cbAddWatch, true); // add watch
+    dbgcmdnew("delwatch", cbDelWatch, true); // delete watch
+    dbgcmdnew("watchdog", cbWatchdog, true); // Watchdog
+    dbgcmdnew("setwatchdog", cbSetWatchdog, true); // Setup watchdog
 
     //variables
     dbgcmdnew("varnew\1var", cbInstrVar, false); //make a variable arg1:name,[arg2:value]

--- a/src/dbg/x64_dbg_dbg.vcxproj
+++ b/src/dbg/x64_dbg_dbg.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -77,6 +77,7 @@
     <ClCompile Include="TraceRecord.cpp" />
     <ClCompile Include="value.cpp" />
     <ClCompile Include="variable.cpp" />
+    <ClCompile Include="watch.cpp" />
     <ClCompile Include="x64_dbg.cpp" />
     <ClCompile Include="xrefs.cpp" />
     <ClCompile Include="xrefsanalysis.cpp" />
@@ -171,6 +172,7 @@
     <ClInclude Include="serializablemap.h" />
     <ClInclude Include="tcpconnections.h" />
     <ClInclude Include="TraceRecord.h" />
+    <ClInclude Include="watch.h" />
     <ClInclude Include="xrefs.h" />
     <ClInclude Include="xrefsanalysis.h" />
     <ClInclude Include="yara\yara\stream.h" />

--- a/src/dbg/x64_dbg_dbg.vcxproj.filters
+++ b/src/dbg/x64_dbg_dbg.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -325,6 +325,9 @@
     </ClCompile>
     <ClCompile Include="xrefsanalysis.cpp">
       <Filter>Source Files\Analysis</Filter>
+    </ClCompile>
+    <ClCompile Include="watch.cpp">
+      <Filter>Source Files\Information</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -738,6 +741,9 @@
     </ClInclude>
     <ClInclude Include="keystone\x86.h">
       <Filter>Header Files\Third Party\keystone</Filter>
+    </ClInclude>
+    <ClInclude Include="watch.h">
+      <Filter>Header Files\Information</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Watchdog is a feature related to the unfinished watch view. It notifies the user if a watch item has changed or become true since last checkpoint. In principle it can be checked in a worker thread, but currently a command is provided to check the watchdog conditions.

Four new commands are added. "addwatch" adds a expression to the watch view, "delwatch" deletes a watch. "setwatchdog" sets the watchdog mode. "watchdog" command checks all the watch items and notify the user if any watchdog is triggered.
"watchdog" command can be placed in the breakpoint command, so that the breakpoint becomes a checkpoint. It will set "breakcondition" variable and "result" variable to true if any watchdog is triggered.

In order to pause the debugger when a watchdog is triggered, I introduced script controllable conditional breakpoint. Break condition is passed in and out as "breakcondition" variable, which can be accessed from script. The user can check something in the script, and perhaps modify the program context, then generate the break condition in script. However this feature is only useful if the user can execute a script instead of a command. We need to allow "jump" and "call" commands outside the script environment so that the user can write "jump myconditionalbreakpoint" in the edit breakpoint dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/768)
<!-- Reviewable:end -->
