### PR TITLE
Add wait reason to threads list

### DIFF
--- a/src/dbg/thread.h
+++ b/src/dbg/thread.h
@@ -18,7 +18,7 @@ bool ThreadGetTib(duint TEBAddress, NT_TIB* Tib);
 bool ThreadGetTeb(duint TEBAddress, TEB* Teb);
 int ThreadGetSuspendCount(HANDLE Thread);
 THREADPRIORITY ThreadGetPriority(HANDLE Thread);
-THREADWAITREASON ThreadGetWaitReason(HANDLE Thread);
+bool ThreadGetWaitReasons(THREADLIST* List);
 DWORD ThreadGetLastErrorTEB(ULONG_PTR ThreadLocalBase);
 DWORD ThreadGetLastError(DWORD ThreadId);
 bool ThreadSetName(DWORD dwThreadId, const char* name);

--- a/src/dbg/undocumented.h
+++ b/src/dbg/undocumented.h
@@ -6,6 +6,8 @@
 //Thanks to: https://github.com/zer0fl4g/Nanomite
 
 typedef LONG NTSTATUS;
+#define NT_SUCCESS(Status) ((NTSTATUS)(Status) >= 0)
+#define STATUS_INFO_LENGTH_MISMATCH 0xC0000004
 
 typedef struct _UNICODE_STRING
 {
@@ -240,5 +242,60 @@ typedef struct _EXCEPTION_REGISTRATION_RECORD
     _EXCEPTION_DISPOSITION Handler;
 } EXCEPTION_REGISTRATION_RECORD, *PEXCEPTION_REGISTRATION_RECORD;
 #endif
+
+typedef struct _SYSTEM_THREAD_INFORMATION
+{
+    LARGE_INTEGER KernelTime;
+    LARGE_INTEGER UserTime;
+    LARGE_INTEGER CreateTime;
+    ULONG WaitTime;
+    PVOID StartAddress;
+    CLIENT_ID ClientId;
+    LONG Priority;
+    LONG BasePriority;
+    ULONG ContextSwitches;
+    ULONG ThreadState;
+    ULONG WaitReason;
+} SYSTEM_THREAD_INFORMATION, *PSYSTEM_THREAD_INFORMATION;
+
+typedef struct _SYSTEM_PROCESS_INFORMATION
+{
+    ULONG NextEntryOffset;
+    ULONG NumberOfThreads;
+    LARGE_INTEGER SpareLi1;
+    LARGE_INTEGER SpareLi2;
+    LARGE_INTEGER SpareLi3;
+    LARGE_INTEGER CreateTime;
+    LARGE_INTEGER UserTime;
+    LARGE_INTEGER KernelTime;
+    UNICODE_STRING ImageName;
+    LONG BasePriority;
+    HANDLE UniqueProcessId;
+    HANDLE InheritedFromUniqueProcessId;
+    ULONG HandleCount;
+    ULONG SessionId;
+    ULONG_PTR PageDirectoryBase;
+    SIZE_T PeakVirtualSize;
+    SIZE_T VirtualSize;
+    ULONG PageFaultCount;
+    SIZE_T PeakWorkingSetSize;
+    SIZE_T WorkingSetSize;
+    SIZE_T QuotaPeakPagedPoolUsage;
+    SIZE_T QuotaPagedPoolUsage;
+    SIZE_T QuotaPeakNonPagedPoolUsage;
+    SIZE_T QuotaNonPagedPoolUsage;
+    SIZE_T PagefileUsage;
+    SIZE_T PeakPagefileUsage;
+    SIZE_T PrivatePageCount;
+    LARGE_INTEGER ReadOperationCount;
+    LARGE_INTEGER WriteOperationCount;
+    LARGE_INTEGER OtherOperationCount;
+    LARGE_INTEGER ReadTransferCount;
+    LARGE_INTEGER WriteTransferCount;
+    LARGE_INTEGER OtherTransferCount;
+    SYSTEM_THREAD_INFORMATION Threads[1];
+} SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
+
+#define SystemProcessInformation 5 // For use with NtQuerySystemInformation
 
 #endif // _UNDOCUMENTED_H


### PR DESCRIPTION
I noticed threads were always being shown as being in the "executive" wait state, which I found a bit silly because WrExecutive is normally reserved for the kernel. Taking a look at the source I found ThreadGetWaitReason was actually unimplemented :P So that would explain it.

This is an implementation that uses NtQuerySystemInformation(SystemProcessInformation), the only possible way to get the thread wait reason.

It is monstrously inefficient because it gets info on all running processes AND all of their threads (even though we only need one piece of info on one thread). It could be made more efficient by at least caching the results for the whole process so that ThreadGetWaitReason would only have to be called once per process instead of for every thread. But that would require some restructuring of how the thread info is queried right now. There's also no reason to loop over the threads of processes we already know aren't the debuggee, but I found no easy way to get the PID from the THREADALLINFO that ThreadGetList makes. There is GetProcessIdOfThread, but it isn't available on XP. Anyway, even with all this I tested the performance and it came in at under 1 ms per call, so it's actually not too bad. Since the thread list only gets refreshed once per second it should be acceptable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1470)
<!-- Reviewable:end -->
