### PR TITLE
added extra info prints for access violation exceptions for the exinfo command

### DIFF
--- a/src/dbg/commands/cmd-analysis.cpp
+++ b/src/dbg/commands/cmd-analysis.cpp
@@ -418,15 +418,20 @@ bool cbInstrExinfo(int argc, char* argv[])
     else
         dprintf_untranslated("        ExceptionAddress: %p\n", record.ExceptionAddress);
     dprintf_untranslated("        NumberParameters: %u\n", record.NumberParameters);
-    if(record.NumberParameters)
-        for(DWORD i = 0; i < record.NumberParameters; i++)
-        {
-            symbolic = SymGetSymbolicName(duint(record.ExceptionInformation[i]));
-            if(symbolic.length())
-                dprintf_untranslated("ExceptionInformation[%02u]: %p %s\n", i, record.ExceptionInformation[i], symbolic.c_str());
-            else
-                dprintf_untranslated("ExceptionInformation[%02u]: %p\n", i, record.ExceptionInformation[i]);
-        }
+    if(record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
+    {
+        if(record.ExceptionInformation[0] == 0)
+            dputs_untranslated("           OperationType: MEM READ\n");
+        else if(record.ExceptionInformation[0] == 1)
+            dputs_untranslated("           OperationType: MEM WRITE\n");
+        else if(record.ExceptionInformation[0] == 8)
+            dputs_untranslated("           OperationType: DEP VIOLATION\n");
+        symbolic = SymGetSymbolicName(duint(record.ExceptionInformation[1]));
+        if(symbolic.length())
+            dprintf_untranslated("     InaccessibleAddress: %p %s\n", record.ExceptionInformation[1], symbolic.c_str());
+        else
+            dprintf_untranslated("     InaccessibleAddress: %p\n", record.ExceptionInformation[1]);
+    }
     return true;
 }
 

--- a/src/dbg/commands/cmd-analysis.cpp
+++ b/src/dbg/commands/cmd-analysis.cpp
@@ -418,20 +418,30 @@ bool cbInstrExinfo(int argc, char* argv[])
     else
         dprintf_untranslated("        ExceptionAddress: %p\n", record.ExceptionAddress);
     dprintf_untranslated("        NumberParameters: %u\n", record.NumberParameters);
-    if(record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
-    {
-        if(record.ExceptionInformation[0] == 0)
-            dputs_untranslated("           OperationType: MEM READ\n");
-        else if(record.ExceptionInformation[0] == 1)
-            dputs_untranslated("           OperationType: MEM WRITE\n");
-        else if(record.ExceptionInformation[0] == 8)
-            dputs_untranslated("           OperationType: DEP VIOLATION\n");
-        symbolic = SymGetSymbolicName(duint(record.ExceptionInformation[1]));
-        if(symbolic.length())
-            dprintf_untranslated("     InaccessibleAddress: %p %s\n", record.ExceptionInformation[1], symbolic.c_str());
-        else
-            dprintf_untranslated("     InaccessibleAddress: %p\n", record.ExceptionInformation[1]);
-    }
+    if(record.NumberParameters)
+        for(DWORD i = 0; i < record.NumberParameters; i++)
+        {
+            symbolic = SymGetSymbolicName(duint(record.ExceptionInformation[i]));
+            if(symbolic.length())
+                dprintf_untranslated("ExceptionInformation[%02u]: %p %s", i, record.ExceptionInformation[i], symbolic.c_str());
+            else
+                dprintf_untranslated("ExceptionInformation[%02u]: %p", i, record.ExceptionInformation[i]);
+            if(record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
+            {
+                if(i == 0)
+                {
+                    if(record.ExceptionInformation[i] == 0)
+                        dprintf_untranslated(" MEM READ");
+                    else if(record.ExceptionInformation[i] == 1)
+                        dprintf_untranslated(" MEM WRITE");
+                    else if(record.ExceptionInformation[i] == 8)
+                        dprintf_untranslated(" DEP VIOLATION");
+                }
+                else if(i == 1)
+                    dprintf_untranslated(" Inaccessible Address");
+            }
+            dprintf_untranslated("\n");
+        }
     return true;
 }
 


### PR DESCRIPTION
resolves #1331 

I removed the current ExceptionInformation logging code, but it may be a good idea to have some handling for undocumented use of this var.  What do you think?

preview for each access violation case:

![access_violation_preview](https://cloud.githubusercontent.com/assets/18407097/21073651/9c4b6edc-beb2-11e6-9799-7b0c0a40c17d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1361)
<!-- Reviewable:end -->
