### PR TITLE
Highlight segment register from reg view

### DIFF
--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -21,7 +21,7 @@ namespace Keystone
     static char* stristr(const char* haystack, const char* needle)
     {
         // Case insensitive strstr
-        // http://stackoverflow.com/questions/27303062/strstr-function-like-that-ignores-upper-or-lower-case
+        // https://stackoverflow.com/questions/27303062/strstr-function-like-that-ignores-upper-or-lower-case
         do
         {
             const char* h = haystack;

--- a/src/dbg/disasm_helper.cpp
+++ b/src/dbg/disasm_helper.cpp
@@ -296,6 +296,7 @@ static bool isasciistring(const unsigned char* data, int maxlen)
 
 static bool isunicodestring(const unsigned char* data, int maxlen)
 {
+
     int len = 0;
     for(wchar_t* p = (wchar_t*)data; *p; len++, p++)
     {
@@ -305,6 +306,7 @@ static bool isunicodestring(const unsigned char* data, int maxlen)
 
     if(len < 2 || len + 1 >= maxlen)
         return false;
+    /*
     for(int i = 0; i < len * 2; i += 2)
     {
         if(data[i + 1]) //Extended ASCII only
@@ -312,7 +314,10 @@ static bool isunicodestring(const unsigned char* data, int maxlen)
         if(!isprint(data[i]) && !isspace(data[i]))
             return false;
     }
-    return true;
+    */
+    INT options = IS_TEXT_UNICODE_ASCII16;
+    BOOL ok = IsTextUnicode(data, maxlen, &options);
+    return ok != FALSE;
 }
 
 bool disasmispossiblestring(duint addr)
@@ -364,12 +369,9 @@ bool disasmgetstringat(duint addr, STRING_TYPE* type, char* ascii, char* unicode
         // Determine string length only once, limited to output buffer size
         int unicodeLength = min(int(wcslen(unicodeData)), maxlen);
 
-        // Truncate each wchar_t to char
-        for(int i = 0; i < unicodeLength; i++)
-            asciiData[i] = char(unicodeData[i] & 0xFF);
-
-        // Fix the null terminator (data len = maxlen + 1)
-        asciiData[unicodeLength] = '\0';
+        // Convert UTF-16 string to UTF-8
+        std::string asciiData2 = StringUtils::Utf16ToUtf8((const wchar_t*)data());
+        memcpy(asciiData, asciiData2.c_str(), min((maxlen + 1) * 2, asciiData2.size() + 1));
 
         // Escape the string
         String escaped = StringUtils::Escape(asciiData);

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -5,7 +5,7 @@
 
 std::unordered_map<String, ExpressionFunctions::Function> ExpressionFunctions::mFunctions;
 
-//Copied from http://stackoverflow.com/a/7858971/1806760
+//Copied from https://stackoverflow.com/a/7858971/1806760
 template<int...>
 struct seq {};
 

--- a/src/dbg/stringutils.cpp
+++ b/src/dbg/stringutils.cpp
@@ -61,12 +61,95 @@ String StringUtils::Escape(unsigned char ch)
     }
 }
 
+static int IsValidUTF8Char(const char* data, int size)
+{
+    if(*(unsigned char*)data >= 0xF8) //5 or 6 bytes
+        return 0;
+    else if(*(unsigned char*)data >= 0xF0) //4 bytes
+    {
+        if(size < 4)
+            return 0;
+        for(int i = 1; i <= 3; i++)
+        {
+            if((*(unsigned char*)(data + i) & 0xC0) != 0x80)
+                return 0;
+        }
+        return 4;
+    }
+    else if(*(unsigned char*)data >= 0xE0) //3 bytes
+    {
+        if(size < 3)
+            return 0;
+        for(int i = 1; i <= 2; i++)
+        {
+            if((*(unsigned char*)(data + i) & 0xC0) != 0x80)
+                return 0;
+        }
+        return 3;
+    }
+    else if(*(unsigned char*)data >= 0xC0) //2 bytes
+    {
+        if(size < 2)
+            return 0;
+        if((*(unsigned char*)(data + 1) & 0xC0) != 0x80)
+            return 0;
+        return 2;
+    }
+    else if(*(unsigned char*)data >= 0x80) // BAD
+        return 0;
+    else
+        return 1;
+}
+
 String StringUtils::Escape(const String & s)
 {
-    String escaped;
+    std::string escaped;
     escaped.reserve(s.length() + s.length() / 2);
     for(size_t i = 0; i < s.length(); i++)
-        escaped.append(Escape((unsigned char)s[i]));
+    {
+        char buf[8];
+        memset(buf, 0, sizeof(buf));
+        unsigned char ch = (unsigned char)s[i];
+        switch(ch)
+        {
+        case '\0':
+            memcpy(buf, "\\0", 2);
+            break;
+        case '\t':
+            memcpy(buf, "\\t", 2);
+            break;
+        case '\f':
+            memcpy(buf, "\\f", 2);
+            break;
+        case '\v':
+            memcpy(buf, "\\v", 2);
+            break;
+        case '\n':
+            memcpy(buf, "\\n", 2);
+            break;
+        case '\r':
+            memcpy(buf, "\\r", 2);
+            break;
+        case '\\':
+            memcpy(buf, "\\\\", 2);
+            break;
+        case '\"':
+            memcpy(buf, "\\\"", 2);
+            break;
+        default:
+            int UTF8CharSize;
+            if(ch >= 0x80 && (UTF8CharSize = IsValidUTF8Char(s.c_str() + i, s.length() - i)) != 0) //UTF-8 Character is emitted directly
+            {
+                memcpy(buf, s.c_str() + i, UTF8CharSize);
+                i += UTF8CharSize - 1;
+            }
+            else if(!isprint(ch))  //unknown unprintable character
+                sprintf_s(buf, "\\x%02X", ch);
+            else
+                *buf = ch;
+        }
+        escaped.append(buf);
+    }
     return escaped;
 }
 
@@ -151,7 +234,7 @@ bool StringUtils::Unescape(const String & s, String & result, bool quoted)
     return true;
 }
 
-//Trim functions taken from: http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring/16743707#16743707
+//Trim functions taken from: https://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring/16743707#16743707
 const String StringUtils::WHITESPACE = " \n\r\t";
 
 String StringUtils::Trim(const String & s, const String & delim)
@@ -219,7 +302,7 @@ WString StringUtils::Utf8ToUtf16(const char* str)
     return Utf8ToUtf16(str ? String(str) : String());
 }
 
-//Taken from: http://stackoverflow.com/a/24315631
+//Taken from: https://stackoverflow.com/a/24315631
 void StringUtils::ReplaceAll(String & s, const String & from, const String & to)
 {
     size_t start_pos = 0;

--- a/src/dbg/undocumented.h
+++ b/src/dbg/undocumented.h
@@ -216,7 +216,7 @@ typedef struct _TEB
     PVOID                   StackReserved;
 } TEB, *PTEB;
 
-// http://stackoverflow.com/questions/36961152/detect-windows-kit-8-0-and-windows-kit-8-1-sdks
+// https://stackoverflow.com/questions/36961152/detect-windows-kit-8-0-and-windows-kit-8-1-sdks
 #if defined(WINAPI_PARTITION_APP)
 #if (WINAPI_PARTITION_APP == 0x00000002)
 #define USING_WINDOWS_8_0_SDK

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -1295,7 +1295,7 @@ bool valapifromstring(const char* name, duint* value, int* value_size, bool prin
     if(!value || !DbgIsDebugging())
         return false;
     //explicit API handling
-    const char* apiname = strchr(name, ':'); //the ':' character cannot be in a path: http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions
+    const char* apiname = strchr(name, ':'); //the ':' character cannot be in a path: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions
     bool noexports = false;
     if(!apiname) //not found
     {

--- a/src/dbg/x64dbg_dbg.vcxproj
+++ b/src/dbg/x64dbg_dbg.vcxproj
@@ -151,6 +151,7 @@
     <ClInclude Include="bookmark.h" />
     <ClInclude Include="breakpoint.h" />
     <ClInclude Include="btparser\btparser\ast.h" />
+    <ClInclude Include="btparser\btparser\helpers.h" />
     <ClInclude Include="btparser\btparser\keywords.h" />
     <ClInclude Include="btparser\btparser\lexer.h" />
     <ClInclude Include="btparser\btparser\operators.h" />

--- a/src/dbg/x64dbg_dbg.vcxproj.filters
+++ b/src/dbg/x64dbg_dbg.vcxproj.filters
@@ -943,5 +943,8 @@
     <ClInclude Include="btparser\btparser\parser.h">
       <Filter>Header Files\btparser</Filter>
     </ClInclude>
+    <ClInclude Include="btparser\btparser\helpers.h">
+      <Filter>Header Files\btparser</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/gui/Src/Gui/AppearanceDialog.cpp
+++ b/src/gui/Src/Gui/AppearanceDialog.cpp
@@ -703,6 +703,7 @@ void AppearanceDialog::on_fontAbstractTablesStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -719,6 +720,7 @@ void AppearanceDialog::on_fontAbstractTablesSize_currentIndexChanged(const QStri
     QString id = "AbstractTableView";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -731,6 +733,7 @@ void AppearanceDialog::on_fontDisassembly_currentFontChanged(const QFont & f)
     QString id = "Disassembly";
     QFont font = fontMap->find(id).value();
     font.setFamily(f.family());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -744,6 +747,7 @@ void AppearanceDialog::on_fontDisassemblyStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -760,6 +764,7 @@ void AppearanceDialog::on_fontDisassemblySize_currentIndexChanged(const QString 
     QString id = "Disassembly";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -772,6 +777,7 @@ void AppearanceDialog::on_fontHexDump_currentFontChanged(const QFont & f)
     QString id = "HexDump";
     QFont font = fontMap->find(id).value();
     font.setFamily(f.family());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -785,6 +791,7 @@ void AppearanceDialog::on_fontHexDumpStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -801,6 +808,7 @@ void AppearanceDialog::on_fontHexDumpSize_currentIndexChanged(const QString & ar
     QString id = "HexDump";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -813,6 +821,7 @@ void AppearanceDialog::on_fontStack_currentFontChanged(const QFont & f)
     QString id = "Stack";
     QFont font = fontMap->find(id).value();
     font.setFamily(f.family());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -826,6 +835,7 @@ void AppearanceDialog::on_fontStackStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -842,6 +852,7 @@ void AppearanceDialog::on_fontStackSize_currentIndexChanged(const QString & arg1
     QString id = "Stack";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -854,6 +865,7 @@ void AppearanceDialog::on_fontRegisters_currentFontChanged(const QFont & f)
     QString id = "Registers";
     QFont font = fontMap->find(id).value();
     font.setFamily(f.family());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -867,6 +879,7 @@ void AppearanceDialog::on_fontRegistersStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -883,6 +896,7 @@ void AppearanceDialog::on_fontRegistersSize_currentIndexChanged(const QString & 
     QString id = "Registers";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -895,6 +909,7 @@ void AppearanceDialog::on_fontHexEdit_currentFontChanged(const QFont & f)
     QString id = "HexEdit";
     QFont font = fontMap->find(id).value();
     font.setFamily(f.family());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -908,6 +923,7 @@ void AppearanceDialog::on_fontHexEditStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -924,6 +940,7 @@ void AppearanceDialog::on_fontHexEditSize_currentIndexChanged(const QString & ar
     QString id = "HexEdit";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -936,6 +953,7 @@ void AppearanceDialog::on_fontLog_currentFontChanged(const QFont & f)
     QString id = "Log";
     QFont font = fontMap->find(id).value();
     font.setFamily(f.family());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;
@@ -949,6 +967,7 @@ void AppearanceDialog::on_fontLogStyle_currentIndexChanged(int index)
     QFont font = fontMap->find(id).value();
     font.setBold(false);
     font.setItalic(false);
+    font.setKerning(false);
     if(index == 1 || index == 3)
         font.setBold(true);
     if(index == 2 || index == 3)
@@ -965,6 +984,7 @@ void AppearanceDialog::on_fontLogSize_currentIndexChanged(const QString & arg1)
     QString id = "Log";
     QFont font = fontMap->find(id).value();
     font.setPointSize(arg1.toInt());
+    font.setKerning(false);
     (*fontMap)[id] = font;
     if(isInit)
         return;

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -60,7 +60,7 @@ BreakpointsView::BreakpointsView(QWidget* parent) : QWidget(parent)
     mMemBPTable->loadColumnFromConfig("MemoryBreakpoint");
 
     // DLL
-    mDLLBPTable = new BreakpointsViewTable(this);
+    mDLLBPTable = new StdTable(this);
     mDLLBPTable->setWindowTitle("DllBreakpoints");
     mDLLBPTable->setContextMenuPolicy(Qt::CustomContextMenu);
     mDLLBPTable->addColumnAt(8 + wCharWidth * 32, tr("Name"), false);
@@ -74,7 +74,7 @@ BreakpointsView::BreakpointsView(QWidget* parent) : QWidget(parent)
     mDLLBPTable->loadColumnFromConfig("DLLBreakpoint");
 
     // Exception
-    mExceptionBPTable = new BreakpointsViewTable(this);
+    mExceptionBPTable = new StdTable(this);
     mExceptionBPTable->setWindowTitle("ExceptionBreakpoints");
     mExceptionBPTable->setContextMenuPolicy(Qt::CustomContextMenu);
     mExceptionBPTable->addColumnAt(8 + wCharWidth * 2 * sizeof(duint), tr("Exception Code"), false);

--- a/src/gui/Src/Gui/BreakpointsView.h
+++ b/src/gui/Src/Gui/BreakpointsView.h
@@ -87,11 +87,11 @@ public slots:
 private:
     QVBoxLayout* mVertLayout;
     LabeledSplitter* mSplitter;
-    BreakpointsViewTable* mHardBPTable;
-    BreakpointsViewTable* mSoftBPTable;
-    BreakpointsViewTable* mMemBPTable;
-    BreakpointsViewTable* mDLLBPTable;
-    BreakpointsViewTable* mExceptionBPTable;
+    StdTable* mHardBPTable;
+    StdTable* mSoftBPTable;
+    StdTable* mMemBPTable;
+    StdTable* mDLLBPTable;
+    StdTable* mExceptionBPTable;
     // Conditional BP Context Menu
     BPXTYPE mCurrentType;
     QAction* mEditBreakpointAction;

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -187,16 +187,16 @@ void CPUInfoBox::disasmSelectionChanged(dsint parVA)
             switch(memsize)
             {
             case size_byte:
-                sizeName = "byte ";
+                sizeName = "byte ptr";
                 break;
             case size_word:
-                sizeName = "word ";
+                sizeName = "word ptr";
                 break;
             case size_dword:
-                sizeName = "dword ";
+                sizeName = "dword ptr";
                 break;
             case size_qword:
-                sizeName = "qword ";
+                sizeName = "qword ptr";
                 break;
             }
 

--- a/src/gui/Src/Gui/EditFloatRegister.ui
+++ b/src/gui/Src/Gui/EditFloatRegister.ui
@@ -227,7 +227,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>0-1</string>
+          <string>10-11</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -243,7 +243,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>2-3</string>
+          <string>12-13</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -259,7 +259,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>4-5</string>
+          <string>14-15</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -275,7 +275,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>6-7</string>
+          <string>16-17</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -291,7 +291,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>8-9</string>
+          <string>18-19</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -307,7 +307,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>A-B</string>
+          <string>1A-1B</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -323,7 +323,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>C-D</string>
+          <string>1C-1D</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -339,7 +339,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>E-F</string>
+          <string>1E-1F</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -2635,10 +2635,7 @@ void RegistersView::onPushAction()
 {
     duint csp = (* ((duint*) registerValue(&wRegDumpStruct, CSP))) - sizeof(void*);
     duint regVal = 0;
-    if(mSEGMENTREGISTER.contains(mSelected))
-        regVal = * ((unsigned short*) registerValue(&wRegDumpStruct, mSelected));
-    else
-        regVal = * ((duint*) registerValue(&wRegDumpStruct, mSelected));
+    regVal = * ((duint*) registerValue(&wRegDumpStruct, mSelected));
     setRegister(CSP, csp);
     DbgMemWrite(csp, (const unsigned char*)&regVal , sizeof(void*));
 }
@@ -2649,8 +2646,6 @@ void RegistersView::onPopAction()
     duint newVal;
     DbgMemRead(csp, (unsigned char*)&newVal, sizeof(void*));
     setRegister(CSP, csp + sizeof(void*));
-    if(mSEGMENTREGISTER.contains(mSelected))
-        newVal &= 0xFFFF;
     setRegister(mSelected, newVal);
 }
 
@@ -2714,6 +2709,8 @@ void RegistersView::onHighlightSlot()
     Disassembly* CPUDisassemblyView = mParent->getDisasmWidget();
     if(mGPR.contains(mSelected) && mSelected != REGISTER_NAME::EFLAGS)
         CPUDisassemblyView->hightlightToken(CapstoneTokenizer::SingleToken(CapstoneTokenizer::TokenType::GeneralRegister, mRegisterMapping.constFind(mSelected).value()));
+    else if(mSEGMENTREGISTER.contains(mSelected))
+        CPUDisassemblyView->hightlightToken(CapstoneTokenizer::SingleToken(CapstoneTokenizer::TokenType::MemorySegment, mRegisterMapping.constFind(mSelected).value()));
     else if(mFPUMMX.contains(mSelected))
         CPUDisassemblyView->hightlightToken(CapstoneTokenizer::SingleToken(CapstoneTokenizer::TokenType::MmxRegister, mRegisterMapping.constFind(mSelected).value()));
     else if(mFPUXMM.contains(mSelected))
@@ -3048,7 +3045,7 @@ void RegistersView::displayCustomContextMenuSlot(QPoint pos)
                 wMenu.addAction(wCM_CopySymbolToClipboard);
         }
 
-        if((mGPR.contains(mSelected) && mSelected != REGISTER_NAME::EFLAGS) || mFPUMMX.contains(mSelected) || mFPUXMM.contains(mSelected) || mFPUYMM.contains(mSelected))
+        if((mGPR.contains(mSelected) && mSelected != REGISTER_NAME::EFLAGS) || mSEGMENTREGISTER.contains(mSelected) || mFPUMMX.contains(mSelected) || mFPUXMM.contains(mSelected) || mFPUYMM.contains(mSelected))
         {
             wMenu.addAction(wCM_Highlight);
         }
@@ -3085,7 +3082,7 @@ void RegistersView::displayCustomContextMenuSlot(QPoint pos)
             wMenu.addAction(wCM_DecrementPtrSize);
         }
 
-        if(mGPR.contains(mSelected) || mSEGMENTREGISTER.contains(mSelected) || mSelected == CIP)
+        if(mGPR.contains(mSelected) || mSelected == CIP)
         {
             wMenu.addAction(wCM_Push);
             wMenu.addAction(wCM_Pop);


### PR DESCRIPTION
*  Highlight segment register from reg view, and remove push/pop segment register to/from the stack.
*  Disable font kerning to make the width of text and the background of it consistent with variable-width font
*  Changed some BreakpointViewTable back to StdTable because they does not contain a memory address.
*  info box: change "dword[eax]" to "dword ptr[eax]"
*  Edit floating point register: correctly label byte offset of high part, from 0x10 to 0x1F
*  Use IsTextUnicode, although the behaviour is still the same. It is now possible to write a plugin that hooks IsTextUnicode to support better Unicode text detection. And do not escape or corrupt valid UTF-8 character. It is now possible to display Unicode text in the auto comment without corruption or escape if IsTextUnicode detects Unicode text.
*  Fix missing btparser file "helpers.h" in the project.
*  Use secure website

In fact the look of x64dbg is almost the same as previous, despite so many changes in DBG and GUI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1376)
<!-- Reviewable:end -->
