### PR TITLE
Fixed

### DIFF
--- a/src/gui/Src/Gui/CPUArgumentWidget.cpp
+++ b/src/gui/Src/Gui/CPUArgumentWidget.cpp
@@ -38,6 +38,12 @@ CPUArgumentWidget::~CPUArgumentWidget()
     delete ui;
 }
 
+void CPUArgumentWidget::updateStackOffset(bool iscall)
+{
+    const auto & cur = mCallingConventions[mCurrentCallingConvention];
+    mStackOffset = cur.getStackOffset() + (iscall ? 0 : cur.getCallOffset());
+}
+
 void CPUArgumentWidget::disassembledAtSlot(dsint, dsint cip, bool, dsint)
 {
     if(mCurrentCallingConvention == -1) //no calling conventions
@@ -46,12 +52,9 @@ void CPUArgumentWidget::disassembledAtSlot(dsint, dsint cip, bool, dsint)
         mTable->reloadData();
         return;
     }
-
     BASIC_INSTRUCTION_INFO disasm;
     DbgDisasmFastAt(cip, &disasm);
-
-    const auto & cur = mCallingConventions[mCurrentCallingConvention];
-    mStackOffset = cur.getStackOffset() + (disasm.call ? 0 : cur.getCallOffset());
+    updateStackOffset(disasm.call);
     if(ui->checkBoxLock->checkState() == Qt::PartiallyChecked) //Calls
     {
         mAllowUpdate = disasm.call;
@@ -206,14 +209,14 @@ void CPUArgumentWidget::loadConfig()
     CallingConvention x32(tr("Default (stdcall)"), 5);
     mCallingConventions.push_back(x32);
 
-    CallingConvention x32ebp(tr("Default (stdcall, EBP stack)"), 5, "ebp");
+    CallingConvention x32ebp(tr("Default (stdcall, EBP stack)"), 5, "ebp", 8, 0);
     mCallingConventions.push_back(x32ebp);
 
     CallingConvention thiscall(tr("thiscall"), 4);
     thiscall.addArgument(Argument("this", "ecx", ""));
     mCallingConventions.push_back(thiscall);
 
-    CallingConvention fastcall(tr("fastcall"), 5);
+    CallingConvention fastcall(tr("fastcall"), 3);
     fastcall.addArgument(Argument("", "ecx", ""));
     fastcall.addArgument(Argument("", "edx", ""));
     mCallingConventions.push_back(fastcall);
@@ -245,6 +248,11 @@ void CPUArgumentWidget::on_comboCallingConvention_currentIndexChanged(int index)
     mCurrentCallingConvention = index;
     const auto & cur = mCallingConventions[index];
     ui->spinArgCount->setValue(int(cur.arguments.size()) + cur.stackArgCount); //set the default argument count
+    if(!DbgIsDebugging())
+        return;
+    BASIC_INSTRUCTION_INFO disasm;
+    DbgDisasmFastAt(DbgValFromString("CIP"), &disasm);
+    updateStackOffset(disasm.call);
     refreshData();
 }
 
@@ -258,21 +266,21 @@ void CPUArgumentWidget::on_checkBoxLock_stateChanged(int)
 {
     switch(ui->checkBoxLock->checkState())
     {
-    case Qt::Checked:
+    case Qt::Checked: //Locked, update disabled.
         refreshData(); //first refresh then lock
         ui->checkBoxLock->setText(tr("Locked"));
         ui->spinArgCount->setEnabled(false);
         ui->comboCallingConvention->setEnabled(false);
         mAllowUpdate = false;
         break;
-    case Qt::PartiallyChecked:
+    case Qt::PartiallyChecked://Locked, but still update when a call is encountered.
         refreshData(); //first refresh then lock
         ui->checkBoxLock->setText(tr("Calls"));
         ui->spinArgCount->setEnabled(false);
         ui->comboCallingConvention->setEnabled(false);
         mAllowUpdate = false;
         break;
-    case Qt::Unchecked:
+    case Qt::Unchecked://Unlocked, update enabled
         ui->checkBoxLock->setText(tr("Unlocked"));
         ui->spinArgCount->setEnabled(true);
         ui->comboCallingConvention->setEnabled(true);

--- a/src/gui/Src/Gui/CPUArgumentWidget.cpp
+++ b/src/gui/Src/Gui/CPUArgumentWidget.cpp
@@ -16,6 +16,7 @@ CPUArgumentWidget::CPUArgumentWidget(QWidget* parent) :
     setupTable();
     loadConfig();
     refreshData();
+    ui->checkBoxLock->setToolTip(tr("Refresh is automatical."));
 
     mFollowDisasm = new QAction(this);
     connect(mFollowDisasm, SIGNAL(triggered()), this, SLOT(followDisasmSlot()));
@@ -269,6 +270,7 @@ void CPUArgumentWidget::on_checkBoxLock_stateChanged(int)
     case Qt::Checked: //Locked, update disabled.
         refreshData(); //first refresh then lock
         ui->checkBoxLock->setText(tr("Locked"));
+        ui->checkBoxLock->setToolTip(tr("Refresh is disabled."));
         ui->spinArgCount->setEnabled(false);
         ui->comboCallingConvention->setEnabled(false);
         mAllowUpdate = false;
@@ -276,12 +278,14 @@ void CPUArgumentWidget::on_checkBoxLock_stateChanged(int)
     case Qt::PartiallyChecked://Locked, but still update when a call is encountered.
         refreshData(); //first refresh then lock
         ui->checkBoxLock->setText(tr("Calls"));
+        ui->checkBoxLock->setToolTip(tr("Refresh is only done when executing a CALL instruction."));
         ui->spinArgCount->setEnabled(false);
         ui->comboCallingConvention->setEnabled(false);
         mAllowUpdate = false;
         break;
     case Qt::Unchecked://Unlocked, update enabled
         ui->checkBoxLock->setText(tr("Unlocked"));
+        ui->checkBoxLock->setToolTip(tr("Refresh is automatical."));
         ui->spinArgCount->setEnabled(true);
         ui->comboCallingConvention->setEnabled(true);
         mAllowUpdate = true;

--- a/src/gui/Src/Gui/CPUArgumentWidget.h
+++ b/src/gui/Src/Gui/CPUArgumentWidget.h
@@ -150,6 +150,8 @@ private:
 
     void loadConfig();
     void setupTable();
+
+    void updateStackOffset(bool iscall);
 };
 
 #endif // CPUARGUMENTWIDGET_H

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -378,7 +378,7 @@ void CPUDump::mouseDoubleClickEvent(QMouseEvent* event)
     }
 }
 
-static QString getTooltipForVa(duint va)
+static QString getTooltipForVa(duint va, int depth)
 {
     duint ptr = 0;
     if(!DbgMemRead(va, &ptr, sizeof(duint)))
@@ -399,9 +399,9 @@ static QString getTooltipForVa(duint va)
     // Get information about the pointer type
     case enc_unknown:
     default:
-        if(DbgMemIsValidReadPtr(ptr))
+        if(DbgMemIsValidReadPtr(ptr) && depth >= 0)
         {
-            tooltip = QString("[%1] = %2").arg(ToPtrString(ptr), getTooltipForVa(ptr));
+            tooltip = QString("[%1] = %2").arg(ToPtrString(ptr), getTooltipForVa(ptr, depth - 1));
         }
         // If not a pointer, hide tooltips
         else
@@ -484,7 +484,7 @@ void CPUDump::mouseMoveEvent(QMouseEvent* event)
     auto va = rvaToVa(getItemStartingAddress(x, y));
 
     // Read VA
-    QToolTip::showText(event->globalPos(), getTooltipForVa(va), this);
+    QToolTip::showText(event->globalPos(), getTooltipForVa(va, 4), this);
 
     HexDump::mouseMoveEvent(event);
 }

--- a/src/gui/Src/Gui/CPUSideBar.cpp
+++ b/src/gui/Src/Gui/CPUSideBar.cpp
@@ -439,6 +439,7 @@ void CPUSideBar::mouseMoveEvent(QMouseEvent* event)
     if(!DbgIsDebugging() || !mInstrBuffer->size())
     {
         QAbstractScrollArea::mouseMoveEvent(event);
+        setCursor(QCursor(Qt::ArrowCursor));
         return;
     }
 

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1664,7 +1664,11 @@ void RegistersView::mousePressEvent(QMouseEvent* event)
 void RegistersView::mouseMoveEvent(QMouseEvent* event)
 {
     if(!DbgIsDebugging())
+    {
+        QScrollArea::mouseMoveEvent(event);
+        setCursor(QCursor(Qt::ArrowCursor));
         return;
+    }
 
     REGISTER_NAME r = REGISTER_NAME::UNKNOWN;
     QString registerHelpInformation;


### PR DESCRIPTION
1. (CRITICAL BUG) x64dbg crash when mouse hovers over a pointer pointing to itself in the dump.
2. Fixed EBP based calling convention
3. Fixed some small issues with mouse cursor.
4. Added some tooltips about lock modes in arguments widget.

EBP calling convention details:
Memory addresses with arguments will not change whether current instruction is CALL or not. Only change argument address when it executes "mov ebp,esp". It may not work when the debuggee use EBP as a variable, and cannot use "Calls" update strategy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1526)
<!-- Reviewable:end -->
