### PR TITLE
Extend Follow in Disassembler button in Calculator window

### DIFF
--- a/src/gui/Src/Gui/CalculatorDialog.ui
+++ b/src/gui/Src/Gui/CalculatorDialog.ui
@@ -28,7 +28,7 @@
     <rect>
      <x>10</x>
      <y>240</y>
-     <width>141</width>
+     <width>181</width>
      <height>23</height>
     </rect>
    </property>
@@ -223,7 +223,7 @@
   <widget class="QPushButton" name="btnGotoDump">
    <property name="geometry">
     <rect>
-     <x>160</x>
+     <x>200</x>
      <y>240</y>
      <width>141</width>
      <height>23</height>


### PR DESCRIPTION
In default theme there is no problem:

![dev](https://cloud.githubusercontent.com/assets/2598963/21002461/a193eab6-bd2e-11e6-9e23-1da9bbcab10a.png)

In other themes(like dark theme) the problem reappears:

![dark_theme](https://cloud.githubusercontent.com/assets/2598963/21002491/d2b8e286-bd2e-11e6-8b19-7d824bcaae5f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1356)
<!-- Reviewable:end -->
