### PR TITLE
fix incorrectly restored page protection for cross-boundary memory reads

### DIFF
--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -301,53 +301,33 @@ bool MemRead(duint BaseAddress, void* Buffer, duint Size, duint* NumberOfBytesRe
     if(!NumberOfBytesRead)
         NumberOfBytesRead = &bytesReadTemp;
 
-    // Check that we aren't reading memory that spans multiple memory regions
-    MEMORY_BASIC_INFORMATION mbi;
-    if(!VirtualQueryEx(fdProcessInfo->hProcess, (LPVOID)BaseAddress, &mbi, sizeof(mbi)))
-        return false;
-
-    const duint regionEnd = (duint)mbi.BaseAddress + mbi.RegionSize - 1;
-
-    // Adjust read size so that it's contained in one memory region
-    if(BaseAddress + Size > regionEnd)
-        Size = regionEnd - BaseAddress;
+    // Determine the number of pages the requested read spans
+    const SIZE_T pageCount = BYTES_TO_PAGES(BaseAddress % PAGE_SIZE + Size);
 
     // Normal single-call read
-    bool ret = MemoryReadSafe(fdProcessInfo->hProcess, (LPVOID)BaseAddress, Buffer, Size, NumberOfBytesRead);
+    if(pageCount == 1)
+        return MemoryReadSafe(fdProcessInfo->hProcess, (LPVOID)BaseAddress, Buffer, Size, NumberOfBytesRead);
 
-    if(ret && *NumberOfBytesRead == Size)
-        return true;
+    // Read page-by-page
+    // Determine the number of bytes between ADDRESS and the next page
+    duint offset = 0;
+    duint readBase = BaseAddress;
+    duint readSize = ROUND_TO_PAGES(readBase) - readBase;
 
-    // Read page-by-page (Skip if only 1 page exists)
-    // If (SIZE > PAGE_SIZE) or (ADDRESS exceeds boundary), multiple reads will be needed
-    SIZE_T pageCount = BYTES_TO_PAGES(Size);
-
-    if(pageCount > 1)
+    for(SIZE_T i = 0; i < pageCount; i++)
     {
-        // Determine the number of bytes between ADDRESS and the next page
-        duint offset = 0;
-        duint readBase = BaseAddress;
-        duint readSize = ROUND_TO_PAGES(readBase) - readBase;
+        SIZE_T bytesRead = 0;
 
-        // Reset the bytes read count
-        *NumberOfBytesRead = 0;
+        if(MemoryReadSafe(fdProcessInfo->hProcess, (PVOID)readBase, ((PBYTE)Buffer + offset), readSize, &bytesRead))
+            *NumberOfBytesRead += bytesRead;
 
-        for(SIZE_T i = 0; i < pageCount; i++)
-        {
-            SIZE_T bytesRead = 0;
+        offset += readSize;
+        readBase += readSize;
 
-            if(MemoryReadSafe(fdProcessInfo->hProcess, (PVOID)readBase, ((PBYTE)Buffer + offset), readSize, &bytesRead))
-                *NumberOfBytesRead += bytesRead;
-
-            offset += readSize;
-            readBase += readSize;
-
-            Size -= readSize;
-            readSize = min(PAGE_SIZE, Size);
-        }
+        Size -= readSize;
+        readSize = min(PAGE_SIZE, Size);
     }
 
-    SetLastError(ERROR_PARTIAL_COPY);
     return (*NumberOfBytesRead > 0);
 }
 


### PR DESCRIPTION
fixes #1374

To debug this I hooked NtProtectVirtualMemory in x64dbg using an injected dll.  All VirtualProtectEx calls (excluding the call in MemSetPageRights which isn't executed) followed this chain:
<pre>
x64dbg.dll!MemRead
TitanEngine.dll!MemoryReadSafe
    - ReadProcessMemory
    if this fails
        - VirtualProtectEx PAGE_EXECUTE_READWRITE
        - ReadProcessMemory
        - VirtualProtectEx oldprot
</pre>

This is the hook output when viewing the noaccess page region boundary from the [POC repo](https://github.com/changeofpace/x64dbg-Anti-Debug-POC).  '>' denotes a print before a call to the original NtProtectVirtualMemory, '<' is after:

<pre>
000000013F150000  0000000000001000  x64dbg anti-debug poc.exe                                IMG  -R---
000000013F151000  0000000000009000   ".text"                     Executable code             IMG  ER---
000000013F15A000  0000000000001000   ".text"                     Executable code             IMG  -----
000000013F15B000  0000000000007000   ".text"                     Executable code             IMG  ER---
</pre>

<pre>
# adjust protection so ReadProcessMemory succeeds
146   > base=000000013F159FE2 #bytes=00000040 new=0040
146   < base=000000013F159000 #bytes=00002000 new=0040 old=0020

# restore original protection
147   > base=000000013F159FE2 #bytes=00000040 new=0020
147   < base=000000013F159000 #bytes=00002000 new=0020 old=0080
</pre>

The kernel is adjusting the size arg from x40 to x2000 because the memory read request crosses a memory region boundary.  This is expected behavior according to msdn's definition of VirtualProtectEx.  The protection of both regions are set to PAGE_EXECUTE_READWRITE which causes the debugger to view them as one region.  The PAGE_NOACCESS region isn't restored because the boundary no longer exists after the first VirtualProtectEx call.

While debugging I found other instances of cross-boundary reads.  GUI stack updates do not check region boundaries so memory reads spill into unmapped memory regions.  This is fixed by the VirtualQueryEx check.

Restricting memory reads to one region seems to be the correct solution.

---

I found two potential bugs with TitanEngine while writing this.

1.  MemoryReadSafe should use PAGE_EXECUTE_READ instead of PAGE_EXECUTE_READWRITE to prevent weird PAGE_EXECUTE_WRITECOPY behavior.

2.  The return value for the second call to VirtualProtectEx in MemoryReadSafe isn't checked which could be exploitable if it fails.

    <pre>
    if(!ReadProcessMemory(hProcess, lpBaseAddress, lpBuffer, nSize, pNumBytes))
    {
        if(VirtualProtectEx(hProcess, lpBaseAddress, nSize, PAGE_EXECUTE_READWRITE, &dwProtect))
        {
            if(ReadProcessMemory(hProcess, lpBaseAddress, lpBuffer, nSize, pNumBytes))
            {
                retValue = true;
            }
            VirtualProtectEx(hProcess, lpBaseAddress, nSize, dwProtect, &dwProtect);
        }
    }
    </pre>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1406)
<!-- Reviewable:end -->
