### PR TITLE
GUI: Add View->Next/Previous Tab actions

### DIFF
--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -316,6 +316,8 @@ MainWindow::MainWindow(QWidget* parent)
     connect(ui->actionSnowman, SIGNAL(triggered()), this, SLOT(displaySnowmanWidget()));
     connect(ui->actionHandles, SIGNAL(triggered()), this, SLOT(displayHandlesWidget()));
     connect(ui->actionGraph, SIGNAL(triggered()), this, SLOT(displayGraphWidget()));
+    connect(ui->actionPreviousTab, SIGNAL(triggered()), this, SLOT(displayPreviousTab()));
+    connect(ui->actionNextTab, SIGNAL(triggered()), this, SLOT(displayNextTab()));
     makeCommandAction(ui->actionStepIntoSource, "TraceIntoConditional src.line(cip) && !src.disp(cip)");
     makeCommandAction(ui->actionStepOverSource, "TraceOverConditional src.line(cip) && !src.disp(cip)");
     makeCommandAction(ui->actionseStepInto, "seStepInto");
@@ -572,6 +574,8 @@ void MainWindow::refreshShortcuts()
     setGlobalShortcut(ui->actionSnowman, ConfigShortcut("ViewSnowman"));
     setGlobalShortcut(ui->actionHandles, ConfigShortcut("ViewHandles"));
     setGlobalShortcut(ui->actionGraph, ConfigShortcut("ViewGraph"));
+    setGlobalShortcut(ui->actionPreviousTab, ConfigShortcut("ViewPreviousTab"));
+    setGlobalShortcut(ui->actionNextTab, ConfigShortcut("ViewNextTab"));
 
     setGlobalShortcut(ui->actionRun, ConfigShortcut("DebugRun"));
     setGlobalShortcut(ui->actioneRun, ConfigShortcut("DebugeRun"));
@@ -916,6 +920,16 @@ void MainWindow::displaySnowmanWidget()
 void MainWindow::displayGraphWidget()
 {
     showQWidgetTab(mGraphView);
+}
+
+void MainWindow::displayPreviousTab()
+{
+    mTabWidget->showPreviousTab();
+}
+
+void MainWindow::displayNextTab()
+{
+    mTabWidget->showNextTab();
 }
 
 void MainWindow::openSettings()

--- a/src/gui/Src/Gui/MainWindow.h
+++ b/src/gui/Src/Gui/MainWindow.h
@@ -83,6 +83,8 @@ public slots:
     void displayThreadsWidget();
     void displaySnowmanWidget();
     void displayGraphWidget();
+    void displayPreviousTab();
+    void displayNextTab();
     void openSettings();
     void openAppearance();
     void openCalculator();

--- a/src/gui/Src/Gui/MainWindow.ui
+++ b/src/gui/Src/Gui/MainWindow.ui
@@ -72,6 +72,9 @@
     <addaction name="actionSnowman"/>
     <addaction name="actionHandles"/>
     <addaction name="actionGraph"/>
+    <addaction name="separator"/>
+    <addaction name="actionPreviousTab"/>
+    <addaction name="actionNextTab"/>
    </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
@@ -1046,6 +1049,24 @@
    </property>
    <property name="text">
     <string>Customize menus</string>
+   </property>
+  </action>
+  <action name="actionPreviousTab">
+   <property name="icon">
+    <iconset resource="../../resource.qrc">
+     <normaloff>:/icons/images/previous.png</normaloff>:/icons/images/previous.png</iconset>
+   </property>
+   <property name="text">
+    <string>Previous Tab</string>
+   </property>
+  </action>
+  <action name="actionNextTab">
+   <property name="icon">
+    <iconset resource="../../resource.qrc">
+     <normaloff>:/icons/images/next.png</normaloff>:/icons/images/next.png</iconset>
+   </property>
+   <property name="text">
+    <string>Next Tab</string>
    </property>
   </action>
  </widget>

--- a/src/gui/Src/Gui/TabWidget.cpp
+++ b/src/gui/Src/Gui/TabWidget.cpp
@@ -198,6 +198,36 @@ QString MHTabWidget::getNativeName(int index)
     }
 }
 
+void MHTabWidget::showPreviousTab()
+{
+    if(QTabWidget::count() <= 1)
+    {
+        return;
+    }
+
+    int previousTabIndex = QTabWidget::currentIndex();
+    if(previousTabIndex == 0)
+    {
+        previousTabIndex = QTabWidget::count() - 1;
+    }
+    else
+    {
+        previousTabIndex--;
+    }
+
+    QTabWidget::setCurrentIndex(previousTabIndex);
+}
+
+void MHTabWidget::showNextTab()
+{
+    if(QTabWidget::count() <= 1)
+    {
+        return;
+    }
+
+    QTabWidget::setCurrentIndex((QTabWidget::currentIndex() + 1) % QTabWidget::count());
+}
+
 //----------------------------------------------------------------------------
 
 MHDetachedWindow::MHDetachedWindow(QWidget* parent, MHTabWidget* tabwidget) : QMainWindow(parent)

--- a/src/gui/Src/Gui/TabWidget.h
+++ b/src/gui/Src/Gui/TabWidget.h
@@ -29,6 +29,8 @@ public:
 
     int addTabEx(QWidget* widget, const QIcon & icon, const QString & label, const QString & nativeName);
     QString getNativeName(int index);
+    void showPreviousTab();
+    void showNextTab();
 signals:
     void tabMovedTabWidget(int from, int to);
 

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -308,6 +308,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ViewSnowman", Shortcut(tr("View -> Snowman"), "", true));
     defaultShortcuts.insert("ViewHandles", Shortcut(tr("View -> Handles"), "", true));
     defaultShortcuts.insert("ViewGraph", Shortcut(tr("View -> Graph"), "Alt+G", true));
+    defaultShortcuts.insert("ViewPreviousTab", Shortcut(tr("View -> Previous Tab"), "Ctrl+Shift+Tab"));
+    defaultShortcuts.insert("ViewNextTab", Shortcut(tr("View -> Next Tab"), "Ctrl+Tab"));
 
     defaultShortcuts.insert("DebugRun", Shortcut(tr("Debug -> Run"), "F9", true));
     defaultShortcuts.insert("DebugeRun", Shortcut(tr("Debug -> Run (pass exceptions)"), "Shift+F9", true));


### PR DESCRIPTION
This allows users to cycle through their attached tabs. Detached tabs will not be cycled through.
The default hotkeys are Ctrl+Tab/Ctrl+Shift+Tab.

Closes  #1017.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1152)
<!-- Reviewable:end -->
