### PR TITLE
Initial go at implementing GuiGetActiveView function.

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1072,6 +1072,11 @@ BRIDGE_IMPEXP HWND GuiGetWindowHandle()
     return (HWND)_gui_sendmessage(GUI_GET_WINDOW_HANDLE, 0, 0);
 }
 
+BRIDGE_IMPEXP int GuiGetActiveView()
+{
+	return (int)_gui_sendmessage(GUI_GET_ACTIVE_VIEW, 0, 0);
+}
+
 BRIDGE_IMPEXP void GuiDumpAt(duint va)
 {
     _gui_sendmessage(GUI_DUMP_AT, (void*)va, 0);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -870,6 +870,26 @@ BRIDGE_IMPEXP bool DbgGetWatchList(ListOf(WATCHINFO) list);
 #define GUI_MAX_LINE_SIZE 65536
 #define GUI_MAX_DISASSEMBLY_SIZE 2048
 
+// Active view/tab defines
+typedef enum
+{
+	GUI_VIEW_CPU,
+	GUI_VIEW_GRAPH,
+	GUI_VIEW_LOG,
+	GUI_VIEW_NOTES,
+	GUI_VIEW_BREAKPOINTS,
+	GUI_VIEW_MEMORYMAP,
+	GUI_VIEW_CALLSTACK,
+	GUI_VIEW_SEH,
+	GUI_VIEW_SCRIPT,
+	GUI_VIEW_SYMBOLS,
+	GUI_VIEW_SOURCE,
+	GUI_VIEW_REFERENCES,
+	GUI_VIEW_THREADS,
+	GUI_VIEW_SNOWMAN,
+	GUI_VIEW_HANDLES,
+} GUIVIEWS;
+
 //Gui enums
 typedef enum
 {
@@ -959,7 +979,8 @@ typedef enum
     GUI_ADD_FAVOURITE_TOOL,         // param1=const char* name      param2=const char* description
     GUI_ADD_FAVOURITE_COMMAND,      // param1=const char* command   param2=const char* shortcut
     GUI_SET_FAVOURITE_TOOL_SHORTCUT,// param1=const char* name      param2=const char* shortcut
-    GUI_FOLD_DISASSEMBLY            // param1=duint startAddress    param2=duint length
+    GUI_FOLD_DISASSEMBLY,           // param1=duint startAddress    param2=duint length
+	GUI_GET_ACTIVE_VIEW				// param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1007,6 +1028,7 @@ BRIDGE_IMPEXP void GuiUpdateDisassemblyView();
 BRIDGE_IMPEXP void GuiUpdateBreakpointsView();
 BRIDGE_IMPEXP void GuiUpdateWindowTitle(const char* filename);
 BRIDGE_IMPEXP HWND GuiGetWindowHandle();
+BRIDGE_IMPEXP int GuiGetActiveView();
 BRIDGE_IMPEXP void GuiDumpAt(duint va);
 BRIDGE_IMPEXP void GuiScriptAdd(int count, const char** lines);
 BRIDGE_IMPEXP void GuiScriptClear();

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -16,6 +16,7 @@ Bridge::Bridge(QObject* parent) : QObject(parent)
 {
     mBridgeMutex = new QMutex();
     winId = 0;
+	activeViewId = 0;
     scriptView = 0;
     referenceManager = 0;
     bridgeResult = 0;
@@ -119,6 +120,9 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
     case GUI_GET_WINDOW_HANDLE:
         return winId;
 
+    case GUI_GET_ACTIVE_VIEW:
+        return activeViewId;
+		
     case GUI_DUMP_AT:
         emit dumpAt((dsint)param1);
         break;

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -38,6 +38,7 @@ public:
 
     //Public variables
     void* winId;
+	void* activeViewId;
     QWidget* scriptView;
     ReferenceManager* referenceManager;
 

--- a/src/gui/Src/Gui/BreakpointsView.h
+++ b/src/gui/Src/Gui/BreakpointsView.h
@@ -11,13 +11,14 @@ class StdTable;
 class BreakpointsView : public QWidget
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit BreakpointsView(QWidget* parent = 0);
     void setupRightClickContextMenu();
     void setupHardBPRightClickContextMenu();
     void setupSoftBPRightClickContextMenu();
     void setupMemBPRightClickContextMenu();
-
+	
 signals:
     void showCpu();
 
@@ -62,6 +63,7 @@ public slots:
     void editBreakpointSlot();
 
 private:
+    int m_viewId;
     QVBoxLayout* mVertLayout;
     QSplitter* mSplitter ;
     StdTable* mHardBPTable;

--- a/src/gui/Src/Gui/CPUDisassembly.h
+++ b/src/gui/Src/Gui/CPUDisassembly.h
@@ -10,7 +10,8 @@ class GotoDialog;
 class CPUDisassembly : public Disassembly
 {
     Q_OBJECT
-
+    Q_PROPERTY(int viewId MEMBER m_viewId)
+	
 public:
     explicit CPUDisassembly(CPUWidget* parent);
 
@@ -109,6 +110,7 @@ protected:
     void paintEvent(QPaintEvent* event);
 
 private:
+    int m_viewId;
     bool getLabelsFromInstruction(duint addr, QSet<QString> & labels);
 
     // Menus

--- a/src/gui/Src/Gui/CPUStack.h
+++ b/src/gui/Src/Gui/CPUStack.h
@@ -10,6 +10,7 @@ class GotoDialog;
 class CPUStack : public HexDump
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit CPUStack(CPUMultiDump* multiDump, QWidget* parent = 0);
 
@@ -23,7 +24,7 @@ public:
     void mouseDoubleClickEvent(QMouseEvent* event);
     void setupContextMenu();
     void updateFreezeStackAction();
-
+	
 signals:
     void displayReferencesWidget();
 
@@ -74,6 +75,7 @@ public slots:
     void dbgStateChangedSlot(DBGSTATE state);
 
 private:
+    int m_viewId;
     duint mCsp;
     bool bStackFrozen;
 

--- a/src/gui/Src/Gui/CPUWidget.h
+++ b/src/gui/Src/Gui/CPUWidget.h
@@ -20,7 +20,7 @@ namespace Ui
 class CPUWidget : public QWidget
 {
     Q_OBJECT
-
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit CPUWidget(QWidget* parent = 0);
     ~CPUWidget();
@@ -52,6 +52,7 @@ protected:
     CPUArgumentWidget* mArgumentWidget;
 
 private:
+    int m_viewId;
     Ui::CPUWidget* ui;
 };
 

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -6,10 +6,11 @@
 class CallStackView : public StdTable
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit CallStackView(StdTable* parent = 0);
     void setupContextMenu();
-
+	
 signals:
     void showCpu();
 
@@ -21,6 +22,7 @@ protected slots:
     void followFrom();
 
 private:
+    int m_viewId;
     MenuBuilder* mMenuBuilder;
 };
 

--- a/src/gui/Src/Gui/DisassemblerGraphView.h
+++ b/src/gui/Src/Gui/DisassemblerGraphView.h
@@ -22,6 +22,7 @@
 class DisassemblerGraphView : public QAbstractScrollArea
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     struct DisassemblerBlock;
 
@@ -261,6 +262,7 @@ signals:
     void showCpu();
 
 private:
+    int m_viewId;
     QString status;
     Analysis analysis;
     duint function;

--- a/src/gui/Src/Gui/HandlesView.h
+++ b/src/gui/Src/Gui/HandlesView.h
@@ -11,6 +11,7 @@ class QSplitter;
 class HandlesView : public QWidget
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit HandlesView(QWidget* parent = nullptr);
 
@@ -30,6 +31,7 @@ public slots:
     void enableAllPrivilegesSlot();
 
 private:
+    int m_viewId;
     QVBoxLayout* mVertLayout;
     QSplitter* mSplitter;
     StdTable* mHandlesTable;

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -7,6 +7,7 @@
 class LogView : public QTextEdit
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit LogView(QWidget* parent = 0);
     ~LogView();
@@ -25,6 +26,7 @@ public slots:
     void saveSlot();
     void toggleLoggingSlot();
 private:
+    int m_viewId;
     bool loggingEnabled;
 
     QAction* actionCopy;

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -104,18 +104,21 @@ MainWindow::MainWindow(QWidget* parent)
     mLogView = new LogView();
     mLogView->setWindowTitle(tr("Log"));
     mLogView->setWindowIcon(DIcon("log.png"));
+    mLogView->setProperty("viewId", GUI_VIEW_LOG);
     mLogView->hide();
 
     // Symbol view
     mSymbolView = new SymbolView();
     mSymbolView->setWindowTitle(tr("Symbols"));
     mSymbolView->setWindowIcon(DIcon("pdb.png"));
+    mSymbolView->setProperty("viewId", GUI_VIEW_SYMBOLS);
     mSymbolView->hide();
 
     // Source view
     mSourceViewManager = new SourceViewerManager();
     mSourceViewManager->setWindowTitle(tr("Source"));
     mSourceViewManager->setWindowIcon(DIcon("source.png"));
+    mSourceViewManager->setProperty("viewId", GUI_VIEW_SOURCE);
     mSourceViewManager->hide();
     connect(mSourceViewManager, SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
 
@@ -123,6 +126,7 @@ MainWindow::MainWindow(QWidget* parent)
     mBreakpointsView = new BreakpointsView();
     mBreakpointsView->setWindowTitle(tr("Breakpoints"));
     mBreakpointsView->setWindowIcon(DIcon("breakpoint.png"));
+    mBreakpointsView->setProperty("viewId", GUI_VIEW_BREAKPOINTS);
     mBreakpointsView->hide();
     connect(mBreakpointsView, SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
 
@@ -132,29 +136,34 @@ MainWindow::MainWindow(QWidget* parent)
     connect(mMemMapView, SIGNAL(showReferences()), this, SLOT(displayReferencesWidget()));
     mMemMapView->setWindowTitle(tr("Memory Map"));
     mMemMapView->setWindowIcon(DIcon("memory-map.png"));
+    mMemMapView->setProperty("viewId", GUI_VIEW_MEMORYMAP);
     mMemMapView->hide();
 
     // Callstack view
     mCallStackView = new CallStackView();
     mCallStackView->setWindowTitle(tr("Call Stack"));
     mCallStackView->setWindowIcon(DIcon("callstack.png"));
+    mCallStackView->setProperty("viewId", GUI_VIEW_CALLSTACK);
     connect(mCallStackView, SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
 
     // SEH Chain view
     mSEHChainView = new SEHChainView();
     mSEHChainView->setWindowTitle(tr("SEH"));
     mSEHChainView->setWindowIcon(DIcon("seh-chain.png"));
+    mSEHChainView->setProperty("viewId", GUI_VIEW_SEH);
     connect(mSEHChainView, SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
 
     // Script view
     mScriptView = new ScriptView();
     mScriptView->setWindowTitle(tr("Script"));
     mScriptView->setWindowIcon(DIcon("script-code.png"));
+    mScriptView->setProperty("viewId", GUI_VIEW_SCRIPT);
     mScriptView->hide();
 
     // CPU view
     mCpuWidget = new CPUWidget();
     mCpuWidget->setWindowTitle(tr("CPU"));
+    mCpuWidget->setProperty("viewId", GUI_VIEW_CPU);
 #ifdef _WIN64
     mCpuWidget->setWindowIcon(DIcon("processor64.png"));
 #else
@@ -167,12 +176,14 @@ MainWindow::MainWindow(QWidget* parent)
     Bridge::getBridge()->referenceManager = mReferenceManager;
     mReferenceManager->setWindowTitle(tr("References"));
     mReferenceManager->setWindowIcon(DIcon("search.png"));
+    mReferenceManager->setProperty("viewId", GUI_VIEW_REFERENCES);
 
     // Thread view
     mThreadView = new ThreadView();
     connect(mThreadView, SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
     mThreadView->setWindowTitle(tr("Threads"));
     mThreadView->setWindowIcon(DIcon("arrow-threads.png"));
+    mThreadView->setProperty("viewId", GUI_VIEW_THREADS);
 
     // Snowman view (decompiler)
     mSnowmanView = CreateSnowman(this);
@@ -180,21 +191,25 @@ MainWindow::MainWindow(QWidget* parent)
         mSnowmanView = (SnowmanView*)new QLabel("<center>Snowman is disabled...</center>", this);
     mSnowmanView->setWindowTitle(tr("Snowman"));
     mSnowmanView->setWindowIcon(DIcon("snowman.png"));
+    mSnowmanView->setProperty("viewId", GUI_VIEW_SNOWMAN);
 
     // Notes manager
     mNotesManager = new NotesManager(this);
     mNotesManager->setWindowTitle(tr("Notes"));
     mNotesManager->setWindowIcon(DIcon("notes.png"));
+    mNotesManager->setProperty("viewId", GUI_VIEW_NOTES);
 
     // Handles view
     mHandlesView = new HandlesView(this);
     mHandlesView->setWindowTitle(tr("Handles"));
     mHandlesView->setWindowIcon(DIcon("handles.png"));
+    mHandlesView->setProperty("viewId", GUI_VIEW_HANDLES);
 
     // Graph view
     mGraphView = new DisassemblerGraphView(this);
     mGraphView->setWindowTitle(tr("Graph"));
     mGraphView->setWindowIcon(DIcon("graph.png"));
+    mGraphView->setProperty("viewId", GUI_VIEW_GRAPH);
 
     // Create the tab widget
     mTabWidget = new MHTabWidget();
@@ -1378,6 +1393,7 @@ void MainWindow::showQWidgetTab(QWidget* qWidget)
     qWidget->show();
     qWidget->setFocus();
     setTab(qWidget);
+
 }
 
 void MainWindow::closeQWidgetTab(QWidget* qWidget)

--- a/src/gui/Src/Gui/MemoryMapView.h
+++ b/src/gui/Src/Gui/MemoryMapView.h
@@ -6,6 +6,7 @@
 class MemoryMapView : public StdTable
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit MemoryMapView(StdTable* parent = 0);
     QString paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h);
@@ -42,6 +43,7 @@ public slots:
     void findAddressSlot();
 
 private:
+    int m_viewId;
     QString getProtectionString(DWORD Protect);
 
     QAction* mFollowDump;

--- a/src/gui/Src/Gui/NotepadView.h
+++ b/src/gui/Src/Gui/NotepadView.h
@@ -6,14 +6,17 @@
 class NotepadView : public QPlainTextEdit
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit NotepadView(QWidget* parent = 0);
-
+	
 public slots:
     void updateStyle();
     void setNotes(const QString text);
     void getNotes(void* ptr);
 
+private:
+    int m_viewId;
 };
 
 #endif // NOTEPADVIEW_H

--- a/src/gui/Src/Gui/NotesManager.h
+++ b/src/gui/Src/Gui/NotesManager.h
@@ -8,10 +8,12 @@
 class NotesManager : public QTabWidget
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit NotesManager(QWidget* parent = 0);
 
 private:
+    int m_viewId;
     NotepadView* mGlobal;
     NotepadView* mDebuggee;
 };

--- a/src/gui/Src/Gui/PageMemoryRights.h
+++ b/src/gui/Src/Gui/PageMemoryRights.h
@@ -17,7 +17,7 @@ public:
     explicit PageMemoryRights(QWidget* parent = 0);
     void RunAddrSize(duint, duint, QString);
     ~PageMemoryRights();
-
+	
 private slots:
     void on_btnSelectall_clicked();
     void on_btnDeselectall_clicked();

--- a/src/gui/Src/Gui/ReferenceManager.h
+++ b/src/gui/Src/Gui/ReferenceManager.h
@@ -8,6 +8,7 @@
 class ReferenceManager : public QTabWidget
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit ReferenceManager(QWidget* parent = 0);
     ReferenceView* currentReferenceView();
@@ -21,6 +22,7 @@ signals:
     void showCpu();
 
 private:
+    int m_viewId;
     ReferenceView* mCurrentReferenceView;
     QPushButton* mCloseAllTabs;
 };

--- a/src/gui/Src/Gui/SEHChainView.h
+++ b/src/gui/Src/Gui/SEHChainView.h
@@ -6,10 +6,11 @@
 class SEHChainView : public StdTable
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit SEHChainView(StdTable* parent = 0);
     void setupContextMenu();
-
+	
 signals:
     void showCpu();
 
@@ -21,6 +22,7 @@ protected slots:
     void followHandler();
 
 private:
+    int m_viewId;
     QAction* mFollowAddress;
     QAction* mFollowHandler;
 };

--- a/src/gui/Src/Gui/ScriptView.h
+++ b/src/gui/Src/Gui/ScriptView.h
@@ -6,6 +6,7 @@
 class ScriptView : public StdTable
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit ScriptView(StdTable* parent = 0);
 
@@ -16,7 +17,7 @@ public:
     QString paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h);
     void mouseDoubleClickEvent(QMouseEvent* event);
     void keyPressEvent(QKeyEvent* event);
-
+	
 public slots:
     void refreshShortcutsSlot();
     void contextMenuSlot(const QPoint & pos);
@@ -47,6 +48,7 @@ private:
     bool isScriptCommand(QString text, QString cmd);
 
     //private variables
+    int m_viewId;
     int mIpLine;
     bool mEnableSyntaxHighlighting;
     QString filename;

--- a/src/gui/Src/Gui/SourceView.h
+++ b/src/gui/Src/Gui/SourceView.h
@@ -10,13 +10,15 @@
 class SourceView : public ReferenceView
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit SourceView(QString path, int line = 0, StdTable* parent = 0);
     QString getSourcePath();
     void setupContextMenu();
     void setSelection(int line);
-
+	
 private:
+    int m_viewId;
     QString mSourcePath;
     int mIpLine;
     void loadFile();

--- a/src/gui/Src/Gui/SourceViewerManager.h
+++ b/src/gui/Src/Gui/SourceViewerManager.h
@@ -9,9 +9,10 @@
 class SourceViewerManager : public QTabWidget
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit SourceViewerManager(QWidget* parent = 0);
-
+	
 public slots:
     void loadSourceFile(QString path, int line, int selection = 0);
     void closeTab(int index);
@@ -21,6 +22,7 @@ signals:
     void showCpu();
 
 private:
+    int m_viewId;
     QPushButton* mCloseAllTabs;
 };
 

--- a/src/gui/Src/Gui/SymbolView.h
+++ b/src/gui/Src/Gui/SymbolView.h
@@ -17,12 +17,13 @@ namespace Ui
 class SymbolView : public QWidget
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 
 public:
     explicit SymbolView(QWidget* parent = 0);
     ~SymbolView();
     void setupContextMenu();
-
+	
 private slots:
     void updateStyle();
     void addMsgToSymbolLogSlot(QString msg);
@@ -56,6 +57,7 @@ signals:
     void showReferences();
 
 private:
+    int m_viewId;
     Ui::SymbolView* ui;
     QVBoxLayout* mMainLayout;
     QVBoxLayout* mSymbolLayout;

--- a/src/gui/Src/Gui/ThreadView.h
+++ b/src/gui/Src/Gui/ThreadView.h
@@ -7,11 +7,12 @@
 class ThreadView : public StdTable
 {
     Q_OBJECT
+    Q_PROPERTY(int viewId MEMBER m_viewId)
 public:
     explicit ThreadView(StdTable* parent = 0);
     QString paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h);
     void setupContextMenu();
-
+	
 public slots:
     void updateThreadList();
     void doubleClickedSlot();
@@ -33,6 +34,7 @@ signals:
     void showCpu();
 
 private:
+    int m_viewId;
     QString mCurrentThreadId;
     QAction* mSwitchThread;
     QAction* mSuspendThread;

--- a/src/gui/Src/ThirdPartyLibs/snowman/SnowmanView.h
+++ b/src/gui/Src/ThirdPartyLibs/snowman/SnowmanView.h
@@ -6,6 +6,12 @@
 class SnowmanView : public QWidget
 {
     Q_OBJECT
+	Q_PROPERTY(int viewId MEMBER m_viewId)
+public:
+
+private:
+    int m_viewId;
+
 };
 
 extern "C" __declspec(dllexport) SnowmanView* CreateSnowman(QWidget* parent);

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -128,6 +128,107 @@ int main(int argc, char* argv[])
 
     // Set some data
     Bridge::getBridge()->winId = (void*)mainWindow->winId();
+	
+	// Get active view - account for reordered tabs. Tab index 0 will be the active one initially.
+
+	if(!ConfigBool("Miscellaneous", "LoadSaveTabOrder"))
+        Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_CPU;
+	else
+    {
+        //duint tabIndex = 0;
+        duint tabIndex = Config()->getUint("TabOrder", "CPUTab");
+		if(tabIndex == 0)
+            Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_CPU;
+		else
+		{
+			duint tabIndex = Config()->getUint("TabOrder", "GraphTab");
+			if(tabIndex == 0)
+                Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_GRAPH;
+			else
+			{
+				duint tabIndex = Config()->getUint("TabOrder", "LogTab");
+				if(tabIndex == 0)
+                    Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_LOG;
+				else
+				{
+					duint tabIndex = Config()->getUint("TabOrder", "NotesTab");
+					if(tabIndex == 0)
+                        Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_NOTES;
+					else
+					{
+						duint tabIndex = Config()->getUint("TabOrder", "BreakpointsTab");
+						if(tabIndex == 0)
+                            Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_BREAKPOINTS;
+						else
+						{
+							duint tabIndex = Config()->getUint("TabOrder", "MemoryMapTab");
+							if(tabIndex == 0)
+                                Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_MEMORYMAP;
+							else
+							{
+								duint tabIndex = Config()->getUint("TabOrder", "CallStackTab");
+								if(tabIndex == 0)
+                                    Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_CALLSTACK;
+								else
+								{
+									duint tabIndex = Config()->getUint("TabOrder", "SEHTab");
+									if(tabIndex == 0)
+                                        Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_SEH;
+									else
+									{
+										duint tabIndex = Config()->getUint("TabOrder", "ScriptTab");
+										if(tabIndex == 0)
+                                            Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_SCRIPT;
+										else
+										{
+											duint tabIndex = Config()->getUint("TabOrder", "SymbolsTab");
+											if(tabIndex == 0)
+                                                Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_SYMBOLS;
+											else
+											{
+												duint tabIndex = Config()->getUint("TabOrder", "SourceTab");
+												if(tabIndex == 0)
+                                                    Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_SOURCE;
+												else
+												{
+													duint tabIndex = Config()->getUint("TabOrder", "ReferencesTab");
+													if(tabIndex == 0)
+                                                        Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_REFERENCES;
+													else
+													{
+														duint tabIndex = Config()->getUint("TabOrder", "ThreadsTab");
+														if(tabIndex == 0)
+                                                            Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_THREADS;
+														else
+														{
+															duint tabIndex = Config()->getUint("TabOrder", "SnowmanTab");
+															if(tabIndex == 0)
+                                                                Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_SNOWMAN;
+															else
+															{
+																duint tabIndex = Config()->getUint("TabOrder", "HandlesTab");
+																if(tabIndex == 0)
+                                                                    Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_HANDLES;
+																else
+																{
+																	// default ?
+                                                                    Bridge::getBridge()->activeViewId = (void*)GUI_VIEW_CPU;
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
     // Init debugger
     const char* errormsg = DbgInit();


### PR DESCRIPTION
Not sure if this is exactly the correct way to go about adding in this functionality. 

Also couldnt find a way to get the viewId from the qWidget when calling SetTab or the like, as it didn't seem to like it, complaining about converting Qvariant to int, so left that bit out.

Hopefully you'll get an idea of what i was looking to achieve - basically id each widget, then when they are set as the active one, the activeviewId field in the bridge object is updated to reflect the currently active widget based on the GIUVIEWS enum. Then a call to GuiGetActiveView will return this value.

I tried to take into account the different tab orders that might be set when starting - lots of nested if statements - perhaps there is a nicer/better way to do this.

Apologies in advance if some of the code stuff is wrong, as I'm sure you know, I wouldn't be up to speed on c/c++ coding. Anyhow hope it is a step in the right direction or enough to provide a starting point for someone with more expertise and experience.

Cheers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/927)
<!-- Reviewable:end -->
