### PR TITLE
Use HTTPS for Microsoft symbol server URL

### DIFF
--- a/src/dbg/commands/cmd-analysis.cpp
+++ b/src/dbg/commands/cmd-analysis.cpp
@@ -157,7 +157,7 @@ bool cbDebugDownloadSymbol(int argc, char* argv[])
     const char* szSymbolStore = szDefaultStore();
     if(!BridgeSettingGet("Symbols", "DefaultStore", szDefaultStore()))  //get default symbol store from settings
     {
-        strcpy_s(szDefaultStore(), MAX_SETTING_SIZE, "http://msdl.microsoft.com/download/symbols");
+        strcpy_s(szDefaultStore(), MAX_SETTING_SIZE, "https://msdl.microsoft.com/download/symbols");
         BridgeSettingSet("Symbols", "DefaultStore", szDefaultStore());
     }
     if(argc < 2)  //no arguments

--- a/src/dbg/symbolinfo.cpp
+++ b/src/dbg/symbolinfo.cpp
@@ -145,7 +145,7 @@ void SymDownloadAllSymbols(const char* SymbolStore)
 {
     // Default to Microsoft's symbol server
     if(!SymbolStore)
-        SymbolStore = "http://msdl.microsoft.com/download/symbols";
+        SymbolStore = "https://msdl.microsoft.com/download/symbols";
 
     // Build the vector of modules
     std::vector<SYMBOLMODULEINFO> modList;

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -258,7 +258,7 @@ void SettingsDialog::LoadSettings()
         ui->editSymbolStore->setText(QString(setting));
     else
     {
-        QString defaultStore("http://msdl.microsoft.com/download/symbols");
+        QString defaultStore("https://msdl.microsoft.com/download/symbols");
         ui->editSymbolStore->setText(defaultStore);
         BridgeSettingSet("Symbols", "DefaultStore", defaultStore.toUtf8().constData());
     }


### PR DESCRIPTION
Update Microsoft symbol server URL to https://msdl.microsoft.com/download/symbols. This is the default sympath in WinDbg 10.0.14321.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1300)
<!-- Reviewable:end -->
