### PR TITLE
Warn the user about mismatch of database and executable

### DIFF
--- a/src/dbg/database.h
+++ b/src/dbg/database.h
@@ -15,5 +15,6 @@ void DbLoad(DbLoadSaveType loadType, const char* dbfile = nullptr);
 void DbClose();
 void DbClear(bool terminating = false);
 void DbSetPath(const char* Directory, const char* ModulePath);
+bool DbCheckHash(duint currentHash);
 
 #endif // _DATABASE_H

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -31,7 +31,9 @@
 #include "cmd-watch-control.h"
 #include "filemap.h"
 #include "jit.h"
-
+/**
+\brief Conditional tracing structures
+*/
 struct TraceCondition
 {
     ExpressionParser condition;
@@ -217,7 +219,7 @@ private:
     BufferedWriter* logWriter = nullptr;
     bool writeUtf16 = false;
 };
-
+// Debugging variables
 static PROCESS_INFORMATION g_pi = {0, 0, 0, 0};
 static char szBaseFileName[MAX_PATH] = "";
 static TraceState traceState;
@@ -1463,6 +1465,7 @@ static void cbCreateProcess(CREATE_PROCESS_DEBUG_INFO* CreateProcessInfo)
     if(!bFileIsDll && !bIsAttached) //Set entry breakpoint
     {
         pDebuggedBase = pCreateProcessBase; //debugged base = executable
+        DbCheckHash(ModContentHashFromAddr(pDebuggedBase)); //Check hash mismatch
         char command[deflen] = "";
 
         if(settingboolget("Events", "TlsCallbacks"))
@@ -1762,6 +1765,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     {
         bIsDebuggingThis = true;
         pDebuggedBase = (duint)base;
+        DbCheckHash(ModContentHashFromAddr(pDebuggedBase)); //Check hash mismatch
         if(settingboolget("Events", "EntryBreakpoint"))
         {
             bAlreadySetEntry = true;

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -285,6 +285,21 @@ duint ModHashFromAddr(duint Address)
     return module->hash + (Address - module->base);
 }
 
+duint ModContentHashFromAddr(duint Address)
+{
+    SHARED_ACQUIRE(LockModules);
+
+    auto module = ModInfoFromAddr(Address);
+
+    if(!module)
+        return 0;
+
+    if(module->fileMapVA != 0 && module->loadedSize > 0)
+        return murmurhash((void*)module->fileMapVA, module->loadedSize);
+    else
+        return 0;
+}
+
 duint ModHashFromName(const char* Module)
 {
     // return MODINFO.hash (based on the name)

--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -47,6 +47,7 @@ bool ModNameFromAddr(duint Address, char* Name, bool Extension);
 duint ModBaseFromAddr(duint Address);
 duint ModHashFromAddr(duint Address);
 duint ModHashFromName(const char* Module);
+duint ModContentHashFromAddr(duint Address);
 duint ModBaseFromName(const char* Module);
 duint ModSizeFromAddr(duint Address);
 std::string ModNameFromHash(duint Hash);


### PR DESCRIPTION
Prepare for run trace subsystem. This approach reads the hash from the database and compare it to the debuggee when the debuggee is loaded. The reverse is not possible because when debugging a DLL, the database loads before the debuggee loads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1570)
<!-- Reviewable:end -->
