### PR TITLE
Translate the launcher and add more shortcuts

### DIFF
--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -43,8 +43,8 @@ extern "C"
 #define DBG_VERSION 25
 
 //Bridge functions
-BRIDGE_IMPEXP const char* BridgeInit();
-BRIDGE_IMPEXP const char* BridgeStart();
+BRIDGE_IMPEXP const wchar_t* BridgeInit();
+BRIDGE_IMPEXP const wchar_t* BridgeStart();
 BRIDGE_IMPEXP void* BridgeAlloc(size_t size);
 BRIDGE_IMPEXP void BridgeFree(void* ptr);
 BRIDGE_IMPEXP bool BridgeSettingGet(const char* section, const char* key, char* value);

--- a/src/exe/LoadResourceString.h
+++ b/src/exe/LoadResourceString.h
@@ -1,0 +1,18 @@
+#include <string>
+
+#include "resource1.h" // String resources
+
+inline std::wstring _LoadResString(UINT uID) {
+    wchar_t* p = nullptr;
+    int len = ::LoadStringW(NULL, uID, reinterpret_cast<LPWSTR>(&p), 0);
+    if(len > 0)
+    {
+        return std::wstring(p, len);
+    }
+    else
+    {
+        return std::wstring();
+    }
+}
+
+#define LoadResString(uID) _LoadResString(uID).c_str()

--- a/src/exe/Strings.rc
+++ b/src/exe/Strings.rc
@@ -1,0 +1,135 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource1.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// zh(CN) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_CHS)
+LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource1.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR               "错误"
+    IDS_ERRORGETTINGMODULEPATH "获取模块路径时出错!"
+    IDS_QUESTION            "温馨提示"
+    IDS_ASKSHELLEXT         "您想要为调试器注册右键菜单吗?"
+    IDS_ASKDESKTOPSHORTCUT  "您想要创建桌面快捷方式吗?"
+    IDS_DONE                "完成!"
+    IDS_NEWCFGWRITTEN       "新的配置已经写入!"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_INVDPATH32          "启动器的配置文件中没有指定x32dbg的路径..."
+    IDS_INVDPATH64          "启动器的配置文件中没有指定x64dbg的路径..."
+    IDS_INVDPE              "无效的PE文件!"
+    IDS_FILEERR             "文件没找到，或者已被占用!"
+    IDS_SHORTCUTDESC        "一个面向未来的调试器!"
+    IDS_ASKADMIN            "您确定以管理员权限运行本程序了吗?"
+    IDS_REGCREATEKEYFAIL    "RegCreateKey 失败!"
+    IDS_REGSETVALUEEXFAIL   "RegSetValueEx 失败!"
+    IDS_REGOPENKEYFAIL      "RegOpenKeyEx 失败!"
+    IDS_BRIDGEINITERR       "BridgeInit 发生错误"
+    IDS_SHELLEXTDBG         "用x64dbg调试"
+    IDS_BRIDGESTARTERR      "BridgeStart 发生错误"
+END
+
+#endif    // zh(CN) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////
+// en(US) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR               "Error"
+    IDS_ERRORGETTINGMODULEPATH "Error getting module path!"
+    IDS_QUESTION            "Question"
+    IDS_ASKSHELLEXT         "Do you want to register a shell extension?"
+    IDS_ASKDESKTOPSHORTCUT  "Do you want to create Desktop Shortcuts?"
+    IDS_DONE                "Done!"
+    IDS_NEWCFGWRITTEN       "New configuration written!"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_INVDPATH32          "Path to x32dbg not specified in launcher configuration..."
+    IDS_INVDPATH64          "Path to x64dbg not specified in launcher configuration..."
+    IDS_INVDPE              "Invalid PE File!"
+    IDS_FILEERR             "File not found or in use!"
+    IDS_SHORTCUTDESC        "A Debugger for the future!"
+    IDS_ASKADMIN            "Running as Admin?"
+    IDS_REGCREATEKEYFAIL    "RegCreateKey failed!"
+    IDS_REGSETVALUEEXFAIL   "RegSetValueEx failed!"
+    IDS_REGOPENKEYFAIL      "RegOpenKeyEx Failed!"
+    IDS_BRIDGEINITERR       "BridgeInit Error"
+    IDS_SHELLEXTDBG         "Debug with x64dbg"
+    IDS_BRIDGESTARTERR      "BridgeStart Error"
+END
+
+#endif    // en(US) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/src/exe/resource1.h
+++ b/src/exe/resource1.h
@@ -1,0 +1,34 @@
+//{{NO_DEPENDENCIES}}
+//
+//
+//
+#define IDS_ERROR                       105
+#define IDS_ERRORGETTINGMODULEPATH      106
+#define IDS_QUESTION                    107
+#define IDS_ASKSHELLEXT                 108
+#define IDS_ASKDESKTOPSHORTCUT          109
+#define IDS_DONE                        110
+#define IDS_NEWCFGWRITTEN               111
+#define IDS_INVDPATH32                  112
+#define IDS_INVDPATH64                  113
+#define IDS_INVDPE                      114
+#define IDS_FILEERR                     115
+#define IDS_SHORTCUTDESC                116
+#define IDS_ASKADMIN                    117
+#define IDS_REGCREATEKEYFAIL            118
+#define IDS_REGSETVALUEEXFAIL           119
+#define IDS_REGOPENKEYFAIL              120
+#define IDS_BRIDGEINITERR               121
+#define IDS_SHELLEXTDBG                 122
+#define IDS_BRIDGESTARTERR              126
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/exe/x64_dbg_exe.cpp
+++ b/src/exe/x64_dbg_exe.cpp
@@ -8,6 +8,7 @@
 #include <windows.h>
 #include "crashdump.h"
 #include "..\bridge\bridgemain.h"
+#include "LoadResourceString.h"
 
 /**
  @fn int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
@@ -26,16 +27,16 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 {
     CrashDumpInitialize();
 
-    const char* errormsg = BridgeInit();
+    const wchar_t* errormsg = BridgeInit();
     if(errormsg)
     {
-        MessageBoxA(0, errormsg, "BridgeInit Error", MB_ICONERROR | MB_SYSTEMMODAL);
+        MessageBoxW(0, errormsg, LoadResString(IDS_BRIDGEINITERR), MB_ICONERROR | MB_SYSTEMMODAL);
         return 1;
     }
     errormsg = BridgeStart();
     if(errormsg)
     {
-        MessageBoxA(0, errormsg, "BridgeStart Error", MB_ICONERROR | MB_SYSTEMMODAL);
+        MessageBoxW(0, errormsg, LoadResString(IDS_BRIDGESTARTERR), MB_ICONERROR | MB_SYSTEMMODAL);
         return 1;
     }
     return 0;

--- a/src/exe/x64_dbg_exe.vcxproj
+++ b/src/exe/x64_dbg_exe.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -25,7 +25,9 @@
   <ItemGroup>
     <ClInclude Include="crashdump.h" />
     <ClInclude Include="icon.h" />
+    <ClInclude Include="LoadResourceString.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="resource1.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="icon32.rc">
@@ -37,6 +39,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ResourceCompile>
     <ResourceCompile Include="resource.rc" />
+    <ResourceCompile Include="Strings.rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\bug.ico" />

--- a/src/exe/x64_dbg_exe.vcxproj.filters
+++ b/src/exe/x64_dbg_exe.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -32,6 +32,12 @@
     <ClInclude Include="icon.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource1.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LoadResourceString.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="resource.rc">
@@ -41,6 +47,9 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
     <ResourceCompile Include="icon64.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="Strings.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -234,9 +234,9 @@ void CPUDisassembly::setupRightClickContextMenu()
     });
 
     QAction* toggleBreakpointAction = makeShortcutAction(tr("Toggle"), SLOT(toggleInt3BPActionSlot()), "ActionToggleBreakpoint");
-    QAction* editSoftwareBreakpointAction = makeAction(tr("Edit"), SLOT(editSoftBpActionSlot()));
-    QAction* setHwBreakpointAction = makeAction(tr("Set Hardware on Execution"), SLOT(toggleHwBpActionSlot()));
-    QAction* removeHwBreakpointAction = makeAction(tr("Remove Hardware"), SLOT(toggleHwBpActionSlot()));
+    QAction* editSoftwareBreakpointAction = makeShortcutAction(tr("Edit"), SLOT(editSoftBpActionSlot()), "ActionEditBreakpoint");
+    QAction* setHwBreakpointAction = makeShortcutAction(tr("Set Hardware on Execution"), SLOT(toggleHwBpActionSlot()), "ActionSetHwBpE");
+    QAction* removeHwBreakpointAction = makeShortcutAction(tr("Remove Hardware"), SLOT(toggleHwBpActionSlot()), "ActionRemoveHwBp");
 
     QMenu* replaceSlotMenu = makeMenu(tr("Set Hardware on Execution"));
     QAction* replaceSlot0Action = makeMenuAction(replaceSlotMenu, tr("Replace Slot 0 (Free)"), SLOT(setHwBpOnSlot0ActionSlot()));
@@ -281,16 +281,16 @@ void CPUDisassembly::setupRightClickContextMenu()
                     switch(bpList.bp[i].slot)
                     {
                     case 0:
-                        replaceSlot0Action->setText("Replace Slot 0 (0x" + QString("%1").arg(bpList.bp[i].addr, 8, 16, QChar('0')).toUpper() + ")");
+                        replaceSlot0Action->setText(tr("Replace Slot %1 (0x%2)").arg(1).arg(ToPtrString(bpList.bp[i].addr)));
                         break;
                     case 1:
-                        replaceSlot1Action->setText("Replace Slot 1 (0x" + QString("%1").arg(bpList.bp[i].addr, 8, 16, QChar('0')).toUpper() + ")");
+                        replaceSlot1Action->setText(tr("Replace Slot %1 (0x%2)").arg(2).arg(ToPtrString(bpList.bp[i].addr)));
                         break;
                     case 2:
-                        replaceSlot2Action->setText("Replace Slot 2 (0x" + QString("%1").arg(bpList.bp[i].addr, 8, 16, QChar('0')).toUpper() + ")");
+                        replaceSlot2Action->setText(tr("Replace Slot %1 (0x%2)").arg(3).arg(ToPtrString(bpList.bp[i].addr)));
                         break;
                     case 3:
-                        replaceSlot3Action->setText("Replace Slot 3 (0x" + QString("%1").arg(bpList.bp[i].addr, 8, 16, QChar('0')).toUpper() + ")");
+                        replaceSlot3Action->setText(tr("Replace Slot %1 (0x%2)").arg(4).arg(ToPtrString(bpList.bp[i].addr)));
                         break;
                     default:
                         break;
@@ -412,21 +412,26 @@ void CPUDisassembly::setupRightClickContextMenu()
 
 
     analysisMenu->addAction(makeShortcutAction(tr("Analyze single function"), SLOT(analyzeSingleFunctionSlot()), "ActionAnalyzeSingleFunction"));
-    analysisMenu->addAction(makeAction(tr("Remove analysis from module"), SLOT(removeAnalysisModuleSlot())));
+    analysisMenu->addAction(makeShortcutAction(tr("Remove analysis from module"), SLOT(removeAnalysisModuleSlot()), "ActionRemoveAnalysisFromModule"));
 
     analysisMenu->addSeparator();
 
-    analysisMenu->addAction(makeAction(tr("Remove analysis from selection"), SLOT(removeAnalysisSelectionSlot())));
+    analysisMenu->addAction(makeShortcutAction(tr("Remove analysis from selection"), SLOT(removeAnalysisSelectionSlot()), "ActionRemoveAnalysisFromSelection"));
 
-    QMenu* encodeTypeMenu = makeMenu("Treat selection head as");
+    QMenu* encodeTypeMenu = makeMenu(tr("Treat selection head as"));
 
-    QMenu* encodeTypeRangeMenu = makeMenu("Treat selection as");
+    QMenu* encodeTypeRangeMenu = makeMenu(tr("Treat selection as"));
 
-    std::string strTable[] = {"Command", "Byte", "Word", "Dword", "Fword", "Qword", "Tbyte", "Oword", "",
+    const char* strTable[] = {"Command", "Byte", "Word", "Dword", "Fword", "Qword", "Tbyte", "Oword", "",
                               "Float", "Double", "Long Double", "",
                               "ASCII", "UNICODE", "",
                               "MMWord", "XMMWord", "YMMWord"
                              };
+
+    const char* shortcutTable[] = {nullptr, "ActionTreatSelectionAsByte", nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                                   nullptr, nullptr, nullptr, nullptr,
+                                   "ActionTreatSelectionAsASCII", "ActionTreatSelectionAsUNICODE", nullptr,
+                                   nullptr, nullptr, nullptr};
 
     ENCODETYPE enctypeTable[] = {enc_code, enc_byte, enc_word, enc_dword, enc_fword, enc_qword, enc_tbyte, enc_oword, enc_middle,
                                  enc_real4, enc_real8, enc_real10 , enc_middle,
@@ -445,10 +450,14 @@ void CPUDisassembly::setupRightClickContextMenu()
         }
         else
         {
-            QAction* action = makeAction(tr(strTable[i].c_str()), SLOT(setEncodeTypeRangeSlot()));
+            QAction* action;
+            if(shortcutTable[i])
+                action = makeShortcutAction(tr(strTable[i]), SLOT(setEncodeTypeRangeSlot()), shortcutTable[i]);
+            else
+                action = makeAction(tr(strTable[i]), SLOT(setEncodeTypeRangeSlot()));
             action->setData(enctypeTable[i]);
             encodeTypeRangeMenu->addAction(action);
-            action = makeAction(tr(strTable[i].c_str()), SLOT(setEncodeTypeSlot()));
+            action = makeAction(tr(strTable[i]), SLOT(setEncodeTypeSlot()));
             action->setData(enctypeTable[i]);
             encodeTypeMenu->addAction(action);
         }

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -127,10 +127,14 @@ void CPUDump::setupContextMenu()
 
     //Sync with expression
     mSyncWithExpression = new QAction(QIcon(":/icons/images/sync.png"), tr("&Sync with expression"), this);
+    mSyncWithExpression->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(mSyncWithExpression);
     connect(mSyncWithExpression, SIGNAL(triggered(bool)), this, SLOT(syncWithExpressionSlot()));
 
     //Entropy
     mEntropy = new QAction(QIcon(":/icons/images/entropy.png"), tr("Entrop&y..."), this);
+    mEntropy->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(mEntropy);
     connect(mEntropy, SIGNAL(triggered()), this, SLOT(entropySlot()));
 
     //Label
@@ -423,6 +427,8 @@ void CPUDump::refreshShortcutsSlot()
     mGotoEnd->setShortcut(ConfigShortcut("ActionGotoEnd"));
     mGotoFileOffset->setShortcut(ConfigShortcut("ActionGotoFileOffset"));
     mYaraAction->setShortcut(ConfigShortcut("ActionYara"));
+    mSyncWithExpression->setShortcut(ConfigShortcut("ActionSyncWithExpression"));
+    mEntropy->setShortcut(ConfigShortcut("ActionEntropy"));
 }
 
 void CPUDump::getColumnRichText(int col, dsint rva, RichTextPainter::List & richText)

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -53,7 +53,7 @@ void LogView::setupContextMenu()
 void LogView::refreshShortcutsSlot()
 {
     actionCopy->setShortcut(ConfigShortcut("ActionCopy"));
-    // More shortcuts?
+    actionToggleLogging->setShortcut(ConfigShortcut("ActionToggleLogging"));
 }
 
 void LogView::contextMenuEvent(QContextMenuEvent* event)
@@ -111,7 +111,7 @@ void LogView::saveSlot()
     {
         savedLog.write(this->document()->toPlainText().toUtf8().constData());
         savedLog.close();
-        addMsgToLogSlot(tr("Log have been saved to %1\n").arg(fileName));
+        addMsgToLogSlot(tr("Log have been saved as %1\n").arg(fileName));
     }
 }
 

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -460,6 +460,10 @@ void MainWindow::refreshShortcuts()
     setGlobalShortcut(ui->actionRtu, ConfigShortcut("DebugRtu"));
     setGlobalShortcut(ui->actionCommand, ConfigShortcut("DebugCommand"));
     setGlobalShortcut(ui->actionSkipNextInstruction, ConfigShortcut("DebugSkipNextInstruction"));
+    setGlobalShortcut(ui->actionTicnd, ConfigShortcut("DebugTraceIntoConditional"));
+    setGlobalShortcut(ui->actionTocnd, ConfigShortcut("DebugTraceOverConditional"));
+    setGlobalShortcut(ui->actionTRBit, ConfigShortcut("DebugEnableTraceRecordBit"));
+    setGlobalShortcut(ui->actionTRNone, ConfigShortcut("DebugTraceRecordNone"));
 
     setGlobalShortcut(ui->actionScylla, ConfigShortcut("PluginsScylla"));
 

--- a/src/gui/Src/Gui/MemoryMapView.cpp
+++ b/src/gui/Src/Gui/MemoryMapView.cpp
@@ -109,11 +109,13 @@ void MemoryMapView::setupContextMenu()
 
     //Allocate memory
     mMemoryAllocate = new QAction(tr("&Allocate memory"), this);
+    mMemoryAllocate->setShortcutContext(Qt::WidgetShortcut);
     connect(mMemoryAllocate, SIGNAL(triggered()), this, SLOT(memoryAllocateSlot()));
     this->addAction(mMemoryAllocate);
 
     //Free memory
     mMemoryFree = new QAction(tr("&Free memory"), this);
+    mMemoryFree->setShortcutContext(Qt::WidgetShortcut);
     connect(mMemoryFree, SIGNAL(triggered()), this, SLOT(memoryFreeSlot()));
     this->addAction(mMemoryFree);
 
@@ -123,6 +125,8 @@ void MemoryMapView::setupContextMenu()
 
     //Entropy
     mEntropy = new QAction(QIcon(":/icons/images/entropy.png"), tr("Entropy..."), this);
+    mEntropy->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(mEntropy);
     connect(mEntropy, SIGNAL(triggered()), this, SLOT(entropy()));
 
     //Find
@@ -145,6 +149,9 @@ void MemoryMapView::refreshShortcutsSlot()
     mMemoryRemove->setShortcut(ConfigShortcut("ActionToggleBreakpoint"));
     mMemoryExecuteSingleshootToggle->setShortcut(ConfigShortcut("ActionToggleBreakpoint"));
     mFindPattern->setShortcut(ConfigShortcut("ActionFindPattern"));
+    mEntropy->setShortcut(ConfigShortcut("ActionEntropy"));
+    mMemoryFree->setShortcut(ConfigShortcut("ActionFreeMemory"));
+    mMemoryAllocate->setShortcut(ConfigShortcut("ActionAllocateMemory"));
 }
 
 void MemoryMapView::contextMenuSlot(const QPoint & pos)
@@ -471,7 +478,7 @@ void MemoryMapView::entropy()
     DbgMemRead(addr, data, size);
 
     EntropyDialog entropyDialog(this);
-    entropyDialog.setWindowTitle(QString().sprintf("Entropy (Address: %p, Size: %p)", addr, size));
+    entropyDialog.setWindowTitle(tr("Entropy (Address: %1, Size: %2)").arg(ToPtrString(addr).arg(ToPtrString(size))));
     entropyDialog.show();
     entropyDialog.GraphMemory(data, size);
     entropyDialog.exec();

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -441,6 +441,7 @@ RegistersView::RegistersView(QWidget* parent) : QScrollArea(parent), mVScrollOff
     wCM_CopySymbolToClipboard->setShortcutContext(Qt::WidgetShortcut);
     this->addAction(wCM_CopySymbolToClipboard);
     wCM_CopyAll = new QAction(tr("Copy all registers"), this);
+    wCM_CopyAll->setShortcutContext(Qt::WidgetShortcut);
     this->addAction(wCM_CopyAll);
     wCM_FollowInDisassembly = new QAction(tr("Follow in Disassembler"), this);
     wCM_FollowInDump = new QAction(tr("Follow in Dump"), this);
@@ -1152,6 +1153,7 @@ void RegistersView::refreshShortcutsSlot()
     wCM_ToggleValue->setShortcut(ConfigShortcut("ActionToggleRegisterValue"));
     wCM_CopyToClipboard->setShortcut(ConfigShortcut("ActionCopy"));
     wCM_CopySymbolToClipboard->setShortcut(ConfigShortcut("ActionCopySymbol"));
+    wCM_CopyAll->setShortcut(ConfigShortcut("ActionCopyAllRegisters"));
 }
 
 RegistersView::~RegistersView()

--- a/src/gui/Src/Gui/ShortcutsDialog.cpp
+++ b/src/gui/Src/Gui/ShortcutsDialog.cpp
@@ -11,7 +11,7 @@ ShortcutsDialog::ShortcutsDialog(QWidget* parent) : QDialog(parent), ui(new Ui::
 
     // x64 has no model-view-controler pattern
     QStringList tblHeader;
-    tblHeader << "Instruction" << "Shortcut";
+    tblHeader << tr("Instruction") << tr("Shortcut");
 
     currentRow = 0;
 

--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -144,12 +144,24 @@ void SymbolView::setupContextMenu()
     connect(mEntropyAction, SIGNAL(triggered()), this, SLOT(moduleEntropy()));
 
     mModSetUserAction = new QAction(tr("Mark as &user module"), this);
+    mModSetUserAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    this->addAction(mModSetUserAction);
+    mModuleList->mList->addAction(mModSetUserAction);
+    mModuleList->mSearchList->addAction(mModSetUserAction);
     connect(mModSetUserAction, SIGNAL(triggered()), this, SLOT(moduleSetUser()));
 
     mModSetSystemAction = new QAction(tr("Mark as &system module"), this);
+    mModSetSystemAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    this->addAction(mModSetSystemAction);
+    mModuleList->mList->addAction(mModSetSystemAction);
+    mModuleList->mSearchList->addAction(mModSetSystemAction);
     connect(mModSetSystemAction, SIGNAL(triggered()), this, SLOT(moduleSetSystem()));
 
     mModSetPartyAction = new QAction(tr("Mark as &party..."), this);
+    mModSetPartyAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    this->addAction(mModSetPartyAction);
+    mModuleList->mList->addAction(mModSetPartyAction);
+    mModuleList->mSearchList->addAction(mModSetPartyAction);
     connect(mModSetPartyAction, SIGNAL(triggered()), this, SLOT(moduleSetParty()));
 
     //Shortcuts
@@ -161,6 +173,9 @@ void SymbolView::refreshShortcutsSlot()
 {
     mToggleBreakpoint->setShortcut(ConfigShortcut("ActionToggleBreakpoint"));
     mToggleBookmark->setShortcut(ConfigShortcut("ActionToggleBookmark"));
+    mModSetUserAction->setShortcut(ConfigShortcut("ActionMarkAsUser"));
+    mModSetSystemAction->setShortcut(ConfigShortcut("ActionMarkAsSystem"));
+    mModSetPartyAction->setShortcut(ConfigShortcut("ActionMarkAsParty"));
 }
 
 void SymbolView::updateStyle()

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -291,6 +291,10 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("DebugRtu", Shortcut(tr("Debug -> Run to user code"), "Alt+F9", true));
     defaultShortcuts.insert("DebugSkipNextInstruction", Shortcut(tr("Debug -> Skip next instruction"), "Ctrl+F8", true));
     defaultShortcuts.insert("DebugCommand", Shortcut(tr("Debug -> Command"), "Ctrl+Return", true));
+    defaultShortcuts.insert("DebugTraceIntoConditional", Shortcut(tr("Debug -> Trace Into Conditional"), ""));
+    defaultShortcuts.insert("DebugTraceOverConditional", Shortcut(tr("Debug -> Trace Over Conditional"), ""));
+    defaultShortcuts.insert("DebugEnableTraceRecordBit", Shortcut(tr("Debug -> Trace Record -> Bit"), ""));
+    defaultShortcuts.insert("DebugTraceRecordNone", Shortcut(tr("Debug -> Trace Record -> None"), ""));
 
     defaultShortcuts.insert("PluginsScylla", Shortcut(tr("Plugins -> Scylla"), "Ctrl+I", true));
 
@@ -344,6 +348,23 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ActionFind", Shortcut(tr("Actions -> Find"), "Ctrl+F"));
     defaultShortcuts.insert("ActionDecompileFunction", Shortcut(tr("Actions -> Decompile Function"), "F5"));
     defaultShortcuts.insert("ActionDecompileSelection", Shortcut(tr("Actions -> Decompile Selection"), "Shift+F5"));
+    defaultShortcuts.insert("ActionEditBreakpoint", Shortcut(tr("Actions -> Edit breakpoint"), ""));
+    defaultShortcuts.insert("ActionToggleLogging", Shortcut(tr("Actions -> Enable/Disable Logging"), ""));
+    defaultShortcuts.insert("ActionAllocateMemory", Shortcut(tr("Actions -> Allocate Memory"), ""));
+    defaultShortcuts.insert("ActionFreeMemory", Shortcut(tr("Actions -> Free Memory"), ""));
+    defaultShortcuts.insert("ActionSyncWithExpression", Shortcut(tr("Actions -> Sync With Expression"), ""));
+    defaultShortcuts.insert("ActionEntropy", Shortcut(tr("Actions -> Entropy"), ""));
+    defaultShortcuts.insert("ActionCopyAllRegisters", Shortcut(tr("Actions -> Copy All Registers"), ""));
+    defaultShortcuts.insert("ActionMarkAsUser", Shortcut(tr("Actions -> Mark As User Module"), ""));
+    defaultShortcuts.insert("ActionMarkAsSystem", Shortcut(tr("Actions -> Mark As System Module"), ""));
+    defaultShortcuts.insert("ActionMarkAsParty", Shortcut(tr("Actions -> Mark As Party"), ""));
+    defaultShortcuts.insert("ActionSetHwBpE", Shortcut(tr("Actions -> Set Hardware Breakpoint (Execute)"), ""));
+    defaultShortcuts.insert("ActionRemoveHwBp", Shortcut(tr("Actions -> Remove Hardware Breakpoint"), ""));
+    defaultShortcuts.insert("ActionRemoveAnalysisFromModule", Shortcut(tr("Actions -> Remove Analysis From Module"), ""));
+    defaultShortcuts.insert("ActionRemoveAnalysisFromSelection", Shortcut(tr("Actions -> Remove Analysis From Selection"), ""));
+    defaultShortcuts.insert("ActionTreatSelectionAsByte", Shortcut(tr("Actions -> Treat Selection As Bytes"), ""));
+    defaultShortcuts.insert("ActionTreatSelectionAsASCII", Shortcut(tr("Actions -> Treat Selection As ASCII"), ""));
+    defaultShortcuts.insert("ActionTreatSelectionAsUNICODE", Shortcut(tr("Actions -> Treat Selection As UNICODE"), ""));
 
     defaultShortcuts.insert("ActionIncreaseRegister", Shortcut(tr("Actions -> Increase Register"), "+"));
     defaultShortcuts.insert("ActionDecreaseRegister", Shortcut(tr("Actions -> Decrease Register"), "-"));

--- a/src/launcher/x64_dbg_launcher.vcxproj
+++ b/src/launcher/x64_dbg_launcher.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ResourceCompile Include="..\exe\resource.rc" />
     <ResourceCompile Include="..\exe\icon.rc" />
+    <ResourceCompile Include="..\exe\Strings.rc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\exe\resource.h" />

--- a/src/launcher/x64_dbg_launcher.vcxproj.filters
+++ b/src/launcher/x64_dbg_launcher.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -24,6 +24,9 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
     <ResourceCompile Include="..\exe\icon.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="..\exe\Strings.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>


### PR DESCRIPTION
The translated strings are stored in "Strings.rc" and loaded via `LoadString`. `LoadString` is the only viable way to get translated strings before the GUI is loaded.
The shortcuts added are :

- ActionEditBreakpoint
- ActionToggleLogging
- ActionAllocateMemory
- ActionFreeMemory
- ActionSyncWithExpression
- ActionEntropy
- ActionCopyAllRegisters
- ActionMarkAsUser
- ActionMarkAsSystem
- ActionMarkAsParty
- AnalysisRemoveAnalysisFromModule
- AnalysisRemoveAnalysisFromSelection
- AnalysisTreatSelectionAsByte
- AnalysisTreatSelectionAsASCII
- AnalysisTreatSelectionAsUNICODE
- ActionSetHwBpE
- ActionRemoveHwBp
- DebugTraceIntoConditional
- DebugTraceOverConditional
- DebugEnableTraceRecordBit
- DebugTraceRecordNone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/793)
<!-- Reviewable:end -->
