### PR TITLE
fix wrong behaviour with prefixed retn

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -959,6 +959,22 @@ void cbRtrStep()
         _dbg_dbgtraceexecute(cip);
     if(ch == 0xC3 || ch == 0xC2)
         cbRtrFinalStep();
+    else if(ch == 0x26 || ch == 0x36 || ch == 0x2e || ch == 0x3e || (ch >= 0x64 && ch <= 0x67) || ch == 0xf2 || ch == 0xf3 //instruction prefixes
+#ifdef _WIN64
+        || (ch >= 0x40 && ch <= 0x4f)
+#endif //_WIN64
+        )
+    {
+        Capstone cp;
+        unsigned char data[MAX_DISASM_BUFFER];
+        memset(data, 0, sizeof(data));
+        MemRead(cip, data, MAX_DISASM_BUFFER);
+        cp.Disassemble(cip, data);
+        if(cp.GetId() == X86_INS_RET)
+            cbRtrFinalStep();
+        else
+            StepOver((void*)cbRtrStep);
+    }
     else
     {
         StepOver((void*)cbRtrStep);


### PR DESCRIPTION
In "rtr", the debugger cannot stop tracing when the executable uses some prefixed retns such as "40 C3"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/869)
<!-- Reviewable:end -->
