### PR TITLE
Add support for Clang compilation

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -38,7 +38,7 @@ static bool bDisableGUIUpdate;
     *((FARPROC*)&name)=GetProcAddress(hInst, #name); \
     if(!name) \
     { \
-        wsprintfW(szError, L"Export %s:%s could not be found!", szLib, L#name); \
+        wsprintfW(szError, L"Export %s:%S could not be found!", szLib, #name); \
         return szError; \
     }
 
@@ -1449,7 +1449,7 @@ BRIDGE_IMPEXP void GuiCloseQWidgetTab(void* qWidget)
 
 BRIDGE_IMPEXP void GuiExecuteOnGuiThread(GUICALLBACK cbGuiThread)
 {
-    _gui_sendmessage(GUI_EXECUTE_ON_GUI_THREAD, cbGuiThread, nullptr);
+    _gui_sendmessage(GUI_EXECUTE_ON_GUI_THREAD, (void*)cbGuiThread, nullptr);
 }
 
 BRIDGE_IMPEXP void GuiUpdateTimeWastedCounter()

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -7,9 +7,6 @@
 #include <stdbool.h>
 #endif
 
-//list structure (and C++ wrapper)
-#include "bridgelist.h"
-
 //default structure alignments forced
 #ifdef _WIN64
 #pragma pack(push, 16)
@@ -58,6 +55,9 @@ BRIDGE_IMPEXP int BridgeGetDbgVersion();
 #ifdef __cplusplus
 }
 #endif
+
+//list structure (and C++ wrapper)
+#include "bridgelist.h"
 
 #include "bridgegraph.h"
 

--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -244,7 +244,7 @@ TraceRecordManager::TraceRecordByteType TraceRecordManager::getByteType(duint ad
 
 void TraceRecordManager::increaseInstructionCounter()
 {
-    InterlockedIncrement(&instructionCounter);
+    InterlockedIncrement((volatile long*)&instructionCounter);
 }
 
 void TraceRecordManager::saveToDb(JSON root)

--- a/src/dbg/commands/cmd-general-purpose.cpp
+++ b/src/dbg/commands/cmd-general-purpose.cpp
@@ -4,6 +4,7 @@
 #include "variable.h"
 #include "_scriptapi_stack.h"
 #include "debugger.h"
+#include <intrin.h>
 
 static bool ReadWriteVariable(const char* varname, const std::function<bool(duint*, int)> & callback)
 {

--- a/src/dbg/commands/cmd-thread-control.cpp
+++ b/src/dbg/commands/cmd-thread-control.cpp
@@ -184,7 +184,7 @@ bool cbDebugSetPriority(int argc, char* argv[])
     }
     else
     {
-        switch(priority)  //check if the priority value is valid
+        switch((int)priority)  //check if the priority value is valid
         {
         case THREAD_PRIORITY_NORMAL:
         case THREAD_PRIORITY_ABOVE_NORMAL:

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -134,7 +134,7 @@ void cbRunToUserCodeBreakpoint(void* ExceptionAddress);
 DWORD WINAPI threadAttachLoop(void* lpParameter);
 void cbDetach();
 bool cbSetModuleBreakpoints(const BREAKPOINT* bp);
-EXCEPTION_DEBUG_INFO getLastExceptionInfo();
+EXCEPTION_DEBUG_INFO & getLastExceptionInfo();
 bool dbgrestartadmin();
 void StepIntoWow64(void* traceCallBack);
 bool dbgisdepenabled();

--- a/src/dbg/expressionparser.cpp
+++ b/src/dbg/expressionparser.cpp
@@ -467,7 +467,7 @@ void ExpressionParser::shuntingYard()
     mPrefixTokens = std::move(queue);
 }
 
-#ifdef _WIN64
+#if defined(_WIN64) && (!defined(__clang__) || __clang_major__ > 3) // This produces an ICE under Clang <= 3.8; fixed in 5.0.
 #include <intrin.h>
 
 static unsigned long long umulhi(unsigned long long x, unsigned long long y)

--- a/src/dbg/handles.cpp
+++ b/src/dbg/handles.cpp
@@ -230,11 +230,11 @@ bool HandlesEnumWindows(std::vector<WINDOW_INFO> & windowsList)
     std::vector<WINDOW_INFO> childWindowsList;
     EnumWindows(getWindowInfoCallback, (LPARAM)&windowsList);
     auto i = windowsList.begin();
-    for(auto & i = windowsList.cbegin(); i != windowsList.cend(); i++)
+    for(auto i = windowsList.cbegin(); i != windowsList.cend(); ++i)
     {
         EnumChildWindows((HWND)i->handle, getWindowInfoCallback, (LPARAM)&childWindowsList);
     }
-    for(auto & i = childWindowsList.cbegin(); i != childWindowsList.cend(); i++)
+    for(auto i = childWindowsList.cbegin(); i != childWindowsList.cend(); ++i)
     {
         windowsList.push_back(*i);
     }

--- a/src/dbg/jit.cpp
+++ b/src/dbg/jit.cpp
@@ -140,7 +140,7 @@ bool dbgsetjitauto(bool auto_on, arch arch_in, arch* arch_out, readwritejitkey_e
                 return true;
         }
     }
-    if(!readwritejitkey(auto_on ? L"1" : L"0", &auto_string_size, "Auto", arch_in, arch_out, &rw_error, true))
+    if(!readwritejitkey((wchar_t*)(auto_on ? L"1" : L"0"), &auto_string_size, "Auto", arch_in, arch_out, &rw_error, true))
     {
         if(rw_error_out != NULL)
             *rw_error_out = rw_error;

--- a/src/dbg/memory.h
+++ b/src/dbg/memory.h
@@ -2,25 +2,9 @@
 #define _MEMORY_H
 
 #include "_global.h"
-#include "addrinfo.h"
 #include "patternfind.h"
 
-extern std::map<Range, MEMPAGE, RangeCompare> memoryPages;
-extern bool bListAllPages;
-extern DWORD memMapThreadCounter;
-
-struct SimplePage
-{
-    duint address;
-    duint size;
-
-    SimplePage(duint address, duint size)
-    {
-        this->address = address;
-        this->size = size;
-    }
-};
-
+struct SimplePage;
 void MemUpdateMap();
 void MemUpdateMapAsync();
 duint MemFindBaseAddr(duint Address, duint* Size = nullptr, bool Refresh = false, bool FindReserved = false);
@@ -43,5 +27,23 @@ bool MemFindInPage(const SimplePage & page, duint startoffset, const std::vector
 bool MemFindInMap(const std::vector<SimplePage> & pages, const std::vector<PatternByte> & pattern, std::vector<duint> & results, duint maxresults, bool progress = true);
 bool MemDecodePointer(duint* Pointer, bool vistaPlus);
 void MemInitRemoteProcessCookie();
+
+#include "addrinfo.h"
+
+extern std::map<Range, MEMPAGE, RangeCompare> memoryPages;
+extern bool bListAllPages;
+extern DWORD memMapThreadCounter;
+
+struct SimplePage
+{
+    duint address;
+    duint size;
+
+    SimplePage(duint address, duint size)
+    {
+        this->address = address;
+        this->size = size;
+    }
+};
 
 #endif // _MEMORY_H

--- a/src/dbg/serializablemap.h
+++ b/src/dbg/serializablemap.h
@@ -1,3 +1,6 @@
+#ifndef _SERIALIZABLEMAP_H
+#define _SERIALIZABLEMAP_H
+
 #include "_global.h"
 #include "threading.h"
 #include "module.h"
@@ -303,7 +306,7 @@ struct SerializableModuleHashMap : SerializableUnorderedMap<TLock, duint, TValue
         // 0x00000000 - 0xFFFFFFFF
         if(start == 0 && end == ~0)
         {
-            Clear();
+            this->Clear();
         }
         else
         {
@@ -317,7 +320,7 @@ struct SerializableModuleHashMap : SerializableUnorderedMap<TLock, duint, TValue
             start -= moduleBase;
             end -= moduleBase;
 
-            DeleteWhere([start, end, inRange](const TValue & value)
+            this->DeleteWhere([start, end, inRange](const TValue & value)
             {
                 return inRange(start, end, value);
             });
@@ -344,21 +347,21 @@ struct AddrInfoSerializer : JSONWrapper<TValue>
 
     bool Save(const TValue & value) override
     {
-        setString("module", value.mod());
-        setHex("address", value.addr);
-        setBool("manual", value.manual);
+        this->setString("module", value.mod());
+        this->setHex("address", value.addr);
+        this->setBool("manual", value.manual);
         return true;
     }
 
     bool Load(TValue & value) override
     {
         value.manual = true; //legacy support
-        getBool("manual", value.manual);
+        this->getBool("manual", value.manual);
         std::string mod;
-        if(!getString("module", mod))
+        if(!this->getString("module", mod))
             return false;
         value.modhash = ModHashFromName(mod.c_str());
-        return getHex("address", value.addr);
+        return this->getHex("address", value.addr);
     }
 };
 
@@ -386,7 +389,7 @@ struct AddrInfoHashMap : SerializableModuleHashMap<TLock, TValue, TSerializer>
 
     void DeleteRange(duint start, duint end, bool manual)
     {
-        DeleteRangeWhere(start, end, [manual](duint start, duint end, const TValue & value)
+        this->DeleteRangeWhere(start, end, [manual](duint start, duint end, const TValue & value)
         {
             if(manual ? !value.manual : value.manual)   //ignore non-matching entries
                 return false;
@@ -400,3 +403,5 @@ protected:
         return value.modhash + value.addr;
     }
 };
+
+#endif // _SERIALIZABLEMAP_H

--- a/src/dbg/taskthread.h
+++ b/src/dbg/taskthread.h
@@ -39,19 +39,20 @@ public:
 template <typename F>
 class StringConcatTaskThread_ : public TaskThread_<F, std::string>
 {
-    virtual std::tuple<std::string> CompressArguments(std::string && msg)
+    virtual std::tuple<std::string> CompressArguments(std::string && msg) override
     {
-        std::get<0>(args) += msg;
-        return args;
+        std::get<0>(this->args) += msg;
+        return this->args;
     }
 
     // Reset called after we latch in a value
     void ResetArgs() override
     {
-        std::get<0>(args).resize(0);
+        std::get<0>(this->args).resize(0);
     }
 public:
-    explicit StringConcatTaskThread_(F fn, size_t minSleepTimeMs = TASK_THREAD_DEFAULT_SLEEP_TIME) : TaskThread_(fn, minSleepTimeMs) {}
+    explicit StringConcatTaskThread_(F fn, size_t minSleepTimeMs = TASK_THREAD_DEFAULT_SLEEP_TIME)
+        : TaskThread_<F, std::string>(fn, minSleepTimeMs) {}
 };
 
 // using aliases for cleaner syntax
@@ -78,7 +79,7 @@ template<> struct gen_seq<1> : seq<0> {};
 
 #define DECLTYPE_AND_RETURN( eval ) -> decltype ( eval ) { return eval; }
 
-template<typename F, typename Tuple, size_t ...S>
+template<typename F, typename Tuple, unsigned ...S>
 auto apply_tuple_impl(F && fn, Tuple && t, const seq<S...> &)
 DECLTYPE_AND_RETURN(std::forward<F>(fn)(std::get<S>(std::forward<Tuple>(t))...));
 
@@ -97,31 +98,31 @@ std::tuple<Args...> TaskThread_<F, Args...>::CompressArguments(Args && ... _args
 
 template <typename F, typename... Args> void TaskThread_<F, Args...>::WakeUp(Args... _args)
 {
-    wakeups++;
-    EnterCriticalSection(&access);
-    args = CompressArguments(std::forward<Args>(_args)...);
-    LeaveCriticalSection(&access);
+    ++this->wakeups;
+    EnterCriticalSection(&this->access);
+    this->args = CompressArguments(std::forward<Args>(_args)...);
+    LeaveCriticalSection(&this->access);
     // This will fail silently if it's redundant, which is what we want.
-    ReleaseSemaphore(wakeupSemaphore, 1, nullptr);
+    ReleaseSemaphore(this->wakeupSemaphore, 1, nullptr);
 }
 
 template <typename F, typename... Args> void TaskThread_<F, Args...>::Loop()
 {
     std::tuple<Args...> argLatch;
-    while(active)
+    while(this->active)
     {
-        WaitForSingleObject(wakeupSemaphore, INFINITE);
+        WaitForSingleObject(this->wakeupSemaphore, INFINITE);
 
-        EnterCriticalSection(&access);
-        argLatch = args;
-        ResetArgs();
-        LeaveCriticalSection(&access);
+        EnterCriticalSection(&this->access);
+        argLatch = this->args;
+        this->ResetArgs();
+        LeaveCriticalSection(&this->access);
 
-        if(active)
+        if(this->active)
         {
-            apply_from_tuple(fn, argLatch);
-            std::this_thread::sleep_for(std::chrono::milliseconds(minSleepTimeMs));
-            execs++;
+            apply_from_tuple(this->fn, argLatch);
+            std::this_thread::sleep_for(std::chrono::milliseconds(this->minSleepTimeMs));
+            ++this->execs;
         }
     }
 }
@@ -130,27 +131,27 @@ template <typename F, typename... Args>
 TaskThread_<F, Args...>::TaskThread_(F fn,
                                      size_t minSleepTimeMs) : fn(fn), minSleepTimeMs(minSleepTimeMs)
 {
-    wakeupSemaphore = CreateSemaphoreW(nullptr, 0, 1, nullptr);
-    InitializeCriticalSection(&access);
+    this->wakeupSemaphore = CreateSemaphoreW(nullptr, 0, 1, nullptr);
+    InitializeCriticalSection(&this->access);
 
-    thread = std::thread([this]
+    this->thread = std::thread([this]
     {
-        Loop();
+        this->Loop();
     });
 }
 
 template <typename F, typename... Args>
 TaskThread_<F, Args...>::~TaskThread_()
 {
-    EnterCriticalSection(&access);
-    active = false;
-    LeaveCriticalSection(&access);
-    ReleaseSemaphore(wakeupSemaphore, 1, nullptr);
+    EnterCriticalSection(&this->access);
+    this->active = false;
+    LeaveCriticalSection(&this->access);
+    ReleaseSemaphore(this->wakeupSemaphore, 1, nullptr);
 
-    thread.join(); //TODO: Microsoft C++ exception: std::system_error on exit
+    this->thread.join(); //TODO: Microsoft C++ exception: std::system_error on exit
 
-    DeleteCriticalSection(&access);
-    CloseHandle(wakeupSemaphore);
+    DeleteCriticalSection(&this->access);
+    CloseHandle(this->wakeupSemaphore);
 }
 
 #endif // _TASKTHREAD_H

--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -123,7 +123,7 @@ void WatchClear()
 
 unsigned int WatchAddExprUnlocked(const char* expr, WATCHVARTYPE type)
 {
-    unsigned int newid = InterlockedExchangeAdd(&idCounter, 1);
+    unsigned int newid = InterlockedExchangeAdd((volatile long*)&idCounter, 1);
     char DefaultName[MAX_WATCH_NAME_SIZE];
     sprintf_s(DefaultName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Watch %u")), newid);
     WatchExpr* newWatch = new WatchExpr(DefaultName, expr, type);


### PR DESCRIPTION
This PR makes x64dbg compile and run using Clang/C2 from VS2017. The main goal of this is to add Clang's impressive diagnostics and warnings for additional compile time error checking. (There are a **lot** of warnings currently, but I've kept the changes to the minimum required to get the project to compile.)

Some notes:
- The launcher (x96dbg.exe) still requires MSVC to compile due to the ATL headers being... well, special. I haven't managed to get the project to compile without modifying the ATL headers, which is probably going a bit too far.
- The GUI DLL also requires MSVC, but this is more due to Qt's build system's lack of support for Clang/C2. It could probably be made to work with enough violence (given that Qt does support Clang/LLVM on Windows), but I'm not really interested in this.
- Clang/C2 from VS2015 doesn't work, due to some MS header deficiencies that seem to have been fixed in VS2017.
- Clang with LLVM also works (as in: compiles). I tested this with the Clang 5.0 alpha from SVN. I haven't even tried running the result though as the MSVC and LLVM ABIs are binary incompatible. Getting this to run would require compiling all dependencies including Qt with Clang/LLVM.

Most of the changes are non-functional, such as added type casts and uses of 'this' in virtual template methods. There are some exceptions though:
- `getLastExceptionInfo()` now returns `EXCEPTION_DEBUG_INFO` by reference rather than by value. This is to get the following to work:
```C++
getLastExceptionInfo().ExceptionRecord.ExceptionCode = 0;
```
To be honest I'm not sure how this even compiles in MSVC. It's possible that this only 'works' currently by modifying a local copy, i.e. effectively a no-op.
- `for(auto & i = windowsList.cbegin(); i != windowsList.cend(); i++)`: I've changed this to simply `auto` (i.e. non-reference). I don't feel bad for this as casting an rvalue to a reference this way is a nonstandard MS construct.
- The `LOADEXPORT` macro has been changed to print (in case of error) export names as ANSI strings (with uppercase `%S` specifier) rather than unicode. This is because I couldn't manage to get the Clang preprocessor to create an `L""` type string no matter what. This shouldn't be a problem though as the export names are all already required to be ANSI as they are passed to `GetProcAddress`.

There are also two changes to headers which are technically nonfunctional, but not especially pretty:
- `memory.h` is now laid out in the order function declarations -> `#include "addrinfo.h"` -> `extern`/`SimplePage` declarations. This is because including `addrinfo.h` causes `serializablemap.h` to be included, which in turn depends on some function declarations from `memory.h`. This could be fixed by moving `extern std::map<Range, MEMPAGE, RangeCompare> memoryPages` to `addrinfo.h` and including that separately where this variable is needed.
- `bridgemain.h` similarly has an \#include moved downwards (`bridgelist.h`). This is because `bridgelist.h` depends on the preceding function declarations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1498)
<!-- Reviewable:end -->
