### PR TITLE
registers view and cpu argument enhancements

### DIFF
--- a/src/gui/Src/Gui/CPUArgumentWidget.cpp
+++ b/src/gui/Src/Gui/CPUArgumentWidget.cpp
@@ -76,7 +76,7 @@ void CPUArgumentWidget::refreshData()
     if(!mAllowUpdate) //view is locked
         return;
 
-    if(mCurrentCallingConvention == -1) //no calling conventions
+    if(mCurrentCallingConvention == -1 || !DbgIsDebugging()) //no calling conventions
     {
         mTable->setRowCount(0);
         mTable->reloadData();
@@ -115,46 +115,52 @@ void CPUArgumentWidget::refreshData()
     mTable->reloadData();
 }
 
+static void configAction(QMenu & wMenu, const QIcon & icon, QAction* action, const QString & value, const QString & name)
+{
+    action->setText(QApplication::translate("CPUArgumentWidget", "Follow %1 in %2").arg(value).arg(name));
+    action->setIcon(icon);
+    action->setObjectName(value);
+    wMenu.addAction(action);
+}
+
 void CPUArgumentWidget::contextMenuSlot(QPoint pos)
 {
+    if(!DbgIsDebugging())
+        return;
     auto selection = mTable->getInitialSelection();
     if(int(mArgumentValues.size()) <= selection)
         return;
     auto value = mArgumentValues[selection];
-    if(!DbgMemIsValidReadPtr(value))
-        return;
-    duint valueAddr;
-    DbgMemRead(value, (unsigned char*)&valueAddr, sizeof(valueAddr));
-
     QMenu wMenu(this);
-    auto valueText = ToHexString(value);
-    auto valueAddrText = QString("[%1]").arg(valueText);
-    auto configAction = [&](QAction * action, const QString & value, const QString & name)
+    if(DbgMemIsValidReadPtr(value))
     {
-        action->setText(tr("Follow %1 in %2").arg(value).arg(name));
-        action->setObjectName(value);
-        wMenu.addAction(action);
-    };
-    auto inStackRange = [](duint addr)
-    {
-        auto csp = DbgValFromString("csp");
-        duint size;
-        auto base = DbgMemFindBaseAddr(csp, &size);
-        return addr >= base && addr < base + size;
-    };
+        duint valueAddr;
+        DbgMemRead(value, (unsigned char*)&valueAddr, sizeof(valueAddr));
 
-    configAction(mFollowDisasm, valueText, tr("Disassembler"));
-    configAction(mFollowDump, valueText, tr("Dump"));
-    if(inStackRange(value))
-        configAction(mFollowStack, valueText, tr("Stack"));
-    if(DbgMemIsValidReadPtr(valueAddr))
-    {
-        configAction(mFollowAddrDisasm, valueAddrText, tr("Disassembler"));
-        configAction(mFollowDump, valueAddrText, tr("Dump"));
-        if(inStackRange(valueAddr))
-            configAction(mFollowAddrStack, valueAddrText, tr("Stack"));
+        auto valueText = ToHexString(value);
+        auto valueAddrText = QString("[%1]").arg(valueText);
+        auto inStackRange = [](duint addr)
+        {
+            auto csp = DbgValFromString("csp");
+            duint size;
+            auto base = DbgMemFindBaseAddr(csp, &size);
+            return addr >= base && addr < base + size;
+        };
+
+        configAction(wMenu, DIcon(ArchValue("processor32.png", "processor64.png")), mFollowDisasm, valueText, tr("Disassembler"));
+        configAction(wMenu, DIcon("dump.png"), mFollowDump, valueText, tr("Dump"));
+        if(inStackRange(value))
+            configAction(wMenu, DIcon("stack.png"), mFollowStack, valueText, tr("Stack"));
+        if(DbgMemIsValidReadPtr(valueAddr))
+        {
+            configAction(wMenu, DIcon(ArchValue("processor32.png", "processor64.png")), mFollowAddrDisasm, valueAddrText, tr("Disassembler"));
+            configAction(wMenu, DIcon("dump.png"), mFollowDump, valueAddrText, tr("Dump"));
+            if(inStackRange(valueAddr))
+                configAction(wMenu, DIcon("stack.png"), mFollowAddrStack, valueAddrText, tr("Stack"));
+        }
     }
     QMenu wCopyMenu(tr("&Copy"));
+    wCopyMenu.setIcon(DIcon("copy.png"));
     mTable->setupCopyMenu(&wCopyMenu);
     if(wCopyMenu.actions().length())
     {

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -13,7 +13,7 @@ class CPUMultiDump;
 
 typedef struct
 {
-    QString string;
+    const char* string;
     unsigned int value;
 } STRING_VALUE_TABLE_t;
 
@@ -65,6 +65,22 @@ public:
         YMM9, YMM10, YMM11, YMM12, YMM13, YMM14, YMM15,
 
         UNKNOWN
+    };
+
+    enum SIMD_REG_DISP_MODE
+    {
+        SIMD_REG_DISP_HEX,
+        SIMD_REG_DISP_FLOAT,
+        SIMD_REG_DISP_DOUBLE,
+        SIMD_REG_DISP_WORD_SIGNED,
+        SIMD_REG_DISP_DWORD_SIGNED,
+        SIMD_REG_DISP_QWORD_SIGNED,
+        SIMD_REG_DISP_WORD_UNSIGNED,
+        SIMD_REG_DISP_DWORD_UNSIGNED,
+        SIMD_REG_DISP_QWORD_UNSIGNED,
+        SIMD_REG_DISP_WORD_HEX,
+        SIMD_REG_DISP_DWORD_HEX,
+        SIMD_REG_DISP_QWORD_HEX
     };
 
     // contains viewport position of register
@@ -157,20 +173,33 @@ protected slots:
     void onPopAction();
     void onHighlightSlot();
     void InitMappings();
+    // switch SIMD display modes
+    void onSIMDHex();
+    void onSIMDFloat();
+    void onSIMDDouble();
+    void onSIMDSWord();
+    void onSIMDUWord();
+    void onSIMDHWord();
+    void onSIMDSDWord();
+    void onSIMDUDWord();
+    void onSIMDHDWord();
+    void onSIMDSQWord();
+    void onSIMDUQWord();
+    void onSIMDHQWord();
     QString getRegisterLabel(REGISTER_NAME);
     int CompareRegisters(const REGISTER_NAME reg_name, REGDUMP* regdump1, REGDUMP* regdump2);
     SIZE_T GetSizeRegister(const REGISTER_NAME reg_name);
-    QString GetRegStringValueFromValue(REGISTER_NAME reg , char* value);
+    QString GetRegStringValueFromValue(REGISTER_NAME reg , const char* value);
     QString GetTagWordStateString(unsigned short);
-    unsigned int GetTagWordValueFromString(QString string);
+    //unsigned int GetTagWordValueFromString(const char* string);
     QString GetControlWordPCStateString(unsigned short);
-    unsigned int GetControlWordPCValueFromString(QString string);
+    //unsigned int GetControlWordPCValueFromString(const char* string);
     QString GetControlWordRCStateString(unsigned short);
-    unsigned int GetControlWordRCValueFromString(QString string);
+    //unsigned int GetControlWordRCValueFromString(const char* string);
     QString GetMxCsrRCStateString(unsigned short);
-    unsigned int GetMxCsrRCValueFromString(QString string);
-    void ModifyFields(QString title, STRING_VALUE_TABLE_t* table, SIZE_T size);
-    unsigned int GetStatusWordTOPValueFromString(QString string);
+    //unsigned int GetMxCsrRCValueFromString(const char* string);
+    void ModifyFields(const QString & title, STRING_VALUE_TABLE_t* table, SIZE_T size);
+    //unsigned int GetStatusWordTOPValueFromString(const char* string);
     QString GetStatusWordTOPStateString(unsigned short state);
     void appendRegister(QString & text, REGISTER_NAME reg, const char* name64, const char* name32);
 private:
@@ -220,8 +249,11 @@ private:
     REGDUMP wCipRegDumpStruct;
     // font measures (TODO: create a class that calculates all thos values)
     unsigned int mRowHeight, mCharWidth;
+    // SIMD registers display mode
+    SIMD_REG_DISP_MODE wSIMDRegDispMode;
     // context menu actions
     QMenu* mFollowInDumpMenu;
+    QMenu* mSwitchSIMDDispMode;
     QAction* mFollowInDump;
     QAction* wCM_Increment;
     QAction* wCM_Decrement;
@@ -244,6 +276,18 @@ private:
     QAction* wCM_Decrementx87Stack;
     QAction* wCM_ChangeFPUView;
     QAction* wCM_Highlight;
+    QAction* SIMDHex;
+    QAction* SIMDFloat;
+    QAction* SIMDDouble;
+    QAction* SIMDSWord;
+    QAction* SIMDUWord;
+    QAction* SIMDHWord;
+    QAction* SIMDSDWord;
+    QAction* SIMDUDWord;
+    QAction* SIMDHDWord;
+    QAction* SIMDSQWord;
+    QAction* SIMDUQWord;
+    QAction* SIMDHQWord;
     dsint mCip;
 };
 

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -228,6 +228,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Handle", 5);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "TcpConnection", 3);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Privilege", 2);
+    guiUint.insert("SIMDRegistersDisplayMode", 0);
     defaultUints.insert("Gui", guiUint);
 
     //uint settings


### PR DESCRIPTION
-   The descriptions for registers (eg, "Nonzero"), have been internationalized.
-   More help information for registers.
-   Can display SIMD registers (XMM and YMM) in float, double or integer format.
-   Adds icons for context menu in arguments list.
-   Can copy small arguments in arguments list now.
-   Other minor fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1101)
<!-- Reviewable:end -->
