### PR TITLE
Add simple message box util function

### DIFF
--- a/src/gui/Src/BasicView/ReferenceView.cpp
+++ b/src/gui/Src/BasicView/ReferenceView.cpp
@@ -4,6 +4,7 @@
 #include "ReferenceView.h"
 #include "Configuration.h"
 #include "Bridge.h"
+#include "MiscUtil.h"
 
 ReferenceView::ReferenceView() : SearchListView()
 {
@@ -364,13 +365,7 @@ void ReferenceView::toggleBookmark()
     else
         result = DbgSetBookmarkAt(wVA, true);
     if(!result)
-    {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("DbgSetBookmarkAt failed!"));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
-    }
+        SimpleErrorBox(this, tr("Error!"), tr("DbgSetBookmarkAt failed!"));
     GuiUpdateAllViews();
 }
 

--- a/src/gui/Src/Gui/AppearanceDialog.cpp
+++ b/src/gui/Src/Gui/AppearanceDialog.cpp
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include "Configuration.h"
 #include "StringUtil.h"
+#include "MiscUtil.h"
 
 AppearanceDialog::AppearanceDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AppearanceDialog)
 {
@@ -326,7 +327,7 @@ void AppearanceDialog::on_buttonSave_clicked()
     Config()->writeFonts();
     GuiUpdateAllViews();
     BridgeSettingFlush();
-    GuiAddStatusBarMessage("Settings saved!\n");
+    GuiAddStatusBarMessage(tr("Settings saved!\n").toUtf8().constData());
 }
 
 void AppearanceDialog::defaultValueSlot()
@@ -550,20 +551,14 @@ void AppearanceDialog::colorInfoListInit()
             notFound += id + "\n";
     }
     if(notFound.length())
-    {
-        QMessageBox msg(QMessageBox::Warning, "NOT FOUND IN CONFIG!", notFound);
-        msg.setWindowIcon(QIcon(":/icons/images/compile-warning.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
-    }
+        SimpleWarningBox(this, "NOT FOUND IN CONFIG!", notFound);
 
     //setup context menu
     ui->listColorNames->setContextMenuPolicy(Qt::ActionsContextMenu);
-    defaultValueAction = new QAction("&Default Value", this);
+    defaultValueAction = new QAction(tr("&Default Value"), this);
     defaultValueAction->setEnabled(false);
     connect(defaultValueAction, SIGNAL(triggered()), this, SLOT(defaultValueSlot()));
-    currentSettingAction = new QAction("&Current Setting", this);
+    currentSettingAction = new QAction(tr("&Current Setting"), this);
     currentSettingAction->setEnabled(false);
     connect(currentSettingAction, SIGNAL(triggered()), this, SLOT(currentSettingSlot()));
     ui->listColorNames->addAction(defaultValueAction);

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -13,6 +13,7 @@
 #include "StringUtil.h"
 #include "Breakpoints.h"
 #include "XrefBrowseDialog.h"
+#include "MiscUtil.h"
 
 CPUDisassembly::CPUDisassembly(CPUWidget* parent) : Disassembly(parent)
 {
@@ -713,13 +714,7 @@ void CPUDisassembly::setLabelSlot()
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
     if(!DbgSetLabelAt(wVA, mLineEdit.editText.toUtf8().constData()))
-    {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("DbgSetLabelAt failed!"));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
-    }
+        SimpleErrorBox(this, tr("Error!"), tr("DbgSetLabelAt failed!"));
 
     GuiUpdateAllViews();
 }
@@ -748,13 +743,7 @@ void CPUDisassembly::setLabelAddressSlot()
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
     if(!DbgSetLabelAt(addr, mLineEdit.editText.toUtf8().constData()))
-    {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("DbgSetLabelAt failed!"));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
-    }
+        SimpleErrorBox(this, tr("Error!"), tr("DbgSetLabelAt failed!"));
 
     GuiUpdateAllViews();
 }
@@ -778,13 +767,7 @@ void CPUDisassembly::setCommentSlot()
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
     if(!DbgSetCommentAt(wVA, mLineEdit.editText.replace('\r', "").replace('\n', "").toUtf8().constData()))
-    {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("DbgSetCommentAt failed!"));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
-    }
+        SimpleErrorBox(this, tr("Error!"), tr("DbgSetCommentAt failed!"));
 
     GuiUpdateAllViews();
 }
@@ -1395,7 +1378,7 @@ void CPUDisassembly::copyRvaSlot()
         Bridge::CopyToClipboard(addrText);
     }
     else
-        QMessageBox::warning(this, "Error!", "Selection not in a module...");
+        SimpleWarningBox(this, tr("Error!"), tr("Selection not in a module..."));
 }
 
 void CPUDisassembly::copyDisassemblySlot()
@@ -1442,11 +1425,7 @@ void CPUDisassembly::findCommandSlot()
 
     if(!DbgFunctions()->Assemble(va + mMemPage->getSize() / 2, dest, &asmsize, mLineEdit.editText.toUtf8().constData(), error))
     {
-        QMessageBox msg(QMessageBox::Critical, "Error!", "Failed to assemble instruction \"" + mLineEdit.editText + "\" (" + error + ")");
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
+        SimpleErrorBox(this, tr("Error!"), tr("Failed to assemble instruction \"") + mLineEdit.editText + "\" (" + error + ")");
         return;
     }
 

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -13,6 +13,7 @@
 #include "WordEditDialog.h"
 #include "CodepageSelectionDialog.h"
 #include <QToolTip>
+#include "MiscUtil.h"
 
 CPUDump::CPUDump(CPUDisassembly* disas, CPUMultiDump* multiDump, QWidget* parent) : HexDump(parent)
 {
@@ -704,13 +705,7 @@ void CPUDump::setLabelSlot()
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
     if(!DbgSetLabelAt(wVA, mLineEdit.editText.toUtf8().constData()))
-    {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("DbgSetLabelAt failed!"));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setParent(this, Qt::Dialog);
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
-    }
+        SimpleErrorBox(this, tr("Error!"), tr("DbgSetLabelAt failed!"));
     GuiUpdateAllViews();
 }
 
@@ -750,7 +745,7 @@ void CPUDump::gotoFileOffsetSlot()
     char modname[MAX_MODULE_SIZE] = "";
     if(!DbgFunctions()->ModNameFromAddr(rvaToVa(getInitialSelection()), modname, true))
     {
-        QMessageBox::critical(this, tr("Error!"), tr("Not inside a module..."));
+        SimpleErrorBox(this, tr("Error!"), tr("Not inside a module..."));
         return;
     }
     GotoDialog mGotoDialog(this);
@@ -1281,11 +1276,7 @@ void CPUDump::addressSlot()
 
 void CPUDump::disassemblySlot()
 {
-    QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Not yet supported!"));
-    msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-    msg.setParent(this, Qt::Dialog);
-    msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-    msg.exec();
+    SimpleErrorBox(this, tr("Error!"), tr("Not yet supported!"));
 }
 
 void CPUDump::selectionGet(SELECTIONDATA* selection)

--- a/src/gui/Src/Gui/MemoryMapView.cpp
+++ b/src/gui/Src/Gui/MemoryMapView.cpp
@@ -8,7 +8,7 @@
 #include "YaraRuleSelectionDialog.h"
 #include "EntropyDialog.h"
 #include "HexEditDialog.h"
-#include "LineEditDialog.h"
+#include "MiscUtil.h"
 #include "GotoDialog.h"
 #include "WordEditDialog.h"
 
@@ -496,16 +496,12 @@ void MemoryMapView::memoryAllocateSlot()
         duint memsize = mLineEdit.getVal();
         if(memsize == 0) // 1GB
         {
-            QMessageBox msg(QMessageBox::Warning, tr("Warning"), tr("You're trying to allocate a zero-sized buffer just now."));
-            msg.setWindowIcon(QIcon(":/icons/images/compile-warning.png"));
-            msg.exec();
+            SimpleWarningBox(this, tr("Warning"), tr("You're trying to allocate a zero-sized buffer just now."));
             return;
         }
         if(memsize > 1024 * 1024 * 1024)
         {
-            QMessageBox msg(QMessageBox::Critical, tr("Error"), tr("The size of buffer you're trying to allocate exceeds 1GB. Please check your expression to ensure nothing is wrong."));
-            msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-            msg.exec();
+            SimpleErrorBox(this, tr("Error"), tr("The size of buffer you're trying to allocate exceeds 1GB. Please check your expression to ensure nothing is wrong."));
             return;
         }
         DbgCmdExecDirect(QString("alloc %1").arg(ToPtrString(memsize)).toUtf8().constData());
@@ -517,9 +513,7 @@ void MemoryMapView::memoryAllocateSlot()
         }
         else
         {
-            QMessageBox msg(QMessageBox::Critical, tr("Error"), tr("Memory allocation failed!"));
-            msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-            msg.exec();
+            SimpleErrorBox(this, tr("Error"), tr("Memory allocation failed!"));
             return;
         }
     }

--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -4,6 +4,7 @@
 #include <QIcon>
 #include <QFileDialog>
 #include <QTextStream>
+#include "MiscUtil.h"
 
 PatchDialog::PatchDialog(QWidget* parent) :
     QDialog(parent),
@@ -453,10 +454,7 @@ void PatchDialog::on_btnPatchFile_clicked()
     char szModName[MAX_PATH] = "";
     if(!DbgFunctions()->ModPathFromAddr(DbgFunctions()->ModBaseFromName(mod.toUtf8().constData()), szModName, MAX_PATH))
     {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Failed to get module filename..."));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
+        SimpleErrorBox(this, tr("Error!"), tr("Failed to get module filename..."));
         return;
     }
 
@@ -482,10 +480,7 @@ void PatchDialog::on_btnPatchFile_clicked()
     delete [] dbgPatchList;
     if(patched == -1)
     {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Failed to save patched file (%1)").arg(error));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
+        SimpleErrorBox(this, tr("Error!"), tr("Failed to save patched file (%1)").arg(error));
         return;
     }
     QMessageBox msg(QMessageBox::Information, tr("Information"), tr("%1/%2 patch(es) applied!").arg(patched).arg(patchList.size()));
@@ -510,10 +505,7 @@ void PatchDialog::on_btnImport_clicked()
     QStringList lines = patch.split("\n", QString::SkipEmptyParts);
     if(!lines.size())
     {
-        QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("The patch file is empty..."));
-        msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-        msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-        msg.exec();
+        SimpleErrorBox(this, tr("Error!"), tr("The patch file is empty..."));
         return;
     }
 
@@ -544,10 +536,7 @@ void PatchDialog::on_btnImport_clicked()
         curLine = curLine.replace(" ", "");
         if(sscanf_s(curLine.toUtf8().constData(), "%llX:%X->%X", &rva, &oldbyte, &newbyte) != 3)
         {
-            QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Patch file format is incorrect..."));
-            msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
-            msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
-            msg.exec();
+            SimpleErrorBox(this, tr("Error!"), tr("Patch file format is incorrect..."));
             return;
         }
         oldbyte &= 0xFF;

--- a/src/gui/Src/Utils/MiscUtil.cpp
+++ b/src/gui/Src/Utils/MiscUtil.cpp
@@ -1,5 +1,8 @@
 #include "MiscUtil.h"
 #include <windows.h>
+#include "LineEditDialog.h"
+#include <QMessageBox>
+#include <QIcon>
 
 void SetApplicationIcon(WId winId)
 {
@@ -18,4 +21,35 @@ QByteArray & ByteReverse(QByteArray & array)
         array[length - i - 1] = temp;
     }
     return array;
+}
+
+QString SimpleInputBox(QWidget* parent, const QString & title, QString defaultValue)
+{
+    LineEditDialog mEdit(parent);
+    mEdit.setWindowIcon(parent->windowIcon());
+    mEdit.setText(defaultValue);
+    mEdit.setWindowTitle(title);
+    mEdit.setCheckBox(false);
+    if(mEdit.exec() == QDialog::Accepted)
+        return mEdit.editText;
+    else
+        return "";
+}
+
+void SimpleErrorBox(QWidget* parent, const QString & title, const QString & text)
+{
+    QMessageBox msg(QMessageBox::Critical, title, text, QMessageBox::NoButton, parent);
+    msg.setWindowIcon(QIcon(":/icons/images/compile-error.png"));
+    msg.setParent(parent, Qt::Dialog);
+    msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
+    msg.exec();
+}
+
+void SimpleWarningBox(QWidget* parent, const QString & title, const QString & text)
+{
+    QMessageBox msg(QMessageBox::Warning, title, text, QMessageBox::NoButton, parent);
+    msg.setWindowIcon(QIcon(":/icons/images/compile-warning.png"));
+    msg.setParent(parent, Qt::Dialog);
+    msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
+    msg.exec();
 }

--- a/src/gui/Src/Utils/MiscUtil.h
+++ b/src/gui/Src/Utils/MiscUtil.h
@@ -5,5 +5,8 @@
 
 void SetApplicationIcon(WId winId);
 QByteArray & ByteReverse(QByteArray & array);
+QString SimpleInputBox(QWidget* parent, const QString & title, QString defaultValue = "");
+void SimpleErrorBox(QWidget* parent, const QString & title, const QString & text);
+void SimpleWarningBox(QWidget* parent, const QString & title, const QString & text);
 
 #endif // MISCUTIL_H


### PR DESCRIPTION
Reduce code size. Make programming easier. Too lazy to convert all `QMessageBox` into `SimpleErrorBox`, however I'm using it in the unfinished watch view code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/818)
<!-- Reviewable:end -->
