### PR TITLE
Save Splitter State

### DIFF
--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -3,6 +3,7 @@
 #include "Configuration.h"
 #include "ColumnReorderDialog.h"
 #include "CachedFontMetrics.h"
+#include "Bridge.h"
 #include <windows.h>
 
 int AbstractTableView::mMouseWheelScrollDelta = 0;
@@ -98,6 +99,10 @@ AbstractTableView::AbstractTableView(QWidget* parent)
 
 AbstractTableView::~AbstractTableView()
 {
+}
+
+void AbstractTableView::slot_close()
+{
     if(ConfigBool("Gui", "SaveColumnOrder"))
         saveColumnToConfig();
 }
@@ -176,6 +181,7 @@ void AbstractTableView::loadColumnFromConfig(const QString & viewName)
             mColumnOrder[i] = order - 1;
     }
     mViewName = viewName;
+    connect(Bridge::getBridge(), SIGNAL(close()), this, SLOT(slot_close()));
 }
 
 void AbstractTableView::saveColumnToConfig()

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -134,6 +134,7 @@ public slots:
     void slot_updateColors();
     void slot_updateFonts();
     void slot_updateShortcuts();
+    void slot_close();
 
     // Update/Reload/Refresh/Repaint
     virtual void reloadData();

--- a/src/gui/Src/BasicView/LabeledSplitter.cpp
+++ b/src/gui/Src/BasicView/LabeledSplitter.cpp
@@ -264,3 +264,24 @@ void LabeledSplitter::contextMenuEvent(QContextMenuEvent* event)
         mExpandCollapseAction->setText(tr("&Expand"));
     mMenu->exec(mapToGlobal(event->pos()));
 }
+
+void LabeledSplitter::loadFromConfig(const QString & configName)
+{
+    if(!configName.isEmpty())
+    {
+        mConfigName = configName;
+        char state[MAX_SETTING_SIZE];
+        memset(state, 0, sizeof(state));
+        BridgeSettingGet("Gui", mConfigName.toUtf8().constData(), state);
+        size_t sizeofState = strlen(state);
+        if(sizeofState > 0)
+            this->restoreState(QByteArray::fromBase64(QByteArray(state, sizeofState)));
+        connect(Bridge::getBridge(), SIGNAL(close()), this, SLOT(closeSlot()));
+    }
+}
+
+void LabeledSplitter::closeSlot()
+{
+    if(Config()->getBool("Gui", "SaveColumnOrder"))
+        BridgeSettingSet("Gui", mConfigName.toUtf8().constData(), this->saveState().toBase64().data());
+}

--- a/src/gui/Src/BasicView/LabeledSplitter.h
+++ b/src/gui/Src/BasicView/LabeledSplitter.h
@@ -16,6 +16,7 @@ public:
     void addWidget(QWidget* widget, const QString & name);
     void insertWidget(int index, QWidget* widget, const QString & name);
     void collapseLowerTabs();
+    void loadFromConfig(const QString & configName);
     QList<QString> names;
     QList<QWidget*> m_Windows;
 public slots:
@@ -24,9 +25,11 @@ public slots:
 protected slots:
     void detachSlot();
     void collapseSlot();
+    void closeSlot();
 protected:
     QMenu* mMenu;
     QAction* mExpandCollapseAction;
+    QString mConfigName;
     int currentIndex;
     void setOrientation(Qt::Orientation o); // LabeledSplitter is always vertical
     void addWidget(QWidget* widget);

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -47,6 +47,7 @@ signals:
     void dbgStateChanged(DBGSTATE state);
     void addMsgToLog(QString msg);
     void clearLog();
+    void close();
     void updateRegisters();
     void updateBreakpoints();
     void updateWindowTitle(QString filename);

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -96,6 +96,7 @@ BreakpointsView::BreakpointsView(QWidget* parent) : QWidget(parent)
     mVertLayout->setContentsMargins(0, 0, 0, 0);
     mVertLayout->addWidget(mSplitter);
     this->setLayout(mVertLayout);
+    mSplitter->loadFromConfig("BreakpointsViewSplitter");
 
     // Create the action list for the right click context menu
     setupRightClickContextMenu();

--- a/src/gui/Src/Gui/HandlesView.cpp
+++ b/src/gui/Src/Gui/HandlesView.cpp
@@ -38,6 +38,7 @@ HandlesView::HandlesView(QWidget* parent) : QWidget(parent)
     mSplitter->addWidget(mHandlesTable, tr("Handles"));
     mSplitter->addWidget(mTcpConnectionsTable, tr("TCP Connections"));
     mSplitter->addWidget(mPrivilegesTable, tr("Privileges"));
+    mSplitter->collapseLowerTabs();
 
     // Layout
     mVertLayout = new QVBoxLayout;
@@ -45,6 +46,7 @@ HandlesView::HandlesView(QWidget* parent) : QWidget(parent)
     mVertLayout->setContentsMargins(0, 0, 0, 0);
     mVertLayout->addWidget(mSplitter);
     this->setLayout(mVertLayout);
+    mSplitter->loadFromConfig("HandlesViewSplitter");
 
     // Create the action list for the right click context menu
     mActionRefresh = new QAction(DIcon("arrow-restart.png"), tr("&Refresh"), this);

--- a/src/gui/Src/Gui/LogStatusLabel.cpp
+++ b/src/gui/Src/Gui/LogStatusLabel.cpp
@@ -41,35 +41,35 @@ void LogStatusLabel::focusChanged(QWidget* old, QWidget* now)
         old->setFocus();
         return;
     }
+    /* //Debug output
+        if(!now)
+            return;
 
-    if(!now)
-        return;
-
-    auto findTitle = [](QWidget * w) -> QString
-    {
-        if(!w)
-            return "(null)";
-        if(!w->windowTitle().length())
+        auto findTitle = [](QWidget * w) -> QString
         {
-            auto p = w->parentWidget();
-            if(p && p->windowTitle().length())
-                return p->windowTitle();
-        }
-        return w->windowTitle();
-    };
-    auto className = [](QWidget * w) -> QString
-    {
-        if(!w)
-            return "";
-        return QString(" (%1)").arg(w->metaObject()->className());
-    };
+            if(!w)
+                return "(null)";
+            if(!w->windowTitle().length())
+            {
+                auto p = w->parentWidget();
+                if(p && p->windowTitle().length())
+                    return p->windowTitle();
+            }
+            return w->windowTitle();
+        };
+        auto className = [](QWidget * w) -> QString
+        {
+            if(!w)
+                return "";
+            return QString(" (%1)").arg(w->metaObject()->className());
+        };
 
-    QString oldTitle = findTitle(old);
-    QString oldClass = className(old);
-    QString nowTitle = findTitle(now);
-    QString nowClass = className(now);
+        QString oldTitle = findTitle(old);
+        QString oldClass = className(old);
+        QString nowTitle = findTitle(now);
+        QString nowClass = className(now);
 
-    printf("[FOCUS] old: %s%s, now: %s%s\n",
-           oldTitle.toUtf8().constData(), oldClass.toUtf8().constData(),
-           nowTitle.toUtf8().constData(), nowClass.toUtf8().constData());
+        printf("[FOCUS] old: %s%s, now: %s%s\n",
+               oldTitle.toUtf8().constData(), oldClass.toUtf8().constData(),
+               nowTitle.toUtf8().constData(), nowClass.toUtf8().constData());*/
 }

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -4,6 +4,7 @@
 #include "BrowseDialog.h"
 #include <QRegularExpression>
 #include <QDesktopServices>
+#include <QClipboard>
 
 /**
  * @brief LogView::LogView The constructor constructs a rich text browser
@@ -67,6 +68,7 @@ void LogView::setupContextMenu()
 {
     actionClear = setupAction(DIcon("eraser.png"), tr("Clea&r"), this, SLOT(clearLogSlot()));
     actionCopy = setupAction(DIcon("copy.png"), tr("&Copy"), this, SLOT(copy()));
+    actionPaste = setupAction(DIcon("binary_paste.png"), tr("&Paste"), this, SLOT(pasteSlot()));
     actionSelectAll = setupAction(tr("Select &All"), this, SLOT(selectAll()));
     actionSave = setupAction(DIcon("binary_save.png"), tr("&Save"), this, SLOT(saveSlot()));
     actionToggleLogging = setupAction(tr("Disable &Logging"), this, SLOT(toggleLoggingSlot()));
@@ -99,6 +101,7 @@ void LogView::contextMenuEvent(QContextMenuEvent* event)
     wMenu.addAction(actionClear);
     wMenu.addAction(actionSelectAll);
     wMenu.addAction(actionCopy);
+    wMenu.addAction(actionPaste);
     wMenu.addAction(actionSave);
     if(getLoggingEnabled())
         actionToggleLogging->setText(tr("Disable &Logging"));
@@ -322,4 +325,14 @@ void LogView::copyToDebuggeeNotes()
     BridgeFree(NotesBuffer);
     Notes.append(this->textCursor().selectedText());
     emit Bridge::getBridge()->setDebuggeeNotes(Notes);
+}
+
+void LogView::pasteSlot()
+{
+    QString clipboardText = QApplication::clipboard()->text();
+    if(clipboardText.isEmpty())
+        return;
+    if(!clipboardText.endsWith('\n'))
+        clipboardText.append('\n');
+    addMsgToLogSlot(clipboardText);
 }

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -22,6 +22,7 @@ public slots:
     void autoScrollSlot();
     void copyToGlobalNotes();
     void copyToDebuggeeNotes();
+    void pasteSlot();
     bool getLoggingEnabled();
     void onAnchorClicked(const QUrl & link);
 
@@ -33,6 +34,7 @@ private:
     bool autoScroll;
 
     QAction* actionCopy;
+    QAction* actionPaste;
     QAction* actionSelectAll;
     QAction* actionClear;
     QAction* actionSave;

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -445,6 +445,8 @@ void MainWindow::setupLanguagesMenu()
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     duint noClose = 0;
+    if(bCanClose)
+        emit Bridge::getBridge()->close();
     if(BridgeSettingGetUint("Gui", "NoCloseDialog", &noClose) && noClose)
         mCloseDialog->hide();
     else

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -449,6 +449,7 @@ RegistersView::RegistersView(CPUWidget* parent, CPUMultiDump* multiDump) : QScro
 {
     setWindowTitle("Registers");
     mChangeViewButton = NULL;
+    connect(Bridge::getBridge(), SIGNAL(close()), this, SLOT(onClose()));
     switch(ConfigUint("Gui", "SIMDRegistersDisplayMode"))
     {
     case 0:
@@ -1304,9 +1305,13 @@ void RegistersView::refreshShortcutsSlot()
 }
 
 /**
- * @brief RegistersView::~RegistersView The destructor. It also saves the current SIMD display mode into the config file.
+ * @brief RegistersView::~RegistersView The destructor.
  */
 RegistersView::~RegistersView()
+{
+}
+
+void RegistersView::onClose()
 {
     duint cfg = 0;
     switch(wSIMDRegDispMode)

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -186,6 +186,7 @@ protected slots:
     void onSIMDSQWord();
     void onSIMDUQWord();
     void onSIMDHQWord();
+    void onClose();
     QString getRegisterLabel(REGISTER_NAME);
     int CompareRegisters(const REGISTER_NAME reg_name, REGDUMP* regdump1, REGDUMP* regdump2);
     SIZE_T GetSizeRegister(const REGISTER_NAME reg_name);

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -33,7 +33,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabEvents">
       <attribute name="title">

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -33,7 +33,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="tabEvents">
       <attribute name="title">
@@ -483,7 +483,7 @@
        <item>
         <widget class="QCheckBox" name="chkSaveColumnOrder">
          <property name="text">
-          <string>Save column order and width</string>
+          <string>Save GUI layout and column orders</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
The state of custom splitters can be saved now. It only works for breakpoints view and handles view. Also adds a "close" event instead of relying on the destructor to save GUI state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1125)
<!-- Reviewable:end -->
