### PR TITLE
fix issue 518: switch to CPU view after closing last reference view tab.

### DIFF
--- a/src/gui/Src/Gui/ReferenceManager.cpp
+++ b/src/gui/Src/Gui/ReferenceManager.cpp
@@ -38,7 +38,7 @@ void ReferenceManager::newReferenceView(QString name)
 void ReferenceManager::closeTab(int index)
 {
     removeTab(index);
-    if (count() <= 0)
+    if(count() <= 0)
         emit showCpu();
 }
 

--- a/src/gui/Src/Gui/ReferenceManager.cpp
+++ b/src/gui/Src/Gui/ReferenceManager.cpp
@@ -38,9 +38,12 @@ void ReferenceManager::newReferenceView(QString name)
 void ReferenceManager::closeTab(int index)
 {
     removeTab(index);
+    if (count() <= 0)
+        emit showCpu();
 }
 
 void ReferenceManager::closeAllTabs()
 {
     clear();
+    emit showCpu();
 }


### PR DESCRIPTION
added showCpu() signal emissions when all or last reference tab is removed from References widget.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/854)
<!-- Reviewable:end -->
