### PR TITLE
initialize fallbackCookie to zero in MemInitRemoteProcessCookie

### DIFF
--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -708,6 +708,9 @@ bool MemDecodePointer(duint* Pointer, bool vistaPlus)
 
 void MemInitRemoteProcessCookie()
 {
+    // Clear previous session's cookie
+    fallbackCookie = 0;
+
     // Windows XP/Vista/7 are unable to obtain remote process cookies using NtQueryInformationProcess
     // Guess the cookie by brute-forcing all possible hashes and validate it using known encodings
     duint RtlpUnhandledExceptionFilter = 0;


### PR DESCRIPTION
fixed a bug where fallbackCookie would use a previous session's process cookie if MemInitRemoteProcessCookie failed before the brute-force loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1418)
<!-- Reviewable:end -->
