### PR TITLE
Do not add breakpoint if SetBPX fails.

### DIFF
--- a/src/dbg/commands/cmd-breakpoint-control.cpp
+++ b/src/dbg/commands/cmd-breakpoint-control.cpp
@@ -123,17 +123,21 @@ bool cbDebugSetBPX(int argc, char* argv[]) //bp addr [,name [,type]]
         dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (memread)\n"), addr);
         return false;
     }
-    if(!SetBPX(addr, type, (void*)cbUserBreakpoint))
-    {
-        if(!MemIsValidReadPtr(addr))
-            return true;
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (SetBPX)\n"), addr);
-        return false;
-    }
     if(!BpNew(addr, true, singleshoot, oldbytes, BPNORMAL, type, bpname))
     {
         dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (bpnew)\n"), addr);
         return false;
+    }
+    if(!SetBPX(addr, type, (void*)cbUserBreakpoint))
+    {
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (SetBPX)\n"), addr);
+        if(!BpDelete(addr, BPNORMAL))
+            dprintf(QT_TRANSLATE_NOOP("DBG", "Error handling invalid breakpoint at %p! (bpdel)\n"), addr);
+        return false;
+        //if(!MemIsValidReadPtr(addr))
+        //    return true;
+        //dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (SetBPX)\n"), addr);
+        //return false;
     }
     GuiUpdateAllViews();
     dprintf(QT_TRANSLATE_NOOP("DBG", "Breakpoint at %p set!\n"), addr);

--- a/src/dbg/commands/cmd-breakpoint-control.cpp
+++ b/src/dbg/commands/cmd-breakpoint-control.cpp
@@ -134,10 +134,6 @@ bool cbDebugSetBPX(int argc, char* argv[]) //bp addr [,name [,type]]
         if(!BpDelete(addr, BPNORMAL))
             dprintf(QT_TRANSLATE_NOOP("DBG", "Error handling invalid breakpoint at %p! (bpdel)\n"), addr);
         return false;
-        //if(!MemIsValidReadPtr(addr))
-        //    return true;
-        //dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (SetBPX)\n"), addr);
-        //return false;
     }
     GuiUpdateAllViews();
     dprintf(QT_TRANSLATE_NOOP("DBG", "Breakpoint at %p set!\n"), addr);

--- a/src/dbg/commands/cmd-breakpoint-control.cpp
+++ b/src/dbg/commands/cmd-breakpoint-control.cpp
@@ -123,12 +123,6 @@ bool cbDebugSetBPX(int argc, char* argv[]) //bp addr [,name [,type]]
         dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (memread)\n"), addr);
         return false;
     }
-    if(!BpNew(addr, true, singleshoot, oldbytes, BPNORMAL, type, bpname))
-    {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (bpnew)\n"), addr);
-        return false;
-    }
-    GuiUpdateAllViews();
     if(!SetBPX(addr, type, (void*)cbUserBreakpoint))
     {
         if(!MemIsValidReadPtr(addr))
@@ -136,6 +130,12 @@ bool cbDebugSetBPX(int argc, char* argv[]) //bp addr [,name [,type]]
         dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (SetBPX)\n"), addr);
         return false;
     }
+    if(!BpNew(addr, true, singleshoot, oldbytes, BPNORMAL, type, bpname))
+    {
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Error setting breakpoint at %p! (bpnew)\n"), addr);
+        return false;
+    }
+    GuiUpdateAllViews();
     dprintf(QT_TRANSLATE_NOOP("DBG", "Breakpoint at %p set!\n"), addr);
     return true;
 }


### PR DESCRIPTION
Normal breakpoints are not removed if SetBPX fails in cbDebugSetBPX.  The invalid breakpoint appears in the breakpoint tab and is highlighted in the disassembly view:

attempting to set the bp:
![invalid_bp_1](https://cloud.githubusercontent.com/assets/18407097/22810278/bfa917ac-ef05-11e6-9cf4-d1d11c3fbe0d.png)

removing the bp:
![invalid_bp_2](https://cloud.githubusercontent.com/assets/18407097/22810280/c0b6b35c-ef05-11e6-93a4-f9af3af98ff8.png)


I removed the MemIsValidReadPtr check because BpAdd will fail if MemIsValidReadPtr(addr) is false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1460)
<!-- Reviewable:end -->
