### PR TITLE
print stack trace

### DIFF
--- a/src/dbg/commands/cmd-script.h
+++ b/src/dbg/commands/cmd-script.h
@@ -6,3 +6,4 @@ bool cbScriptLoad(int argc, char* argv[]);
 bool cbScriptMsg(int argc, char* argv[]);
 bool cbScriptMsgyn(int argc, char* argv[]);
 bool cbInstrLog(int argc, char* argv[]);
+bool cbInstrPrintStack(int argc, char* argv[]);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -423,6 +423,7 @@ static void registercommands()
     dbgcmdnew("meminfo", cbInstrMeminfo, true); //command to debug memory map bugs
     dbgcmdnew("briefcheck", cbInstrBriefcheck, true); //check if mnemonic briefs are missing
     dbgcmdnew("focusinfo", cbInstrFocusinfo, false);
+    dbgcmdnew("printstack\1logstack", cbInstrPrintStack, true); //print the call stack
 };
 
 bool cbCommandProvider(char* cmd, int maxlen)


### PR DESCRIPTION
New command "printstack" or "logstack". Sample output:
11 call stack frames (RIP = 000007FEE427CCE4 , RSP = 00000000001CEFF8 , RBP = 00000000001CF4C0 ):
00000000001CEFF8 return to ntdll.0000000077CA6A98 from <x64gui._DllMainCRTStartup>
00000000001CF1C8 return to ntdll.0000000077CA686E from ntdll.0000000077CA6A98
00000000001CF3C8 return to ntdll.0000000077C95FCF from ntdll.0000000077CA686E
00000000001CF438 return to kernelbase.000007FEFDAF0176 from ntdll.0000000077C95FCF
00000000001CF4B8 return to nvd3d9wrapx.000007FEFA355845 from kernelbase.000007FEFDAF0176
00000000001CF6B8 return to x64bridge.000007FEE9F566CE from nvd3d9wrapx.000007FEFA355845
00000000001CF6E8 return to x64dbg.000000013F0B1FD0 from x64bridge.000007FEE9F566CE
00000000001CF748 return to x64dbg.000000013F0B2555 from x64dbg.000000013F0B1FD0
00000000001CF788 return to kernel32.0000000077B659BD from x64dbg.000000013F0B2555
00000000001CF7B8 return to ntdll.0000000077C9A2E1 from kernel32.0000000077B659BD
00000000001CF808 return to 0000000000000000 from ntdll.0000000077C9A2E1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1210)
<!-- Reviewable:end -->
