### PR TITLE
optimized logging speed

### DIFF
--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -374,7 +374,7 @@ void StdTable::copyLineToLogSlot()
             finalText += "\r\n";
         }
     }
-    emit Bridge::getBridge()->addMsgToLog(finalText);
+    emit Bridge::getBridge()->addMsgToLog(finalText.toUtf8().constData());
 }
 
 QString StdTable::copyTable(const std::vector<int> & colWidths)
@@ -443,7 +443,7 @@ void StdTable::copyTableToLogSlot()
     int colCount = getColumnCount();
     for(int i = 0; i < colCount; i++)
         colWidths.push_back(getColumnWidth(i) / getCharWidth());
-    emit Bridge::getBridge()->addMsgToLog(copyTable(colWidths));
+    emit Bridge::getBridge()->addMsgToLog(copyTable(colWidths).toUtf8().constData());
 }
 
 void StdTable::copyTableResizeSlot()
@@ -473,7 +473,7 @@ void StdTable::copyTableResizeToLogSlot()
             max = std::max(getCellContent(j, i).length(), max);
         colWidths.push_back(max);
     }
-    emit Bridge::getBridge()->addMsgToLog(copyTable(colWidths));
+    emit Bridge::getBridge()->addMsgToLog(copyTable(colWidths).toUtf8().constData());
 }
 
 void StdTable::copyEntrySlot()

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -94,7 +94,7 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         break;
 
     case GUI_ADD_MSG_TO_LOG:
-        emit addMsgToLog(QString((const char*)param1));
+        emit addMsgToLog((const char*)param1); //Speed up performance: don't convert to UCS-2 QString
         break;
 
     case GUI_CLEAR_LOG:

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -45,7 +45,7 @@ signals:
     void disassembleAt(dsint va, dsint eip);
     void repaintGui();
     void dbgStateChanged(DBGSTATE state);
-    void addMsgToLog(QString msg);
+    void addMsgToLog(const char* msg);
     void clearLog();
     void close();
     void updateRegisters();

--- a/src/gui/Src/Gui/LogStatusLabel.cpp
+++ b/src/gui/Src/Gui/LogStatusLabel.cpp
@@ -8,7 +8,7 @@ LogStatusLabel::LogStatusLabel(QStatusBar* parent) : QLabel(parent)
 
     this->setTextFormat(Qt::PlainText);
     setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
-    connect(Bridge::getBridge(), SIGNAL(addMsgToLog(QString)), this, SLOT(logUpdate(QString)));
+    connect(Bridge::getBridge(), SIGNAL(addMsgToLog(const char*)), this, SLOT(logUpdateUtf8(const char*)));
     connect(Bridge::getBridge(), SIGNAL(addMsgToStatusBar(QString)), this, SLOT(logUpdate(QString)));
     connect(Bridge::getBridge(), SIGNAL(getActiveView(ACTIVEVIEW*)), this, SLOT(getActiveView(ACTIVEVIEW*)));
     connect(QApplication::instance(), SIGNAL(focusChanged(QWidget*, QWidget*)), this, SLOT(focusChanged(QWidget*, QWidget*)));
@@ -16,6 +16,7 @@ LogStatusLabel::LogStatusLabel(QStatusBar* parent) : QLabel(parent)
 
 void LogStatusLabel::logUpdate(QString message)
 {
+    //TODO: This subroutine can be optimized
     if(!message.length())
         return;
     labelText += message.replace("\r\n", "\n");
@@ -32,6 +33,11 @@ void LogStatusLabel::logUpdate(QString message)
         }
     }
     setText(finalLabel);
+}
+
+void LogStatusLabel::logUpdateUtf8(const char* message)
+{
+    logUpdate(QString::fromUtf8(message));
 }
 
 void LogStatusLabel::focusChanged(QWidget* old, QWidget* now)

--- a/src/gui/Src/Gui/LogStatusLabel.h
+++ b/src/gui/Src/Gui/LogStatusLabel.h
@@ -13,6 +13,7 @@ public:
 
 public slots:
     void logUpdate(QString message);
+    void logUpdateUtf8(const char* message);
     void focusChanged(QWidget* old, QWidget* now);
     void getActiveView(ACTIVEVIEW* active);
 

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -218,7 +218,7 @@ void LogView::addMsgToLogSlot(const char* msg)
     if(!loggingEnabled)
         return;
     static unsigned char counter = 100;
-    counter++;
+    counter--;
     if(counter == 0)
     {
         if(this->document()->characterCount() > 10000 * 100) //limit the log to ~100mb
@@ -242,14 +242,11 @@ void LogView::addMsgToLogSlot(const char* msg)
         msgUtf16.replace(QString("\r\n"), QString("<br/>\n"));
     }
     linkify(msgUtf16);
+    QTextCursor cursor = this->textCursor();
+    cursor.movePosition(QTextCursor::End);
+    cursor.insertHtml(msgUtf16);
     if(autoScroll)
-        this->insertHtml(msgUtf16); // This sets the cursor to the end for the next insert
-    else
-    {
-        QTextCursor cursor = this->textCursor();
-        cursor.movePosition(QTextCursor::End);
-        cursor.insertHtml(msgUtf16);
-    }
+        this->moveCursor(QTextCursor::End);
 }
 
 /**

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -244,6 +244,8 @@ void LogView::addMsgToLogSlot(const char* msg)
     linkify(msgUtf16);
     QTextCursor cursor = this->textCursor();
     cursor.movePosition(QTextCursor::End);
+    if(redirectError)
+        msgUtf16 += tr("fwrite() failed (GetLastError()= %1 ). Log redirection stopped.\n").arg(GetLastError());
     cursor.insertHtml(msgUtf16);
     if(autoScroll)
         this->moveCursor(QTextCursor::End);

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -22,7 +22,7 @@ LogView::LogView(QWidget* parent) : QTextBrowser(parent), logRedirection(NULL)
 
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(updateStyle()));
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(updateStyle()));
-    connect(Bridge::getBridge(), SIGNAL(addMsgToLog(QString)), this, SLOT(addMsgToLogSlot(QString)));
+    connect(Bridge::getBridge(), SIGNAL(addMsgToLog(const char*)), this, SLOT(addMsgToLogSlot(const char*)));
     connect(Bridge::getBridge(), SIGNAL(clearLog()), this, SLOT(clearLogSlot()));
     connect(Bridge::getBridge(), SIGNAL(setLogEnabled(bool)), this, SLOT(setLoggingEnabled(bool)));
     connect(this, SIGNAL(anchorClicked(QUrl)), this, SLOT(onAnchorClicked(QUrl)));
@@ -150,7 +150,7 @@ static void linkify(QString & msg)
  * @brief LogView::addMsgToLogSlot Adds a message to the log view. This function is a slot for Bridge::addMsgToLog.
  * @param msg The log message
  */
-void LogView::addMsgToLogSlot(QString msg)
+void LogView::addMsgToLogSlot(const char* msg)
 {
     /*
      * This supports the 'UTF-8 Everywhere' manifesto.
@@ -160,39 +160,96 @@ void LogView::addMsgToLogSlot(QString msg)
      */
 
     // fix Unix-style line endings.
-    msg.replace("\r\n", "\n");
     // redirect the log
+    QString msgUtf16;
+    bool redirectError = false;
     if(logRedirection != NULL)
     {
         if(utf16Redirect)
-            msg.replace("\n", "\r\n");
-        msg.utf16();
-        auto data = utf16Redirect ? QByteArray((const char*)msg.utf16(), msg.size() * 2) : msg.toUtf8();
-        if(!fwrite(data.constData(), data.size(), 1, logRedirection))
         {
-            fclose(logRedirection);
-            logRedirection = NULL;
-            msg += tr("fwrite() failed (GetLastError()= %1 ). Log redirection stopped.\n").arg(GetLastError());
+            msgUtf16 = QString::fromUtf8(msg);
+            msgUtf16.replace("\n", "\r\n");
+            if(!fwrite(msgUtf16.utf16(), msgUtf16.length(), 2, logRedirection))
+            {
+                fclose(logRedirection);
+                logRedirection = NULL;
+                //msg += tr("fwrite() failed (GetLastError()= %1 ). Log redirection stopped.\n").arg(GetLastError());
+                redirectError = true;
+            }
+        }
+        else
+        {
+            const char* data;
+            std::string temp;
+            size_t offset = 0;
+            size_t buffersize = 0;
+            if(strstr(msg, "\r\n") != nullptr) // Don't replace "\r\n" to "\n" if there is none
+            {
+                temp = msg;
+                while(true)
+                {
+                    size_t index = temp.find("\r\n", offset);
+                    if(index == std::string::npos)
+                        break;
+                    temp.erase(index);
+                    offset = index;
+                }
+                data = temp.c_str();
+                buffersize = temp.size();
+            }
+            else
+            {
+                data = msg;
+                buffersize = strlen(msg);
+            }
+            if(!fwrite(data, buffersize, 1, logRedirection))
+            {
+                fclose(logRedirection);
+                logRedirection = NULL;
+                //msg += tr("fwrite() failed (GetLastError()= %1 ). Log redirection stopped.\n").arg(GetLastError());
+                redirectError = true;
+            }
+            if(loggingEnabled)
+                msgUtf16 = QString::fromUtf8(data, buffersize);
         }
     }
+    else
+        msgUtf16 = QString::fromUtf8(msg);
     if(!loggingEnabled)
         return;
-    if(this->document()->characterCount() > 10000 * 100) //limit the log to ~100mb
-        this->clear();
-    // This sets the cursor to the end for the next insert
-    QTextCursor cursor = this->textCursor();
-    cursor.movePosition(QTextCursor::End);
+    static unsigned char counter = 100;
+    counter++;
+    if(counter == 0)
+    {
+        if(this->document()->characterCount() > 10000 * 100) //limit the log to ~100mb
+            this->clear();
+        counter = 100;
+    }
+    msgUtf16.replace(QChar('&'), QString("&amp;"));
+    msgUtf16.replace(QChar(' '), QString("&nbsp;"));
+    msgUtf16.replace(QChar('<'), QString("&lt;"));
+    msgUtf16.replace(QChar('>'), QString("&gt;"));
+    if(logRedirection)
+    {
+        if(utf16Redirect)
+            msgUtf16.replace(QString("\r\n"), QString("<br/>\n"));
+        else
+            msgUtf16.replace(QChar('\n'), QString("<br/>\n"));
+    }
+    else
+    {
+        msgUtf16.replace(QChar('\n'), QString("<br/>\n"));
+        msgUtf16.replace(QString("\r\n"), QString("<br/>\n"));
+    }
+    linkify(msgUtf16);
     if(autoScroll)
-        this->moveCursor(QTextCursor::End);
-    if(utf16Redirect)
-        msg.replace("\r\n", "\n");
-    msg.replace(QChar('&'), QString("&amp;"));
-    msg.replace(QChar('<'), QString("&lt;"));
-    msg.replace(QChar('>'), QString("&gt;"));
-    msg.replace(QString("\n"), QString("<br/>\n"));
-    msg.replace(QChar(' '), QString("&nbsp;"));
-    linkify(msg);
-    cursor.insertHtml(msg);
+        this->insertHtml(msgUtf16); // This sets the cursor to the end for the next insert
+    else
+    {
+        QTextCursor cursor = this->textCursor();
+        cursor.movePosition(QTextCursor::End);
+        cursor.insertHtml(msgUtf16);
+    }
 }
 
 /**
@@ -350,5 +407,5 @@ void LogView::pasteSlot()
         return;
     if(!clipboardText.endsWith('\n'))
         clipboardText.append('\n');
-    addMsgToLogSlot(clipboardText);
+    addMsgToLogSlot(clipboardText.toUtf8().constData());
 }

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -16,7 +16,7 @@ public:
 public slots:
     void refreshShortcutsSlot();
     void updateStyle();
-    void addMsgToLogSlot(QString msg);
+    void addMsgToLogSlot(const char* msg);
     void redirectLogSlot();
     void setLoggingEnabled(bool enabled);
     void autoScrollSlot();


### PR DESCRIPTION
Test script:
```
log "Start Performance Testing"
mov $perf,GetTickCount()
mov $i,0x4000
looping:
log {$i}
log {$i*2}
mov $i,$i-1
test $i,$i
jnz looping
nop
nop
mov $perf1,GetTickCount()-$perf
mov $perf,$perf1
log "Performance Testing Finished!Performance: {u:$perf}"
```

Test is conducted by monitoring the user CPU time of the GUI thread of x64dbg before and after running above script. $pref is not sync with GUI updates so it cannot be used. Results:

Old, UTF-8, Log Enabled: 6.9888448
Old, UTF-8, Log Disabled: 1.1388073
Old, UTF-16, Log Enabled: 6.0060385
Old, UTF-16, Log Disabled: 0.312002
New, UTF-8, Log Enabled: 4.6644299 (-33.3%)
New, UTF-8, Log Disabled: 0.3900025 (-65.8%)
New, UTF-16, Log Enabled: 5.1012327 (-15.1%)
New, UTF-16, Log Disabled: 0.1092007 (-65%)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1354)
<!-- Reviewable:end -->
