### PR TITLE
highlight modified bytes

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1633,6 +1633,11 @@ BRIDGE_IMPEXP void GuiFlushLog()
     _gui_sendmessage(GUI_FLUSH_LOG, nullptr, nullptr);
 }
 
+BRIDGE_IMPEXP void GuiResumeDebug()
+{
+    _gui_sendmessage(GUI_RESUME_DEBUG, nullptr, nullptr);
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInst = hinstDLL;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1002,6 +1002,7 @@ typedef enum
     GUI_MENU_SET_ENTRY_HOTKEY,      // param1=int hEntry,           param2=const char* hack
     GUI_REF_SEARCH_GETROWCOUNT,     // param1=unused,               param2=unused
     GUI_REF_SEARCH_GETCELLCONTENT,  // param1=int row,              param2=int col
+    GUI_RESUME_DEBUG                // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1174,6 +1175,7 @@ BRIDGE_IMPEXP bool GuiTypeClear();
 BRIDGE_IMPEXP void GuiUpdateTypeWidget();
 BRIDGE_IMPEXP void GuiCloseApplication();
 BRIDGE_IMPEXP void GuiFlushLog();
+BRIDGE_IMPEXP void GuiResumeDebug();
 
 #ifdef __cplusplus
 }

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -38,6 +38,7 @@ bool cbDebugRunInternal(int argc, char* argv[])
         return false;
     dbgsetispausedbyuser(false);
     GuiSetDebugStateAsync(running);
+    GuiResumeDebug();
     unlock(WAITID_RUN);
     PLUG_CB_RESUMEDEBUG callbackInfo;
     callbackInfo.reserved = 0;

--- a/src/gui/Src/BasicView/HexDump.h
+++ b/src/gui/Src/BasicView/HexDump.h
@@ -166,6 +166,8 @@ public slots:
     void copyAddressSlot();
     void copyRvaSlot();
 
+    void updateOldData();
+
 private:
     enum GuiState_t {NoState, MultiRowsSelectionState};
 
@@ -217,6 +219,11 @@ protected:
     QAction* mCopyAddress;
     QAction* mCopyRva;
     QAction* mCopySelection;
+
+    char* mOldData;
+    duint mOldDataBase;
+    size_t mOldDataSize;
+    bool matchOldData(duint addr, void* buffer, size_t size);
 };
 
 #endif // _HEXDUMP_H

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -812,6 +812,12 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         }
     }
     break;
+
+    case GUI_RESUME_DEBUG:
+        BridgeResult result;
+        emit resumeDebug();
+        result.Wait();
+        break;
     }
 
     return nullptr;

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -155,6 +155,7 @@ signals:
     void closeApplication();
     void flushLog();
     void getDumpAttention();
+    void resumeDebug();
 
 private:
     QMutex* mBridgeMutex;


### PR DESCRIPTION
Highlights modified bytes with shadow buffer.

Known issue: The shadow buffer needs to be updated just before the debuggee resumes. Current architecture does not include a semaphore to achieve reliable locking so sometimes the shadow buffer might be updated **after** the debuggee resumes, and contains bytes that are modified. This circumstance might not be very visible if you are looking only at dump1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x64dbg/x64dbg/1580)
<!-- Reviewable:end -->
