### PR TITLE
√ Allow hiding local module name for memory addresses in the same page.

### DIFF
--- a/src/gui/Src/Disassembler/capstone_gui.h
+++ b/src/gui/Src/Disassembler/capstone_gui.h
@@ -147,7 +147,7 @@ public:
     bool Tokenize(duint addr, const unsigned char* data, int datasize, InstructionToken & instruction);
     bool TokenizeData(const QString & datatype, const QString & data, InstructionToken & instruction);
     void UpdateConfig();
-    void SetConfig(bool bUppercase, bool bTabbedMnemonic, bool bArgumentSpaces, bool bMemorySpaces, bool bNoHighlightOperands);
+    void SetConfig(bool bUppercase, bool bTabbedMnemonic, bool bArgumentSpaces, bool bMemorySpaces, bool bNoHighlightOperands, bool bNoCurrentModuleText);
     int Size() const;
     const Capstone & GetCapstone() const;
 
@@ -173,6 +173,7 @@ private:
     bool _bArgumentSpaces;
     bool _bMemorySpaces;
     bool _bNoHighlightOperands;
+    bool _bNoCurrentModuleText;
     TokenType _mnemonicType;
 
     void addToken(TokenType type, QString text, const TokenValue & value);

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -69,6 +69,7 @@ void SettingsDialog::LoadSettings()
     settings.disasmUppercase = false;
     settings.disasmOnlyCipAutoComments = false;
     settings.disasmTabBetweenMnemonicAndArguments = false;
+    settings.disasmNoCurrentModuleText = false;
     settings.guiNoForegroundWindow = true;
 
     //Events tab
@@ -194,6 +195,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Disassembler", "TabbedMnemonic", &settings.disasmTabBetweenMnemonicAndArguments);
     GetSettingBool("Disassembler", "NoHighlightOperands", &settings.disasmNoHighlightOperands);
     GetSettingBool("Disassembler", "PermanentHighlightingMode", &settings.disasmPermanentHighlightingMode);
+    GetSettingBool("Disassembler", "NoCurrentModuleText", &settings.disasmNoCurrentModuleText);
     ui->chkArgumentSpaces->setChecked(settings.disasmArgumentSpaces);
     ui->chkMemorySpaces->setChecked(settings.disasmMemorySpaces);
     ui->chkUppercase->setChecked(settings.disasmUppercase);
@@ -201,6 +203,7 @@ void SettingsDialog::LoadSettings()
     ui->chkTabBetweenMnemonicAndArguments->setChecked(settings.disasmTabBetweenMnemonicAndArguments);
     ui->chkNoHighlightOperands->setChecked(settings.disasmNoHighlightOperands);
     ui->chkPermanentHighlightingMode->setChecked(settings.disasmPermanentHighlightingMode);
+    ui->chkNoCurrentModuleText->setChecked(settings.disasmNoCurrentModuleText);
 
     //Gui tab
     GetSettingBool("Gui", "FpuRegistersLittleEndian", &settings.guiFpuRegistersLittleEndian);
@@ -332,6 +335,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Disassembler", "TabbedMnemonic", settings.disasmTabBetweenMnemonicAndArguments);
     BridgeSettingSetUint("Disassembler", "NoHighlightOperands", settings.disasmNoHighlightOperands);
     BridgeSettingSetUint("Disassembler", "PermanentHighlightingMode", settings.disasmPermanentHighlightingMode);
+    BridgeSettingSetUint("Disassembler", "NoCurrentModuleText", settings.disasmNoCurrentModuleText);
 
     //Gui tab
     BridgeSettingSetUint("Gui", "FpuRegistersLittleEndian", settings.guiFpuRegistersLittleEndian);
@@ -769,4 +773,10 @@ void SettingsDialog::on_chkPermanentHighlightingMode_toggled(bool checked)
 void SettingsDialog::on_chkNoWow64SingleStepWorkaround_toggled(bool checked)
 {
     settings.engineNoWow64SingleStepWorkaround = checked;
+}
+
+void SettingsDialog::on_chkNoCurrentModuleText_toggled(bool checked)
+{
+    bTokenizerConfigUpdated = true;
+    settings.disasmNoCurrentModuleText = checked;
 }

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -68,6 +68,7 @@ private slots:
     void on_chkOnlyCipAutoComments_stateChanged(int arg1);
     void on_chkTabBetweenMnemonicAndArguments_stateChanged(int arg1);
     void on_chkNoHighlightOperands_toggled(bool checked);
+    void on_chkNoCurrentModuleText_toggled(bool checked);
     void on_chkPermanentHighlightingMode_toggled(bool checked);
     //Gui Tab
     void on_chkFpuRegistersLittleEndian_stateChanged(int arg1);
@@ -153,6 +154,7 @@ private:
         bool disasmOnlyCipAutoComments;
         bool disasmTabBetweenMnemonicAndArguments;
         bool disasmNoHighlightOperands;
+        bool disasmNoCurrentModuleText;
         bool disasmPermanentHighlightingMode;
         //Gui Tab
         bool guiFpuRegistersLittleEndian;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -518,6 +518,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkNoCurrentModuleText">
+         <property name="text">
+          <string>Hide module name for local memory addresses</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkPermanentHighlightingMode">
          <property name="text">
           <string>Permanent highlighting mode</string>

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -205,6 +205,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     disassemblyBool.insert("LongDataInstruction", false);
     disassemblyBool.insert("NoHighlightOperands", false);
     disassemblyBool.insert("PermanentHighlightingMode", false);
+    disassemblyBool.insert("NoCurrentModuleText", false);
     defaultBools.insert("Disassembler", disassemblyBool);
 
     QMap<QString, bool> engineBool;


### PR DESCRIPTION
The user can configure it in the settings dialog to hide module name if the memory address is within the same page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1474)
<!-- Reviewable:end -->
