### PR TITLE
DBG: add autocomment for call $0 (closes #940)

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -269,7 +269,17 @@ extern "C" DLL_EXPORT bool _dbg_addrinfoget(duint addr, SEGMENTREG segment, ADDR
                     if(instr.arg[i].constant == instr.arg[i].value) //avoid: call <module.label> ; addr:label
                     {
                         if(instr.type == instr_branch)
-                            continue;
+                        {
+                            if(strstr(instr.instruction, "call") && instr.argcount == 1 && !instr.arg[0].memvalue && instr.arg[0].constant == addr + instr.instr_size)
+                            {
+                                temp_string.assign("call the next instruction");
+                            }
+                            else
+                            {
+                                continue;
+                            }
+                        }
+
                         auto constant = instr.arg[i].constant;
                         if(instr.arg[i].type == arg_normal && constant < 256 && (isprint(int(constant)) || isspace(int(constant))) && (strstr(instr.instruction, "cmp") || strstr(instr.instruction, "mov")))
                         {


### PR DESCRIPTION
I'm a first time contributor and am not overly familiar with x86 assembly, but I think this should do the trick. (Though perhaps `instr.arg[0].segment` also needs checking, I'm not totally sure.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1164)
<!-- Reviewable:end -->
