### PR TITLE
Use last code page conveniently

### DIFF
--- a/src/gui/Src/Gui/CPUDump.h
+++ b/src/gui/Src/Gui/CPUDump.h
@@ -52,10 +52,12 @@ public slots:
     void hexAsciiSlot();
     void hexUnicodeSlot();
     void hexCodepageSlot();
+    void hexLastCodepageSlot();
 
     void textAsciiSlot();
     void textUnicodeSlot();
     void textCodepageSlot();
+    void textLastCodepageSlot();
 
     void integerSignedByteSlot();
     void integerSignedShortSlot();

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -95,7 +95,7 @@ QString CPUInfoBox::getSymbolicName(dsint addr)
         }
         else if(addr == (addr & 0xFFF)) //UNICODE?
         {
-            QChar c = QChar::fromLatin1((wchar_t)addr);
+            QChar c = QChar((ushort)addr);
             if(c.isPrint())
                 finalText += " L'" + QString(c) + "'";
         }

--- a/src/gui/Src/Gui/CalculatorDialog.cpp
+++ b/src/gui/Src/Gui/CalculatorDialog.cpp
@@ -92,7 +92,7 @@ void CalculatorDialog::expressionChanged(bool validExpression, bool validPointer
         ui->txtAscii->setCursorPosition(1);
         if((value == (value & 0xFFF)))  //UNICODE?
         {
-            QChar c = QChar::fromLatin1((wchar_t)value);
+            QChar c = QChar((ushort)value);
             if(c.isPrint())
                 ui->txtUnicode->setText("L'" + QString(c) + "'");
             else
@@ -233,7 +233,7 @@ void CalculatorDialog::on_txtAscii_textEdited(const QString & arg1)
         return;
     }
     ui->txtAscii->setStyleSheet("");
-    ui->txtExpression->setText(QString().sprintf("%X", text[0].toLatin1()));
+    ui->txtExpression->setText(QString().sprintf("%X", text[0].unicode()));
     ui->txtAscii->setCursorPosition(1);
 }
 

--- a/src/gui/Src/Gui/HexEditDialog.cpp
+++ b/src/gui/Src/Gui/HexEditDialog.cpp
@@ -143,6 +143,12 @@ void HexEditDialog::on_btnCodepage_clicked()
         return;
     LineEditDialog lineEdit(this);
     lineEdit.setWindowTitle(tr("Enter text to convert..."));
+    QString oldText;
+    oldText = textCodec->toUnicode(mHexEdit->data());
+    for(auto & i : oldText)
+        if(!i.isPrint())
+            i = QChar('.');
+    lineEdit.setText(oldText);
     if(lineEdit.exec() != QDialog::Accepted)
         return;
     mHexEdit->setData(resizeData(textCodec->fromUnicode(lineEdit.editText)));

--- a/src/gui/Src/Gui/HexLineEdit.cpp
+++ b/src/gui/Src/Gui/HexLineEdit.cpp
@@ -48,7 +48,7 @@ void HexLineEdit::keyPressEvent(QKeyEvent* event)
             switch(mEncoding)
             {
             case Encoding::Ascii:
-                keyText = event->text().toLatin1();
+                keyText = event->text().toLocal8Bit();
                 break;
             case Encoding::Unicode:
                 keyText = event->text();
@@ -71,22 +71,16 @@ void HexLineEdit::setData(const QByteArray & data)
     switch(mEncoding)
     {
     case Encoding::Ascii:
-        for(int i = 0; i < data.size(); i++)
-        {
-            QChar ch(data.constData()[i]);
-            if(ch >= 0 && ch <= 255)
-                text += ch.toLatin1();
-        }
+        text = QString::fromLocal8Bit(data);
         break;
 
     case Encoding::Unicode:
-        for(int i = 0, j = 0; i < data.size(); i += sizeof(wchar_t), j++)
-        {
-            QChar wch(((wchar_t*)data.constData())[j]);
-            text += wch;
-        }
+        text = QString::fromUtf16((const ushort *)data.constData());
         break;
     }
+    for(auto & i : text)
+        if(!i.isPrint())
+            i = QChar(' ');
 
     mData = toEncodedData(text);
     setText(text);
@@ -162,8 +156,7 @@ QByteArray HexLineEdit::toEncodedData(const QString & text)
     switch(mEncoding)
     {
     case Encoding::Ascii:
-        for(int i = 0; i < text.length(); i++)
-            data.append(text[i].toLatin1());
+        data = text.toLocal8Bit();
         break;
 
     case Encoding::Unicode:


### PR DESCRIPTION
* Add last code page to the context menu of the dump
* View the source string in selected code page before modifying it in hex editor.
* Try to use less `toLatin1` since it is not compatible with Windows ASCII convention. We should use `toLocal8Bit` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1023)
<!-- Reviewable:end -->
