### PR TITLE
Added a plugin callback that allows filtering dbghelp emitted symbols.

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -111,7 +111,10 @@ static bool shouldFilterSymbol(const char* name)
         return true;
     if(strstr(name, "__imp_") == name || strstr(name, "_imp_") == name)
         return true;
-    return false;
+
+    PLUG_CB_FILTERSYMBOL filterInfo = { name, false };
+    plugincbcall(CB_FILTERSYMBOL, &filterInfo);
+    return filterInfo.retval;
 }
 
 static bool getLabel(duint addr, char* label)

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -176,6 +176,12 @@ typedef struct
     int loadSaveType;
 } PLUG_CB_LOADSAVEDB;
 
+typedef struct
+{
+    const char* symbol;
+    bool retval;
+} PLUG_CB_FILTERSYMBOL;
+
 //enums
 typedef enum
 {
@@ -202,6 +208,7 @@ typedef enum
     CB_WINEVENTGLOBAL, //PLUG_CB_WINEVENTGLOBAL
     CB_LOADDB, //PLUG_CB_LOADSAVEDB
     CB_SAVEDB, //PLUG_CB_LOADSAVEDB
+    CB_FILTERSYMBOL, //PLUG_CB_FILTERSYMBOL
     CB_LAST
 } CBTYPE;
 

--- a/src/dbg/plugin_loader.cpp
+++ b/src/dbg/plugin_loader.cpp
@@ -161,6 +161,7 @@ bool pluginload(const char* pluginName, bool loadall)
     regExport("CBWINEVENTGLOBAL", CB_WINEVENTGLOBAL);
     regExport("CBLOADDB", CB_LOADDB);
     regExport("CBSAVEDB", CB_SAVEDB);
+    regExport("CBFILTERSYMBOL", CB_FILTERSYMBOL);
 
     //init plugin
     if(!pluginData.pluginit(&pluginData.initStruct))


### PR DESCRIPTION
Closes #445.
Tested with a simple plugin that filters out a specific symbol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1135)
<!-- Reviewable:end -->
