### PR TITLE
Add length specifier for string formatter

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -899,10 +899,13 @@ BRIDGE_IMPEXP void DbgClearAutoFunctionRange(duint start, duint end)
     _dbg_sendmessage(DBG_DELETE_AUTO_FUNCTION_RANGE, (void*)start, (void*)end);
 }
 
-// FIXME size of the buffer?
-BRIDGE_IMPEXP bool DbgGetStringAt(duint addr, char* text)
+BRIDGE_IMPEXP bool DbgGetStringAt(duint addr, char* text, duint length)
 {
-    if(_dbg_sendmessage(DBG_GET_STRING_AT, (void*)addr, text))
+    STRING_GET_INFO stringInfo;
+    stringInfo.maxLength = length != 0 ? (length > (MAX_STRING_SIZE - 5) ? MAX_STRING_SIZE - 5 : length) : MAX_STRING_SIZE - 5;
+    stringInfo.lengthSpecified = length != 0 ? true : false;
+    stringInfo.addr = addr;
+    if(_dbg_sendmessage(DBG_GET_STRING_AT, (void*)&stringInfo, text))
         return true;
     return false;
 }

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -763,6 +763,14 @@ typedef struct
     XREF_RECORD* references;
 } XREF_INFO;
 
+//using at DbgGetStringAt
+typedef struct
+{
+    duint addr;
+    duint maxLength;
+    bool lengthSpecified;
+} STRING_GET_INFO;
+
 //Debugger functions
 BRIDGE_IMPEXP const char* DbgInit();
 BRIDGE_IMPEXP void DbgExit();
@@ -843,7 +851,7 @@ BRIDGE_IMPEXP bool DbgSetAutoBookmarkAt(duint addr);
 BRIDGE_IMPEXP void DbgClearAutoBookmarkRange(duint start, duint end);
 BRIDGE_IMPEXP bool DbgSetAutoFunctionAt(duint start, duint end);
 BRIDGE_IMPEXP void DbgClearAutoFunctionRange(duint start, duint end);
-BRIDGE_IMPEXP bool DbgGetStringAt(duint addr, char* text);
+BRIDGE_IMPEXP bool DbgGetStringAt(duint addr, char* text, duint bytes = 0);
 BRIDGE_IMPEXP const DBGFUNCTIONS* DbgFunctions();
 BRIDGE_IMPEXP bool DbgWinEvent(MSG* message, long* result);
 BRIDGE_IMPEXP bool DbgWinEventGlobal(MSG* message);

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1159,32 +1159,32 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
 
     case DBG_GET_STRING_AT:
     {
-        auto addr = duint(param1);
-        if(!MemIsValidReadPtrUnsafe(addr, true))
+        STRING_GET_INFO* stringInfo = (STRING_GET_INFO*)param1;
+        if(!MemIsValidReadPtrUnsafe(stringInfo->addr, true))
             return false;
 
         auto dest = (char*)param2;
         *dest = '\0';
-        char string[MAX_STRING_SIZE];
+        char string[MAX_STRING_SIZE] = { 0 };
         duint addrPtr;
         STRING_TYPE strtype;
-        if(MemReadUnsafe(addr, &addrPtr, sizeof(addr)) && MemIsValidReadPtrUnsafe(addrPtr, true))
+        if(MemReadUnsafe(stringInfo->addr, &addrPtr, sizeof(stringInfo->addr)) && MemIsValidReadPtrUnsafe(addrPtr, true))
         {
-            if(disasmgetstringat(addrPtr, &strtype, string, string, MAX_STRING_SIZE - 5))
+            if(disasmgetstringat(addrPtr, &strtype, string, string, stringInfo->maxLength, stringInfo->lengthSpecified))
             {
                 if(strtype == str_ascii)
-                    sprintf_s(dest, MAX_STRING_SIZE, "&\"%s\"", string);
+                    sprintf_s(dest, stringInfo->maxLength + 4, "&\"%s\"", string);
                 else //unicode
-                    sprintf_s(dest, MAX_STRING_SIZE, "&L\"%s\"", string);
+                    sprintf_s(dest, stringInfo->maxLength + 5, "&L\"%s\"", string);
                 return true;
             }
         }
-        if(disasmgetstringat(addr, &strtype, string, string, MAX_STRING_SIZE - 4))
+        if(disasmgetstringat(stringInfo->addr, &strtype, string, string, stringInfo->maxLength, stringInfo->lengthSpecified))
         {
             if(strtype == str_ascii)
-                sprintf_s(dest, MAX_STRING_SIZE, "\"%s\"", string);
+                sprintf_s(dest, stringInfo->maxLength + 3, "\"%s\"", string);
             else //unicode
-                sprintf_s(dest, MAX_STRING_SIZE, "L\"%s\"", string);
+                sprintf_s(dest, stringInfo->maxLength + 4, "L\"%s\"", string);
             return true;
         }
         return false;

--- a/src/dbg/disasm_helper.h
+++ b/src/dbg/disasm_helper.h
@@ -11,7 +11,7 @@ void disasmprint(duint addr);
 void disasmget(unsigned char* buffer, duint addr, DISASM_INSTR* instr);
 void disasmget(duint addr, DISASM_INSTR* instr);
 bool disasmispossiblestring(duint addr);
-bool disasmgetstringat(duint addr, STRING_TYPE* type, char* ascii, char* unicode, int maxlen);
+bool disasmgetstringat(duint addr, STRING_TYPE* type, char* ascii, char* unicode, int maxlen, bool maxLenAsLength = false);
 int disasmgetsize(duint addr, unsigned char* data);
 int disasmgetsize(duint addr);
 


### PR DESCRIPTION
The syntax for that addition is `{s|expression:}`
For example, now we can create conditional breakpoints on **memcpy** function and get string even without null terminator on end:
`log "Text without \0 from memcpy - {s|r8:rdx}"`

One change, that _can_ _possibly_ hit the performance, is exchange of `isasciistring` and `isunicodestring` function calls at `disasmgetstringat` function. If it's true, I can try to figure it out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1139)
<!-- Reviewable:end -->
