### PR TITLE
Added Symbolic Name copy to copy context meny in CPU disassembly window.

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -245,6 +245,16 @@ void CPUDisassembly::setupRightClickContextMenu()
     copyMenu->addAction(makeAction(DIcon("copy_address.png"), tr("&RVA"), SLOT(copyRvaSlot())));
     copyMenu->addAction(makeAction(DIcon("copy_disassembly.png"), tr("Disassembly"), SLOT(copyDisassemblySlot())));
     copyMenu->addAction(makeAction(DIcon("data-copy.png"), tr("&Data..."), SLOT(copyDataSlot())));
+
+    copyMenu->addMenu(makeMenu(DIcon("copy_selection.png"), tr("Symbolic Name")), [this](QMenu * menu)
+    {
+        QSet<QString> labels;
+        if(!getLabelsFromInstruction(rvaToVa(getInitialSelection()), labels))
+            return false;
+        for(auto label : labels)
+            menu->addAction(makeAction(label, SLOT(labelCopySlot())));
+        return true;
+    });
     mMenuBuilder->addMenu(makeMenu(DIcon("copy.png"), tr("&Copy")), copyMenu);
 
     mMenuBuilder->addAction(makeShortcutAction(DIcon("eraser.png"), tr("&Restore selection"), SLOT(undoSelectionSlot()), "ActionUndoSelection"), [this](QMenu*)
@@ -1517,6 +1527,12 @@ void CPUDisassembly::copyDataSlot()
     mMemPage->read(data.data(), selStart, selSize);
     DataCopyDialog dataDialog(&data, this);
     dataDialog.exec();
+}
+
+void CPUDisassembly::labelCopySlot()
+{
+    QString symbol = ((QAction*)sender())->text();
+    Bridge::CopyToClipboard(symbol);
 }
 
 void CPUDisassembly::findCommandSlot()

--- a/src/gui/Src/Gui/CPUDisassembly.h
+++ b/src/gui/Src/Gui/CPUDisassembly.h
@@ -89,6 +89,7 @@ public slots:
     void copyRvaSlot();
     void copyDisassemblySlot();
     void copyDataSlot();
+    void labelCopySlot();
     void findCommandSlot();
     void openSourceSlot();
     void decompileSelectionSlot();


### PR DESCRIPTION
Closes #953.

Could be pulled out of the copy menu but it seems logical for it to be there.

![out](https://cloud.githubusercontent.com/assets/265903/19621516/3e21e3c2-989c-11e6-8bdf-f95f5d04f083.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1186)
<!-- Reviewable:end -->
