### PR TITLE
unicode character display

### DIFF
--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -729,8 +729,8 @@ QString HexDump::wordToString(uint16 word, WordViewMode_e mode)
 
     case UnicodeWord:
     {
-        QChar wChar = QChar::fromLatin1((char)word & 0xFF);
-        if(wChar.isPrint() == true && (word >> 8) == 0)
+        QChar wChar(word);
+        if(wChar.isPrint() == true)
             wStr = QString(wChar);
         else
             wStr = ".";


### PR DESCRIPTION
![x64dbg-ucs](https://cloud.githubusercontent.com/assets/15761310/16341038/a5c4be04-3a1a-11e6-81be-ffbf03095d50.png)

We should add "wide character support" in RichTextPainter. In such mode the rich text painter paints each character with a fixed but wide enough width, so that almost every unicode characters can fit within.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/801)
<!-- Reviewable:end -->
