### PR TITLE
traced background in references and source

### DIFF
--- a/src/gui/Src/BasicView/SearchListViewTable.h
+++ b/src/gui/Src/BasicView/SearchListViewTable.h
@@ -37,6 +37,8 @@ private:
     QColor mSelectedAddressColor;
     QColor mAddressBackgroundColor;
     QColor mAddressColor;
+    QColor mTracedBackgroundColor;
+    QColor mTracedSelectedAddressBackgroundColor;
     duint mCip;
     bool bCipBase;
 };

--- a/src/gui/Src/Gui/CustomizeMenuDialog.cpp
+++ b/src/gui/Src/Gui/CustomizeMenuDialog.cpp
@@ -41,6 +41,8 @@ CustomizeMenuDialog::CustomizeMenuDialog(QWidget* parent) :
             viewName = tr("Graph");
         else if(id == "CPUStack")
             viewName = tr("Stack");
+        else if(id == "SourceView")
+            viewName = tr("Source");
         else if(id == "File")
             viewName = tr("File");
         else if(id == "Debug")

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -1870,17 +1870,21 @@ void MainWindow::onMenuCustomized()
         QMenu* currentMenu = menus[i];
         QMenu* moreCommands = nullptr;
         bool moreCommandsUsed = false;
-        moreCommands = currentMenu->actions().last()->menu();
+        QList<QAction*> & list = currentMenu->actions();
+        moreCommands = list.last()->menu();
         if(moreCommands && moreCommands->title().compare(tr("More Commands")) == 0)
         {
             for(auto & j : moreCommands->actions())
                 moreCommands->removeAction(j);
+            QAction* separatorMoreCommands = list.at(list.length() - 2);
+            currentMenu->removeAction(separatorMoreCommands); // Separator
+            delete separatorMoreCommands;
         }
         else
         {
             moreCommands = new QMenu(tr("More Commands"), currentMenu);
         }
-        for(auto & j : currentMenu->actions())
+        for(auto & j : list)
             currentMenu->removeAction(j);
         for(int j = 0; j < menuTextStrings.at(i)->size() - 1; j++)
         {

--- a/src/gui/Src/Gui/SourceView.cpp
+++ b/src/gui/Src/Gui/SourceView.cpp
@@ -30,6 +30,7 @@ SourceView::SourceView(QString path, int line, QWidget* parent)
     mMenuBuilder = new MenuBuilder(this);
     mMenuBuilder->addAction(makeAction(tr("Open source file"), SLOT(openSourceFileSlot())));
     mMenuBuilder->addAction(makeAction(tr("Show source file in directory"), SLOT(showInDirectorySlot())));
+    mMenuBuilder->loadFromConfig();
 }
 
 void SourceView::setSelection(int line)

--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -555,6 +555,7 @@ void SymbolView::moduleSetParty()
     mLineEdit.setWindowIcon(DIcon("bookmark.png"));
     mLineEdit.setWindowTitle(tr("Mark the party of the module as"));
     mLineEdit.setText(QString::number(party));
+    mLineEdit.setPlaceholderText(tr("0 is user module, 1 is system module."));
     if(mLineEdit.exec() == QDialog::Accepted)
     {
         bool ok;

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -220,6 +220,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     insertMenuBuilderBools(&guiBool, "CallStackView", 50); //CallStackView
     insertMenuBuilderBools(&guiBool, "ThreadView", 50); //Thread
     insertMenuBuilderBools(&guiBool, "CPUStack", 50); //Stack
+    insertMenuBuilderBools(&guiBool, "SourceView", 10); //Source
     insertMenuBuilderBools(&guiBool, "DisassemblerGraphView", 50); //Graph
     insertMenuBuilderBools(&guiBool, "File", 50); //Main Menu : File
     insertMenuBuilderBools(&guiBool, "Debug", 50); //Main Menu : Debug


### PR DESCRIPTION
*  Show traced address green in the source and references view.
*  Customize menu of source view, although there is only 2 items now and you must first open a source view to customize it.
*  A placeholder tip in "Mark as party..." to remind the user that 0 is user module and 1 is system module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1209)
<!-- Reviewable:end -->
