### PR TITLE
Allow debugging dotNET applications

### DIFF
--- a/src/dbg/_global.cpp
+++ b/src/dbg/_global.cpp
@@ -289,7 +289,9 @@ arch GetFileArchitecture(const char* szFileName)
                 IMAGE_NT_HEADERS* pnth = (IMAGE_NT_HEADERS*)(data + pdh->e_lfanew);
                 if(pnth->Signature == IMAGE_NT_SIGNATURE)
                 {
-                    if(pnth->FileHeader.Machine == IMAGE_FILE_MACHINE_I386) //x32
+                    if(pnth->OptionalHeader.DataDirectory[15].VirtualAddress != 0 && pnth->OptionalHeader.DataDirectory[15].Size != 0)
+                        retval = dotnet;
+                    else if(pnth->FileHeader.Machine == IMAGE_FILE_MACHINE_I386) //x32
                         retval = x32;
                     else if(pnth->FileHeader.Machine == IMAGE_FILE_MACHINE_AMD64) //x64
                         retval = x64;

--- a/src/dbg/_global.h
+++ b/src/dbg/_global.h
@@ -56,7 +56,8 @@ enum arch
     notfound,
     invalid,
     x32,
-    x64
+    x64,
+    dotnet
 };
 
 //superglobal variables

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -68,6 +68,9 @@ CMDRESULT cbDebugInit(int argc, char* argv[])
         dputs(QT_TRANSLATE_NOOP("DBG", "Use x64dbg to debug this file!"));
 #endif //_WIN64
         return STATUS_ERROR;
+    case dotnet:
+        dputs(QT_TRANSLATE_NOOP("DBG", "This file is a dotNET application."));
+        break;
     default:
         break;
     }


### PR DESCRIPTION
Allow the user to debug dotNET applications. Note it only changes the file validation function to let dotNET applications pass the test, it does not introduce a pleasant user experience when debugging dotNET applications. The user is required to start dotNET application with the right architecture of x64dbg, and the user must set x64dbg to pause at system breakpoint. x64dbg cannot pause at the entry point of the dotNET application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1124)
<!-- Reviewable:end -->
