### PR TITLE
#1312 disable exinfo on exceptions

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -899,6 +899,7 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
         bSkipInt3Stepping = settingboolget("Engine", "SkipInt3Stepping");
         bIgnoreInconsistentBreakpoints = settingboolget("Engine", "IgnoreInconsistentBreakpoints");
         bNoForegroundWindow = settingboolget("Gui", "NoForegroundWindow");
+        bVerboseExceptionLogging = settingboolget("Engine", "VerboseExceptionLogging");
         stackupdatesettings();
 
         duint setting;

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -194,6 +194,7 @@ bool bTraceRecordEnabledDuringTrace = true;
 bool bSkipInt3Stepping = false;
 bool bIgnoreInconsistentBreakpoints = false;
 bool bNoForegroundWindow = false;
+bool bVerboseExceptionLogging = true;
 duint DbgEvents = 0;
 
 static duint dbgcleartracestate()
@@ -1877,7 +1878,8 @@ static void cbException(EXCEPTION_DEBUG_INFO* ExceptionData)
             }
         }
     }
-    DbgCmdExecDirect("exinfo"); //show extended exception information
+    if(bVerboseExceptionLogging)
+        DbgCmdExecDirect("exinfo"); //show extended exception information
     auto exceptionName = ExceptionCodeToName(ExceptionCode);
     if(!exceptionName.size())  //if no exception was found, try the error codes (RPC_S_*)
         exceptionName = ErrorCodeToName(ExceptionCode);

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -147,5 +147,6 @@ extern bool bTraceRecordEnabledDuringTrace;
 extern bool bSkipInt3Stepping;
 extern bool bIgnoreInconsistentBreakpoints;
 extern bool bNoForegroundWindow;
+extern bool bVerboseExceptionLogging;
 
 #endif // _DEBUGGER_H

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -61,6 +61,7 @@ void SettingsDialog::LoadSettings()
     settings.engineIgnoreInconsistentBreakpoints = false;
     settings.engineMaxTraceCount = 50000;
     settings.engineHardcoreThreadSwitchWarning = false;
+    settings.engineVerboseExceptionLogging = true;
     settings.exceptionRanges = &realExceptionRanges;
     settings.disasmArgumentSpaces = false;
     settings.disasmMemorySpaces = false;
@@ -126,6 +127,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Engine", "NoScriptTimeout", &settings.engineNoScriptTimeout);
     GetSettingBool("Engine", "IgnoreInconsistentBreakpoints", &settings.engineIgnoreInconsistentBreakpoints);
     GetSettingBool("Engine", "HardcoreThreadSwitchWarning", &settings.engineHardcoreThreadSwitchWarning);
+    GetSettingBool("Engine", "VerboseExceptionLogging", &settings.engineVerboseExceptionLogging);
     if(BridgeSettingGetUint("Engine", "MaxTraceCount", &cur))
         settings.engineMaxTraceCount = int(cur);
     switch(settings.engineCalcType)
@@ -159,6 +161,7 @@ void SettingsDialog::LoadSettings()
     ui->chkNoScriptTimeout->setChecked(settings.engineNoScriptTimeout);
     ui->chkIgnoreInconsistentBreakpoints->setChecked(settings.engineIgnoreInconsistentBreakpoints);
     ui->chkHardcoreThreadSwitchWarning->setChecked(settings.engineHardcoreThreadSwitchWarning);
+    ui->chkVerboseExceptionLogging->setChecked(settings.engineVerboseExceptionLogging);
     ui->spinMaxTraceCount->setValue(settings.engineMaxTraceCount);
 
     //Exceptions tab
@@ -302,6 +305,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Engine", "NoScriptTimeout", settings.engineNoScriptTimeout);
     BridgeSettingSetUint("Engine", "IgnoreInconsistentBreakpoints", settings.engineIgnoreInconsistentBreakpoints);
     BridgeSettingSetUint("Engine", "MaxTraceCount", settings.engineMaxTraceCount);
+    BridgeSettingSetUint("Engine", "VerboseExceptionLogging", settings.engineVerboseExceptionLogging);
     BridgeSettingSetUint("Engine", "HardcoreThreadSwitchWarning", settings.engineHardcoreThreadSwitchWarning);
 
     //Exceptions tab
@@ -576,6 +580,11 @@ void SettingsDialog::on_chkEnableDebugPrivilege_stateChanged(int arg1)
 void SettingsDialog::on_chkHardcoreThreadSwitchWarning_toggled(bool checked)
 {
     settings.engineHardcoreThreadSwitchWarning = checked;
+}
+
+void SettingsDialog::on_chkVerboseExceptionLogging_toggled(bool checked)
+{
+    settings.engineVerboseExceptionLogging = checked;
 }
 
 void SettingsDialog::on_chkEnableSourceDebugging_stateChanged(int arg1)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -54,6 +54,7 @@ private slots:
     void on_chkNoScriptTimeout_stateChanged(int arg1);
     void on_chkIgnoreInconsistentBreakpoints_toggled(bool checked);
     void on_chkHardcoreThreadSwitchWarning_toggled(bool checked);
+    void on_chkVerboseExceptionLogging_toggled(bool checked);
     void on_spinMaxTraceCount_valueChanged(int arg1);
     //Exception tab
     void on_btnAddRange_clicked();
@@ -138,6 +139,7 @@ private:
         bool engineNoScriptTimeout;
         bool engineIgnoreInconsistentBreakpoints;
         bool engineHardcoreThreadSwitchWarning;
+        bool engineVerboseExceptionLogging;
         int engineMaxTraceCount;
         //Exception Tab
         QList<RangeStruct>* exceptionRanges;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>381</width>
-    <height>484</height>
+    <height>508</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,7 +33,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabEvents">
       <attribute name="title">

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>381</width>
-    <height>445</height>
+    <height>484</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,7 +33,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabEvents">
       <attribute name="title">
@@ -314,6 +314,13 @@
         <widget class="QCheckBox" name="chkHardcoreThreadSwitchWarning">
          <property name="text">
           <string>Log If the Thread Has Switched</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="chkVerboseExceptionLogging">
+         <property name="text">
+          <string>Enable Verbose Exception Logging</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
fixes #1312

Added an engine setting, "Enable Verbose Exception Logging", which determines if the exinfo command is executed in the exception callback.  Enabled by default.

![preview](https://cloud.githubusercontent.com/assets/18407097/21008855/95732ce6-bd11-11e6-81d1-5a4e3bb16073.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1358)
<!-- Reviewable:end -->
