### PR TITLE
Added ability to roughly measure UI latency; code to try and maintain that latency at <50ms

### DIFF
--- a/src/bridge/_global.cpp
+++ b/src/bridge/_global.cpp
@@ -1,6 +1,7 @@
 #include "_global.h"
 
 GUIGUIINIT _gui_guiinit;
+GUIMESSAGELATENCY _gui_messagelatency;
 GUISENDMESSAGE _gui_sendmessage;
 GUISENDMESSAGEASYNC _gui_sendmessageasync;
 

--- a/src/bridge/_global.h
+++ b/src/bridge/_global.h
@@ -6,11 +6,13 @@
 
 //GUI typedefs
 typedef int (*GUIGUIINIT)(int, char**);
+typedef uint32(*GUIMESSAGELATENCY)();
 typedef void* (*GUISENDMESSAGE)(GUIMSG type, void* param1, void* param2);
 typedef void (*GUISENDMESSAGEASYNC)(GUIMSG type, void* param1, void* param2);
 
 //GUI functions
 extern GUIGUIINIT _gui_guiinit;
+extern  GUIMESSAGELATENCY _gui_messagelatency;
 extern GUISENDMESSAGE _gui_sendmessage;
 extern GUISENDMESSAGEASYNC _gui_sendmessageasync;
 

--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -64,6 +64,7 @@ BRIDGE_IMPEXP const wchar_t* BridgeInit()
     //GUI Load
     LOADLIBRARY(gui_lib);
     LOADEXPORT(_gui_guiinit);
+    LOADEXPORT(_gui_messagelatency);
     LOADEXPORT(_gui_sendmessage);
 
     //DBG Load
@@ -994,6 +995,13 @@ BRIDGE_IMPEXP void GuiSetDebugState(DBGSTATE state)
 {
     _gui_sendmessage(GUI_SET_DEBUG_STATE, (void*)state, 0);
 }
+
+BRIDGE_IMPEXP DWORD GuiGetLatency()
+{
+    return _gui_messagelatency();
+}
+
+
 
 BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg)
 {

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -25,6 +25,10 @@ typedef unsigned long duint;
 typedef signed long dsint;
 #endif //_WIN64
 
+typedef int int32;
+typedef unsigned int uint32;
+
+
 #ifndef BRIDGE_IMPEXP
 #ifdef BUILD_BRIDGE
 #define BRIDGE_IMPEXP __declspec(dllexport)
@@ -974,6 +978,7 @@ typedef struct
 
 //GUI functions
 //code page is utf8
+BRIDGE_IMPEXP DWORD GuiGetLatency();
 BRIDGE_IMPEXP void GuiDisasmAt(duint addr, duint cip);
 BRIDGE_IMPEXP void GuiSetDebugState(DBGSTATE state);
 BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -28,6 +28,9 @@ typedef signed long dsint;
 typedef int int32;
 typedef unsigned int uint32;
 
+typedef long long int64;
+typedef unsigned long long uint64;
+
 #include "bridgegraph.h"
 
 #ifndef BRIDGE_IMPEXP

--- a/src/dbg/_dbgfunctions.h
+++ b/src/dbg/_dbgfunctions.h
@@ -140,7 +140,7 @@ typedef TRACERECORDTYPE(*GETTRACERECORDTYPE)(duint pageAddress);
 typedef bool(*ENUMHANDLES)(ListOf(HANDLEINFO) handles);
 typedef bool(*GETHANDLENAME)(duint handle, char* name, size_t nameSize, char* typeName, size_t typeNameSize);
 typedef bool(*ENUMTCPCONNECTIONS)(ListOf(TCPCONNECTIONINFO) connections);
-typedef duint(*GETDBGEVENTS)();
+typedef uint64(*GETDBGEVENTS)();
 typedef int(*MODGETPARTY)(duint base);
 typedef void(*MODSETPARTY)(duint base, int party);
 typedef bool(*WATCHISWATCHDOGTRIGGERED)(unsigned int id);

--- a/src/dbg/breakpoint.cpp
+++ b/src/dbg/breakpoint.cpp
@@ -230,6 +230,7 @@ bool BpSetBreakCondition(duint Address, BP_TYPE Type, const char* Condition)
         return false;
 
     strcpy_s(bpInfo->breakCondition, Condition);
+    DebugUpdateBreakpointsViewAsync();
     return true;
 }
 
@@ -245,6 +246,7 @@ bool BpSetLogText(duint Address, BP_TYPE Type, const char* Log)
         return false;
 
     strcpy_s(bpInfo->logText, Log);
+    DebugUpdateBreakpointsViewAsync();
     return true;
 }
 
@@ -290,6 +292,7 @@ bool BpSetCommandCondition(duint Address, BP_TYPE Type, const char* Condition)
         return false;
 
     strcpy_s(bpInfo->commandCondition, Condition);
+    DebugUpdateBreakpointsViewAsync();
     return true;
 }
 
@@ -305,6 +308,8 @@ bool BpSetFastResume(duint Address, BP_TYPE Type, bool fastResume)
         return false;
 
     bpInfo->fastResume = fastResume;
+    DebugUpdateBreakpointsViewAsync();
+
     return true;
 }
 

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -378,7 +378,6 @@ void DebugUpdateGuiSetState(duint disasm_addr, bool stack, DBGSTATE state = paus
     GuiSetDebugState(state);
     DebugUpdateGui(disasm_addr, stack);
 }
-
 void DebugUpdateGuiSetStateAsync(duint disasm_addr, bool stack, DBGSTATE state)
 {
     //correctly orders the GuiSetDebugState DebugUpdateGui to prevent drawing inconsistencies
@@ -391,6 +390,13 @@ void DebugUpdateGuiAsync(duint disasm_addr, bool stack)
     static TaskThread_<decltype(&DebugUpdateGui), duint, bool> DebugUpdateGuiTask(&DebugUpdateGui);
     DebugUpdateGuiTask.WakeUp(disasm_addr, stack);
 }
+
+void DebugUpdateBreakpointsViewAsync()
+{
+    static TaskThread_<decltype(&GuiUpdateBreakpointsView)> BreakpointsUpdateGuiTask(&GuiUpdateBreakpointsView);
+    BreakpointsUpdateGuiTask.WakeUp();
+}
+
 
 void DebugUpdateStack(duint dumpAddr, duint csp, bool forceDump)
 {

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -373,22 +373,50 @@ void DebugUpdateGui(duint disasm_addr, bool stack)
     GuiFocusView(GUI_DISASSEMBLY);
 }
 
-void DebugUpdateGuiSetState(duint disasm_addr, bool stack, DBGSTATE state = paused)
+void DebugUpdateGuiSetState(duint disasm_addr, bool stack, DBGSTATE state = paused, bool setDebugState = true)
 {
-    GuiSetDebugState(state);
-    DebugUpdateGui(disasm_addr, stack);
+    if(setDebugState)
+        GuiSetDebugState(state);
+    if(disasm_addr != 0)
+        DebugUpdateGui(disasm_addr, stack);
 }
-void DebugUpdateGuiSetStateAsync(duint disasm_addr, bool stack, DBGSTATE state)
+
+typedef TaskThread_<decltype(&DebugUpdateGuiSetState), duint, bool, DBGSTATE, bool> UpdateGuiSetStateTaskBase;
+struct UpdateGuiSetStateTask : public UpdateGuiSetStateTaskBase
+{
+    UpdateGuiSetStateTask(UpdateGuiSetStateTaskBase::Fn_t f) : UpdateGuiSetStateTaskBase(f) {}
+    virtual UpdateGuiSetStateTaskBase::Args_t CompressArguments(duint && addr, bool && stack, DBGSTATE && state, bool && updateDebugState) override
+    {
+        // Addr and stack args are not simply set; if addr is 0 it doesn't change the current addr and we
+        // stack is sticky until its reset after running.
+        return std::make_tuple(
+                   addr != 0 ? addr : std::get<0>(args),
+                   stack || std::get<1>(args),
+                   updateDebugState ? state : std::get<2>(args),
+                   updateDebugState || std::get<3>(args));
+    }
+    virtual void ResetArgs() override
+    {
+        // Necessary or addr and stack would always be non-zero, and always would run
+        args = std::make_tuple(0, false, paused, false);
+    }
+};
+
+void DebugUpdateGuiSetStateAsync(duint disasm_addr, bool stack, DBGSTATE state, bool updateDebugState)
 {
     //correctly orders the GuiSetDebugState DebugUpdateGui to prevent drawing inconsistencies
-    static TaskThread_<decltype(&DebugUpdateGuiSetState), duint, bool, DBGSTATE> DebugUpdateGuiSetStateTask(&DebugUpdateGuiSetState);
-    DebugUpdateGuiSetStateTask.WakeUp(disasm_addr, stack, state);
+    static UpdateGuiSetStateTask DebugUpdateGuiSetStateTask(&DebugUpdateGuiSetState);
+    DebugUpdateGuiSetStateTask.WakeUp(disasm_addr, stack, state, updateDebugState);
 }
 
 void DebugUpdateGuiAsync(duint disasm_addr, bool stack)
 {
-    static TaskThread_<decltype(&DebugUpdateGui), duint, bool> DebugUpdateGuiTask(&DebugUpdateGui);
-    DebugUpdateGuiTask.WakeUp(disasm_addr, stack);
+    DebugUpdateGuiSetStateAsync(disasm_addr, stack, paused, false);
+}
+
+void GuiSetDebugStateAsync(DBGSTATE state)
+{
+    DebugUpdateGuiSetStateAsync(0, false, state);
 }
 
 void DebugUpdateBreakpointsViewAsync()
@@ -396,7 +424,6 @@ void DebugUpdateBreakpointsViewAsync()
     static TaskThread_<decltype(&GuiUpdateBreakpointsView)> BreakpointsUpdateGuiTask(&GuiUpdateBreakpointsView);
     BreakpointsUpdateGuiTask.WakeUp();
 }
-
 
 void DebugUpdateStack(duint dumpAddr, duint csp, bool forceDump)
 {
@@ -533,12 +560,6 @@ static bool getConditionValue(const char* expression)
     if(valfromstring(expression, &value))
         return value != 0;
     return true;
-}
-
-void GuiSetDebugStateAsync(DBGSTATE state)
-{
-    static TaskThread_<decltype(&GuiSetDebugState), DBGSTATE> GuiSetDebugStateTask(&GuiSetDebugState);
-    GuiSetDebugStateTask.WakeUp(state);
 }
 
 void cbPauseBreakpoint()

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -69,7 +69,7 @@ bool dbgisdll();
 void dbgsetattachevent(HANDLE handle);
 void DebugUpdateGui(duint disasm_addr, bool stack);
 void DebugUpdateGuiAsync(duint disasm_addr, bool stack);
-void DebugUpdateGuiSetStateAsync(duint disasm_addr, bool stack, DBGSTATE state = paused);
+void DebugUpdateGuiSetStateAsync(duint disasm_addr, bool stack, DBGSTATE state = paused, bool updateDebugState = true);
 void DebugUpdateBreakpointsViewAsync();
 void DebugUpdateStack(duint dumpAddr, duint csp, bool forceDump = false);
 void GuiSetDebugStateAsync(DBGSTATE state);

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -88,7 +88,7 @@ bool dbgsetcmdline(const char* cmd_line, cmdline_error_t* cmd_line_error);
 bool dbggetcmdline(char** cmd_line, cmdline_error_t* cmd_line_error);
 void dbgstartscriptthread(CBPLUGINSCRIPT cbScript);
 duint dbggetdebuggedbase();
-duint dbggetdbgevents();
+uint64 dbggetdbgevents();
 bool dbgsettracecondition(String expression, duint maxCount);
 bool dbgtraceactive();
 

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -70,6 +70,7 @@ void dbgsetattachevent(HANDLE handle);
 void DebugUpdateGui(duint disasm_addr, bool stack);
 void DebugUpdateGuiAsync(duint disasm_addr, bool stack);
 void DebugUpdateGuiSetStateAsync(duint disasm_addr, bool stack, DBGSTATE state = paused);
+void DebugUpdateBreakpointsViewAsync();
 void DebugUpdateStack(duint dumpAddr, duint csp, bool forceDump = false);
 void GuiSetDebugStateAsync(DBGSTATE state);
 void dbgsetskipexceptions(bool skip);

--- a/src/dbg/taskthread.h
+++ b/src/dbg/taskthread.h
@@ -128,7 +128,11 @@ template <typename F, typename... Args> void TaskThread_<F, Args...>::Loop()
         if(active)
         {
             apply_from_tuple(fn, argLatch);
-            std::this_thread::sleep_for(std::chrono::milliseconds(minSleepTimeMs));
+            do
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(minSleepTimeMs));
+            }
+            while(GuiGetLatency() > 100);
             execs++;
         }
     }

--- a/src/dbg/taskthread.h
+++ b/src/dbg/taskthread.h
@@ -31,6 +31,8 @@ protected:
     // Reset called after we latch in a value
     virtual void ResetArgs() { }
 public:
+    typedef F Fn_t;
+    typedef std::tuple<Args...> Args_t;
     void WakeUp(Args...);
     TaskThread_(F, size_t minSleepTimeMs = TASK_THREAD_DEFAULT_SLEEP_TIME);
     ~TaskThread_();

--- a/src/dbg/thread.cpp
+++ b/src/dbg/thread.cpp
@@ -221,7 +221,6 @@ HANDLE ThreadGetHandle(DWORD ThreadId)
     if(threadList.find(ThreadId) != threadList.end())
         return threadList[ThreadId].Handle;
 
-    ASSERT_ALWAYS("Trying to get handle of a thread that doesn't exist!");
     return nullptr;
 }
 

--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -952,10 +952,10 @@ int AbstractTableView::getLineToPrintcount()
  *
  * @param[in]   width           Width of the column in pixel
  * @param[in]   isClickable     Boolean that tells whether the header is clickable or not
- *
+ * @param[in]   sortFn          The sort function to use for this column. Defaults to case insensitve text search
  * @return      Nothing.
  */
-void AbstractTableView::addColumnAt(int width, const QString & title, bool isClickable)
+void AbstractTableView::addColumnAt(int width, const QString & title, bool isClickable, SortBy::t sortFn)
 {
     HeaderButton_t wHeaderButton;
     Column_t wColumn;
@@ -969,6 +969,7 @@ void AbstractTableView::addColumnAt(int width, const QString & title, bool isCli
     wColumn.width = width;
     wColumn.hidden = false;
     wColumn.title = title;
+    wColumn.sortFunction = sortFn;
     wCurrentCount = mColumnList.length();
     mColumnList.append(wColumn);
     mColumnOrder.append(wCurrentCount);
@@ -1006,12 +1007,12 @@ QString AbstractTableView::getColTitle(int index)
 /************************************************************************************
                                 Getter & Setter
 ************************************************************************************/
-dsint AbstractTableView::getRowCount()
+dsint AbstractTableView::getRowCount() const
 {
     return mRowCount;
 }
 
-int AbstractTableView::getColumnCount()
+int AbstractTableView::getColumnCount() const
 {
     return mColumnList.size();
 }
@@ -1042,7 +1043,12 @@ bool AbstractTableView::getColumnHidden(int col)
     else
         return true;
 }
-
+AbstractTableView::SortBy::t AbstractTableView::getColumnSortBy(int col) const
+{
+    if(col < getColumnCount() && col >= 0)
+        return mColumnList[col].sortFunction;
+    return SortBy::AsText;
+}
 void AbstractTableView::setColumnHidden(int col, bool hidden)
 {
     if(col < getColumnCount() && col >= 0)
@@ -1166,7 +1172,6 @@ void AbstractTableView::updateViewport()
     this->viewport()->update();
 }
 
-
 /**
  * @brief       This method is called when data have to be reloaded (e.g. When table offset changes).
  *
@@ -1177,4 +1182,19 @@ void AbstractTableView::prepareData()
     int wViewableRowsCount = getViewableRowsCount();
     dsint wRemainingRowsCount = getRowCount() - mTableOffset;
     mNbrOfLineToPrint = (dsint)wRemainingRowsCount > (dsint)wViewableRowsCount ? (int)wViewableRowsCount : (int)wRemainingRowsCount;
+}
+
+bool AbstractTableView::SortBy::AsText(const QString & a, const QString & b)
+{
+    return QString::compare(a, b, Qt::CaseInsensitive) < 0;
+}
+
+bool AbstractTableView::SortBy::AsInt(const QString & a, const QString & b)
+{
+    return a.toLongLong() < b.toLongLong();
+}
+
+bool AbstractTableView::SortBy::AsHex(const QString & a, const QString & b)
+{
+    return a.toLongLong(0, 16) < b.toLongLong(0, 16);
 }

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -86,16 +86,24 @@ public:
     int getViewableRowsCount();
     virtual int getLineToPrintcount();
 
+    struct SortBy
+    {
+        typedef std::function<bool(const QString &, const QString &)> t;
+        static bool AsText(const QString & a, const QString & b);
+        static bool AsInt(const QString & a, const QString & b);
+        static bool AsHex(const QString & a, const QString & b);
+    };
+
     // New Columns/New Size
-    virtual void addColumnAt(int width, const QString & title, bool isClickable);
+    virtual void addColumnAt(int width, const QString & title, bool isClickable, SortBy::t sortFn = SortBy::AsText);
     virtual void setRowCount(dsint count);
     virtual void deleteAllColumns();
     void setColTitle(int index, const QString & title);
     QString getColTitle(int index);
 
     // Getter & Setter
-    dsint getRowCount();
-    int getColumnCount();
+    dsint getRowCount() const;
+    int getColumnCount() const;
     int getRowHeight();
     int getColumnWidth(int index);
     void setColumnWidth(int index, int width);
@@ -108,6 +116,7 @@ public:
     int getCharWidth();
     bool getColumnHidden(int col);
     void setColumnHidden(int col, bool hidden);
+    SortBy::t getColumnSortBy(int idx) const;
 
     // UI customization
     void loadColumnFromConfig(const QString & viewName);
@@ -167,6 +176,7 @@ private:
         bool hidden;
         HeaderButton_t header;
         QString title;
+        SortBy::t sortFunction;
     } Column_t;
 
     typedef struct _Header_t

--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -771,18 +771,23 @@ void Disassembly::keyPressEvent(QKeyEvent* event)
         if(event->modifiers() & Qt::ShiftModifier) //SHIFT pressed
             expand = true;
 
+        dsint initialStart = getSelectionStart();
+
         if(key == Qt::Key_Up)
             selectPrevious(expand);
         else
             selectNext(expand);
 
-        if(getSelectionStart() < botRVA)
+        bool expandedUp = initialStart != getSelectionStart();
+        dsint modifiedSelection = expandedUp ? getSelectionStart() : getSelectionEnd();
+
+        if(modifiedSelection < botRVA)
         {
-            setTableOffset(getSelectionStart());
+            setTableOffset(modifiedSelection);
         }
-        else if(getSelectionEnd() >= topRVA)
+        else if(modifiedSelection >= topRVA)
         {
-            setTableOffset(getInstructionRVA(getSelectionEnd(), -getNbrOfLineToPrint() + 2));
+            setTableOffset(getInstructionRVA(modifiedSelection, -getNbrOfLineToPrint() + 2));
         }
 
         updateViewport();

--- a/src/gui/Src/BasicView/HistoryLineEdit.cpp
+++ b/src/gui/Src/BasicView/HistoryLineEdit.cpp
@@ -1,17 +1,43 @@
 #include "HistoryLineEdit.h"
+#include "Bridge.h"
 
 HistoryLineEdit::HistoryLineEdit(QWidget* parent) : QLineEdit(parent)
 {
-    mCmdHistory.clear();
     mCmdIndex = -1;
     bSixPressed = false;
 }
 
+void HistoryLineEdit::loadSettings(QString sectionPrefix)
+{
+    char buffer[MAX_SETTING_SIZE];
+    for(int i = 1; BridgeSettingGet(sectionPrefix.toUtf8().constData(),
+                                    QString("Line%1").arg(i).toUtf8().constData(),
+                                    buffer) && buffer[0] && i < mCmdHistoryMaxSize; i++)
+    {
+        QString entry = QString::fromUtf8(buffer);
+        mCmdHistory.append(entry);
+    }
+}
+void HistoryLineEdit::saveSettings(QString sectionPrefix)
+{
+    int i = 1;
+    for(i = 1; i <= mCmdHistory.size(); i++)
+    {
+        BridgeSettingSet(sectionPrefix.toUtf8().constData(),
+                         QString("Line%1").arg(i).toUtf8().constData(),
+                         mCmdHistory.at(i - 1).toUtf8().constData());
+    }
+
+    // Sentinel in case we saved less than is in the store currently
+    BridgeSettingSet(sectionPrefix.toUtf8().constData(),
+                     QString("Line%1").arg(i).toUtf8().constData(),
+                     "");
+}
 void HistoryLineEdit::addLineToHistory(QString parLine)
 {
     mCmdHistory.prepend(parLine);
 
-    if(mCmdHistory.size() > 32)
+    if(mCmdHistory.size() > mCmdHistoryMaxSize)
         mCmdHistory.removeLast();
 
     mCmdIndex = -1;

--- a/src/gui/Src/BasicView/HistoryLineEdit.h
+++ b/src/gui/Src/BasicView/HistoryLineEdit.h
@@ -12,11 +12,13 @@ public:
     void keyPressEvent(QKeyEvent* event);
     void addLineToHistory(QString parLine);
     void setFocus();
-
+    void loadSettings(QString sectionPrefix);
+    void saveSettings(QString sectionPrefix);
 signals:
     void keyPressed(int parKey);
 
 private:
+    int mCmdHistoryMaxSize = 1000;
     QList<QString> mCmdHistory;
     int mCmdIndex;
     bool bSixPressed;

--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -232,9 +232,9 @@ bool StdTable::isSelected(int base, int offset)
 /************************************************************************************
                                 Data Management
 ************************************************************************************/
-void StdTable::addColumnAt(int width, QString title, bool isClickable, QString copyTitle)
+void StdTable::addColumnAt(int width, QString title, bool isClickable, QString copyTitle, SortBy::t sortFn)
 {
-    AbstractTableView::addColumnAt(width, title, isClickable);
+    AbstractTableView::addColumnAt(width, title, isClickable, sortFn);
 
     //append empty column to list of rows
     for(int i = 0; i < mData.size(); i++)
@@ -474,6 +474,6 @@ void StdTable::headerButtonPressedSlot(int col)
 void StdTable::reloadData()
 {
     if(mSort.first != -1) //re-sort if the user wants to sort
-        qSort(mData.begin(), mData.end(), ColumnCompare(mSort.first, mSort.second));
+        qSort(mData.begin(), mData.end(), ColumnCompare(mSort.first, mSort.second, getColumnSortBy(mSort.first)));
     AbstractTableView::reloadData();
 }

--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -172,11 +172,13 @@ void StdTable::expandSelectionUpTo(int to)
     {
         mSelection.fromIndex = to;
         mSelection.toIndex = mSelection.firstSelectedIndex;
+        emit selectionChangedSignal(to);
     }
     else if(to > mSelection.firstSelectedIndex)
     {
         mSelection.fromIndex = mSelection.firstSelectedIndex;
         mSelection.toIndex = to;
+        emit selectionChangedSignal(to);
     }
     else if(to == mSelection.firstSelectedIndex)
     {

--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -197,6 +197,17 @@ int StdTable::getInitialSelection()
     return mSelection.firstSelectedIndex;
 }
 
+QList<int> StdTable::getSelection()
+{
+    QList<int> selection;
+    selection.reserve(mSelection.toIndex - mSelection.fromIndex);
+    for(int i = mSelection.fromIndex; i <= mSelection.toIndex; i++)
+    {
+        selection.append(i);
+    }
+    return selection;
+}
+
 void StdTable::selectNext()
 {
     int wNext = getInitialSelection() + 1;

--- a/src/gui/Src/BasicView/StdTable.h
+++ b/src/gui/Src/BasicView/StdTable.h
@@ -24,6 +24,7 @@ public:
     void expandSelectionUpTo(int to);
     void setSingleSelection(int index);
     int getInitialSelection();
+    QList<int> getSelection();
     void selectNext();
     void selectPrevious();
     bool isSelected(int base, int offset);

--- a/src/gui/Src/BasicView/StdTable.h
+++ b/src/gui/Src/BasicView/StdTable.h
@@ -29,7 +29,7 @@ public:
     bool isSelected(int base, int offset);
 
     // Data Management
-    void addColumnAt(int width, QString title, bool isClickable, QString copyTitle = "");
+    void addColumnAt(int width, QString title, bool isClickable, QString copyTitle = "", SortBy::t sortFn = SortBy::AsText);
     void setRowCount(int count);
     void deleteAllColumns();
     void setCellContent(int r, int c, QString s);
@@ -60,15 +60,16 @@ private:
     class ColumnCompare
     {
     public:
-        ColumnCompare(int col, bool greater)
+        ColumnCompare(int col, bool greater, SortBy::t fn)
         {
             mCol = col;
             mGreater = greater;
+            mSortFn = fn;
         }
 
         inline bool operator()(const QList<QString> & a, const QList<QString> & b) const
         {
-            bool less = QString::compare(a.at(mCol), b.at(mCol), Qt::CaseInsensitive) < 0;
+            bool less = mSortFn(a.at(mCol), b.at(mCol));
             if(mGreater)
                 return !less;
             return less;
@@ -76,6 +77,7 @@ private:
     private:
         int mCol;
         int mGreater;
+        SortBy::t mSortFn;
     };
 
     enum GuiState_t {NoState, MultiRowsSelectionState};

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -3,7 +3,9 @@
 #include "QBeaEngine.h"
 #include "main.h"
 #include "Exports.h"
+#include <qmetaobject.h>
 
+#define MEASURE_LATENCY_EVENT ((QEvent::Type)(QEvent::User + 42))
 /************************************************************************************
                             Global Variables
 ************************************************************************************/
@@ -21,11 +23,49 @@ Bridge::Bridge(QObject* parent) : QObject(parent)
     bridgeResult = 0;
     hasBridgeResult = false;
     dbgStopped = false;
+
+    qRegisterMetaType <uint32_t>("uint32_t");
+    connect(this, SIGNAL(measureLatency(uint32_t)),
+            this, SLOT(measureLatencySlot(uint32_t)), Qt::ConnectionType::QueuedConnection);
+
+    latencyThread = std::thread([this]
+    {
+        while(mBridgeMutex)
+        {
+            std::unique_lock<std::mutex> guard(latencyLock);
+            latencyLastRequest = GetTickCount();
+
+            // We can't use a normal signal/slot for this since we can't se the priority on that.
+            // If we don't have the low priority set; this gets scheduled ahead of UI events so
+            // we won't get accurate measurements.
+            QCoreApplication::postEvent(this, new QEvent(MEASURE_LATENCY_EVENT), Qt::LowEventPriority);
+            std::this_thread::sleep_for(std::chrono::milliseconds(40));
+            latencyCV.wait(guard, [this] { return latencyLastRequest < latencyLastResponse; });
+        }
+    });
+}
+void Bridge::customEvent(QEvent* ev)
+{
+    if(ev->type() == MEASURE_LATENCY_EVENT)
+    {
+        std::unique_lock<std::mutex> guard(latencyLock);
+        latencyLastResponse = GetTickCount();
+
+        // TickCount can overflow; just reset lastrequest
+        if(latencyLastResponse < latencyLastRequest)
+            latencyLastRequest = 0;
+
+        latencyMs = latencyLastResponse - latencyLastRequest;
+        latencyCV.notify_one();
+    }
 }
 
 Bridge::~Bridge()
 {
     delete mBridgeMutex;
+    mBridgeMutex = 0;
+    latencyCV.notify_all();
+    latencyThread.join();
 }
 
 void Bridge::CopyToClipboard(const QString & text)
@@ -585,6 +625,24 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
 /************************************************************************************
                             Exported Functions
 ************************************************************************************/
+__declspec(dllexport) uint32 _gui_messagelatency()
+{
+    uint32 latencyLastRequest = Bridge::getBridge()->latencyLastRequest;
+    uint32 latencyLastResponse = Bridge::getBridge()->latencyLastResponse;
+    uint32 latencyMs = Bridge::getBridge()->latencyMs;
+
+    // Indicates a pending request
+    if(latencyLastResponse > latencyLastRequest)
+    {
+        // If the current wait time exceeds the last measurement, use that instead.
+        // this makes sure that if the pipeline is super stalled all of a sudden,
+        // the measurement is still somewhat accurate; although it would still be
+        // a floor on the actual latency.
+        uint32 currentWait = GetTickCount() - latencyLastRequest;
+        latencyMs = std::max(latencyMs, currentWait);
+    }
+    return latencyMs;
+}
 __declspec(dllexport) int _gui_guiinit(int argc, char* argv[])
 {
     return main(argc, argv);

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -8,12 +8,18 @@
 #include "Imports.h"
 #include "ReferenceManager.h"
 #include "BridgeResult.h"
+#include <thread>
+#include <condition_variable>
+#include <mutex>
 
 class Bridge : public QObject
 {
     Q_OBJECT
 
     friend class BridgeResult;
+    std::thread latencyThread;
+    std::mutex latencyLock;
+    std::condition_variable latencyCV;
 
 public:
     explicit Bridge(QObject* parent = 0);
@@ -21,6 +27,10 @@ public:
 
     static Bridge* getBridge();
     static void initBridge();
+
+    uint32 latencyMs = 0;
+    uint32 latencyLastRequest = 0;
+    uint32 latencyLastResponse = 0;
 
     // Message processing function
     void* processMessage(GUIMSG type, void* param1, void* param2);
@@ -40,6 +50,9 @@ public:
     void* winId;
     QWidget* scriptView;
     ReferenceManager* referenceManager;
+
+protected:
+    virtual void customEvent(QEvent* event) override;
 
 signals:
     void disassembleAt(dsint va, dsint eip);

--- a/src/gui/Src/Exports.h
+++ b/src/gui/Src/Exports.h
@@ -8,10 +8,10 @@
 ************************************************************************************/
 
 #ifdef BUILD_LIB
+extern "C" __declspec(dllexport) uint32 _gui_messagelatency();
 extern "C" __declspec(dllexport) int _gui_guiinit(int argc, char* argv[]);
 extern "C" __declspec(dllexport) void* _gui_sendmessage(GUIMSG type, void* param1, void* param2);
 extern "C" __declspec(dllexport) void _gui_sendmessageasync(GUIMSG type, void* param1, void* param2);
 #endif
-
 
 #endif // EXPORTS_H

--- a/src/gui/Src/Gui/CommandLineEdit.cpp
+++ b/src/gui/Src/Gui/CommandLineEdit.cpp
@@ -16,6 +16,8 @@ CommandLineEdit::CommandLineEdit(QWidget* parent)
     mCompleterModel = (QStringListModel*)mCompleter->model();
     this->setCompleter(mCompleter);
 
+    loadSettings("CommandLine");
+
     //Setup signals & slots
     connect(mCompleter, SIGNAL(activated(const QString &)), this, SLOT(clear()), Qt::QueuedConnection);
     connect(this, SIGNAL(textEdited(QString)), this, SLOT(autoCompleteUpdate(QString)));
@@ -25,6 +27,11 @@ CommandLineEdit::CommandLineEdit(QWidget* parent)
     connect(Bridge::getBridge(), SIGNAL(registerScriptLang(SCRIPTTYPEINFO*)), this, SLOT(registerScriptType(SCRIPTTYPEINFO*)));
     connect(Bridge::getBridge(), SIGNAL(unregisterScriptLang(int)), this, SLOT(unregisterScriptType(int)));
     connect(mCmdScriptType, SIGNAL(currentIndexChanged(int)), this, SLOT(scriptTypeChanged(int)));
+}
+
+CommandLineEdit::~CommandLineEdit()
+{
+    saveSettings("CommandLine");
 }
 
 void CommandLineEdit::keyPressEvent(QKeyEvent* event)

--- a/src/gui/Src/Gui/CommandLineEdit.h
+++ b/src/gui/Src/Gui/CommandLineEdit.h
@@ -14,6 +14,8 @@ class CommandLineEdit : public HistoryLineEdit
 
 public:
     explicit CommandLineEdit(QWidget* parent = 0);
+    ~CommandLineEdit();
+
     void keyPressEvent(QKeyEvent* event);
     bool focusNextPrevChild(bool next);
 

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -78,7 +78,10 @@ void LogView::addMsgToLogSlot(QString msg)
         return;
     if(this->document()->characterCount() > 10000 * 100) //limit the log to ~100mb
         this->clear();
+    // This sets the cursor to the end for the next insert
+    this->moveCursor(QTextCursor::End);
     this->insertPlainText(msg);
+    // This sets the cursor to the end to display the new text
     this->moveCursor(QTextCursor::End);
 }
 

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -341,9 +341,8 @@ void MainWindow::setupStatusBar()
     ui->statusBar->addPermanentWidget(mLastLogLabel, 1);
 
     // Time wasted counter
-    QLabel* timeWastedLabel = new QLabel(this);
-    ui->statusBar->addPermanentWidget(timeWastedLabel);
-    mTimeWastedCounter = new TimeWastedCounter(this, timeWastedLabel);
+    mTimeWastedCounter = new TimeWastedCounter(this);
+    ui->statusBar->addPermanentWidget(mTimeWastedCounter);
 }
 
 void MainWindow::closeEvent(QCloseEvent* event)

--- a/src/gui/Src/Gui/ThreadView.cpp
+++ b/src/gui/Src/Gui/ThreadView.cpp
@@ -189,16 +189,16 @@ void ThreadView::setupContextMenu()
 ThreadView::ThreadView(StdTable* parent) : StdTable(parent)
 {
     int charwidth = getCharWidth();
-    addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("Number"), false);
-    addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("ID"), false);
-    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("Entry"), false);
-    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("TEB"), false);
+    addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("Number"), false, "", SortBy::AsInt);
+    addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("ID"), false, "", SortBy::AsHex);
+    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("Entry"), false, "", SortBy::AsHex);
+    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("TEB"), false, "", SortBy::AsHex);
 #ifdef _WIN64
-    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("RIP"), false);
+    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("RIP"), false, "", SortBy::AsHex);
 #else
-    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("EIP"), false);
+    addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("EIP"), false, "", SortBy::AsHex);
 #endif //_WIN64
-    addColumnAt(8 + charwidth * 14, tr("Suspend Count"), false);
+    addColumnAt(8 + charwidth * 14, tr("Suspend Count"), false, "", SortBy::AsInt);
     addColumnAt(8 + charwidth * 12, tr("Priority"), false);
     addColumnAt(8 + charwidth * 12, tr("Wait Reason"), false);
     addColumnAt(8 + charwidth * 11, tr("Last Error"), false);

--- a/src/gui/Src/Gui/TimeWastedCounter.cpp
+++ b/src/gui/Src/Gui/TimeWastedCounter.cpp
@@ -6,6 +6,7 @@ TimeWastedCounter::TimeWastedCounter(QObject* parent, QLabel* label)
 {
     mLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel); //sunken style
     mLabel->setStyleSheet("QLabel { background-color : #c0c0c0; }");
+
     connect(Bridge::getBridge(), SIGNAL(updateTimeWastedCounter()), this, SLOT(updateTimeWastedCounter()));
 }
 
@@ -14,7 +15,7 @@ void TimeWastedCounter::updateTimeWastedCounter()
     duint dbgEvents = DbgFunctions()->GetDbgEvents();
     if(dbgEvents > 4)
     {
-        mLabel->setText(tr("%1 events/s").arg(dbgEvents));
+        mLabel->setText(tr("%1 events/s (%2ms)").arg(dbgEvents).arg(Bridge::getBridge()->latencyMs));
     }
     else
     {

--- a/src/gui/Src/Gui/TimeWastedCounter.cpp
+++ b/src/gui/Src/Gui/TimeWastedCounter.cpp
@@ -1,21 +1,61 @@
 #include "TimeWastedCounter.h"
 #include "Bridge.h"
 
-TimeWastedCounter::TimeWastedCounter(QObject* parent, QLabel* label)
-    : QObject(parent), mLabel(label)
+TimeWastedCounter::TimeWastedCounter(QWidget* parent)
+    : QLabel(parent)
 {
-    mLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel); //sunken style
-    mLabel->setStyleSheet("QLabel { background-color : #c0c0c0; }");
-
+    setFrameStyle(QFrame::Sunken | QFrame::Panel); //sunken style
+    setStyleSheet("QLabel { background-color : #c0c0c0; }");
+    mLastTime = GetTickCount64();
+    BridgeSettingGetUint("TimeWastedCounter", "CounterMode", (duint*)&mCounterMode);
     connect(Bridge::getBridge(), SIGNAL(updateTimeWastedCounter()), this, SLOT(updateTimeWastedCounter()));
+}
+
+void TimeWastedCounter::mousePressEvent(QMouseEvent*)
+{
+    mCounterMode = (TimeWastedCounterMode::t)((int)mCounterMode + 1);
+    if(mCounterMode >= TimeWastedCounterMode::SIZE)
+    {
+        mCounterMode = (TimeWastedCounterMode::t)0;
+    }
+    BridgeSettingSetUint("TimeWastedCounter", "CounterMode", mCounterMode);
 }
 
 void TimeWastedCounter::updateTimeWastedCounter()
 {
-    duint dbgEvents = DbgFunctions()->GetDbgEvents();
+    uint64 totalDbgEvents = DbgFunctions()->GetDbgEvents();
+    uint64 dbgEvents = totalDbgEvents - mLastEventCount;
+    mLastEventCount = totalDbgEvents;
+
+    uint64 time = GetTickCount64();
+    uint64 timeDelta = time - mLastTime;
+    mLastTime = time;
+
     if(dbgEvents > 4)
     {
-        mLabel->setText(tr("%1 events/s (%2ms)").arg(dbgEvents).arg(Bridge::getBridge()->latencyMs));
+        QString msg = "";
+        switch(mCounterMode)
+        {
+        default:
+        case TimeWastedCounterMode::EventsDelta:
+            msg = tr("%1 events in %2ms (%3ms)")
+                  .arg(dbgEvents)
+                  .arg(timeDelta);
+            break;
+        case TimeWastedCounterMode::EventsTotal:
+            msg = tr("%1(+%2) total events (%3ms)")
+                  .arg(totalDbgEvents)
+                  .arg(dbgEvents);
+            break;
+        case TimeWastedCounterMode::EventsHertz:
+            if(timeDelta == 0)  // Keeps the old message
+                return;
+            msg = tr("%1 events/sec (%3ms)")
+                  .arg(dbgEvents * 1000 / timeDelta);
+            break;
+        }
+        msg = msg.arg(Bridge::getBridge()->latencyMs);
+        setText(msg);
     }
     else
     {
@@ -24,6 +64,6 @@ void TimeWastedCounter::updateTimeWastedCounter()
         int hours = (timeWasted / (60 * 60)) % 24;
         int minutes = (timeWasted / 60) % 60;
         int seconds = timeWasted % 60;
-        mLabel->setText(tr("Time Wasted Debugging:") + QString().sprintf(" %d:%02d:%02d:%02d", days, hours, minutes, seconds));
+        setText(tr("Time Wasted Debugging:") + QString().sprintf(" %d:%02d:%02d:%02d", days, hours, minutes, seconds));
     }
 }

--- a/src/gui/Src/Gui/TimeWastedCounter.h
+++ b/src/gui/Src/Gui/TimeWastedCounter.h
@@ -3,18 +3,33 @@
 
 #include <QObject>
 #include <QLabel>
+#include <stdint.h>
 
-class TimeWastedCounter : public QObject
+class TimeWastedCounter : public QLabel
 {
     Q_OBJECT
 public:
-    explicit TimeWastedCounter(QObject* parent, QLabel* label);
+    explicit TimeWastedCounter(QWidget* parent);
 
 private slots:
     void updateTimeWastedCounter();
-
+protected:
+    void mousePressEvent(QMouseEvent* event);
 private:
-    QLabel* mLabel;
+    struct TimeWastedCounterMode
+    {
+        enum t
+        {
+            EventsDelta = 0,
+            EventsTotal,
+            EventsHertz,
+            SIZE
+        };
+    };
+
+    TimeWastedCounterMode::t mCounterMode = TimeWastedCounterMode::EventsDelta;
+    uint64_t mLastEventCount = 0;
+    uint64_t mLastTime = 0;
 };
 
 #endif // TIMEWASTEDCOUNTER_H


### PR DESCRIPTION
The added logic is in deferable taskthreads; they now check the current latency and defer if that latency is too high. This should prevent any additional events from being sent to QT; which should put a firm limit on how backed up the queue can get during heavy load. 

Also modified the event count logic so it took elapsed time into account. Without this logic, the number reported was based on message processing timing, which fluctuates during load; even when the messages are added at one second intervals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/834)
<!-- Reviewable:end -->
