### PR TITLE
Intercept more functions for crashdumps

### DIFF
--- a/src/exe/crashdump.h
+++ b/src/exe/crashdump.h
@@ -4,3 +4,4 @@ void CrashDumpInitialize();
 LONG CALLBACK CrashDumpExceptionHandler(EXCEPTION_POINTERS* ExceptionInfo);
 void InvalidParameterHandler(const wchar_t* Expression, const wchar_t* Function, const wchar_t* File, unsigned int Line, uintptr_t Reserved);
 void TerminateHandler();
+void AbortHandler(int Signal);


### PR DESCRIPTION
This should fix scenarios like #1311 where the crashdump has missing stack information (making it useless for me). I think it's related to FASTFAIL/Windows 10, but not really sure.

It does *not* fix 1311 though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1338)
<!-- Reviewable:end -->
