### PR TITLE
Preserve horizontal spacing in log messages.

### DIFF
--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -229,6 +229,7 @@ void LogView::addMsgToLogSlot(QByteArray msg)
         counter = 100;
     }
     msgUtf16 = msgUtf16.toHtmlEscaped();
+    msgUtf16.replace(QChar(' '), QString("&nbsp;"));
     if(logRedirection)
     {
         if(utf16Redirect)


### PR DESCRIPTION
Reverted a change to LogView::addMsgToLogSlot because QString::toHtmlEscaped does not convert spaces to &nbsp.

https://github.com/qt/qtbase/blob/dev/src/corelib/tools/qstring.cpp#L10760

ref: https://github.com/x64dbg/x64dbg/commit/e295f56c9c74c247618cb1160f5397169521ac27#diff-b6006fbcabfc49bd593d76e5984c4610L232

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1439)
<!-- Reviewable:end -->
