### PR TITLE
restored watchdog submenu

### DIFF
--- a/src/gui/Src/Utils/MenuBuilder.h
+++ b/src/gui/Src/Utils/MenuBuilder.h
@@ -44,7 +44,6 @@ public:
     {
         addBuilder(new MenuBuilder(submenu->parent(), [submenu, callback](QMenu * menu)
         {
-            submenu->clear();
             if(callback(submenu))
                 menu->addMenu(submenu);
             return true;


### PR DESCRIPTION
Previously, watchdog submenu does not work because it is cleared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1045)
<!-- Reviewable:end -->
