### PR TITLE
remove internal instruction "capstone"

### DIFF
--- a/src/gui/Src/Gui/CPUSideBar.cpp
+++ b/src/gui/Src/Gui/CPUSideBar.cpp
@@ -227,9 +227,12 @@ void CPUSideBar::paintEvent(QPaintEvent* event)
 
         if(isJump(line)) //handle jumps
         {
+            duint baseAddr = mDisas->getBase();
+            duint destVA = DbgGetBranchDestination(baseAddr + instr.rva);
+
             JumpLine jmp;
             jmp.isJumpGoingToExecute = DbgIsJumpGoingToExecute(instrVA);
-            jmp.isSelected = (selectedVA == instrVA);
+            jmp.isSelected = (selectedVA == instrVA || selectedVA == destVA);
             jmp.isConditional = instr.branchType == Instruction_t::Conditional;
             jmp.line = line;
 
@@ -240,9 +243,6 @@ void CPUSideBar::paintEvent(QPaintEvent* event)
 
             jumpoffset++;
 
-            duint baseAddr = mDisas->getBase();
-
-            duint destVA = DbgGetBranchDestination(baseAddr + instr.rva);
 
             // Do not try to draw EBFE (Jump to the same line)
             //if(destVA == instrVA)


### PR DESCRIPTION
This internal instruction has too many strings for translation, which wastes translators' time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1150)
<!-- Reviewable:end -->
