### PR TITLE
Fixed issue with detached dumps

### DIFF
--- a/src/gui/Src/Gui/CPUMultiDump.cpp
+++ b/src/gui/Src/Gui/CPUMultiDump.cpp
@@ -61,34 +61,33 @@ CPUDump* CPUMultiDump::getCurrentCPUDump()
     return mCurrentCPUDump;
 }
 
+// Only get tab names for all dump tabs!
 void CPUMultiDump::getTabNames(QList<QString> & names)
 {
-    bool addedDetachedWindows = false;
     names.clear();
-    for(int i = 0; i < count(); i++)
+    int i;
+    int index;
+    // placeholders
+    for(i = 0; i < getMaxCPUTabs(); i++)
+        names.push_back(QString("Dump %1").arg(i + 1));
+    // enumerate all tabs
+    for(i = 0; i < QTabWidget::count(); i++)
     {
         if(!getNativeName(i).startsWith("Dump "))
             continue;
-        // If empty name, then widget is detached
-        if(this->tabBar()->tabText(i).length() == 0)
+        index = getNativeName(i).mid(5).toInt() - 1;
+        if(index < getMaxCPUTabs())
+            names[index] = this->tabBar()->tabText(i);
+    }
+    // enumerate all detached windows
+    for(i = 0; i < windows().count(); i++)
+    {
+        QString nativeName = dynamic_cast<MHDetachedWindow*>(windows()[i]->parent())->mNativeName;
+        if(nativeName.startsWith("Dump "))
         {
-            // If we added all the detached windows once, no need to do it again
-            if(addedDetachedWindows)
-                continue;
-
-            QString windowName;
-            // Loop through all detached widgets
-            for(int n = 0; n < this->windows().size(); n++)
-            {
-                // Get the name and add it to the list
-                windowName = ((MHDetachedWindow*)this->windows().at(n)->parent())->windowTitle();
-                names.push_back(windowName);
-            }
-            addedDetachedWindows = true;
-        }
-        else
-        {
-            names.push_back(this->tabBar()->tabText(i));
+            index = nativeName.mid(5).toInt() - 1;
+            if(index < getMaxCPUTabs())
+                names[index] = dynamic_cast<MHDetachedWindow*>(windows()[i]->parent())->windowTitle();
         }
     }
 }

--- a/src/gui/Src/Gui/CPUWidget.cpp
+++ b/src/gui/Src/Gui/CPUWidget.cpp
@@ -46,7 +46,7 @@ CPUWidget::CPUWidget(QWidget* parent) : QWidget(parent), ui(new Ui::CPUWidget)
     mDump = new CPUMultiDump(mDisas, 5, 0); //dump widget
     ui->mBotLeftFrameLayout->addWidget(mDump);
 
-    mGeneralRegs = new RegistersView(this, mDump);
+    mGeneralRegs = new RegistersView(this);
     mGeneralRegs->setFixedWidth(1000);
     mGeneralRegs->ShowFPU(true);
 

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -108,7 +108,7 @@ public:
     };
 
 
-    explicit RegistersView(CPUWidget* parent, CPUMultiDump* multiDump);
+    explicit RegistersView(CPUWidget* parent);
     ~RegistersView();
 
     QSize sizeHint() const;
@@ -145,7 +145,7 @@ protected:
     char* registerValue(const REGDUMP* regd, const REGISTER_NAME reg);
     bool identifyRegister(const int y, const int x, REGISTER_NAME* clickedReg);
     QString helpRegister(REGISTER_NAME reg);
-    QMenu* CreateDumpNMenu(CPUMultiDump* multiDump);
+    void CreateDumpNMenu(QMenu* dumpMenu);
 
     void displayEditDialog();
 
@@ -256,7 +256,6 @@ private:
     // SIMD registers display mode
     SIMD_REG_DISP_MODE wSIMDRegDispMode;
     // context menu actions
-    QMenu* mFollowInDumpMenu;
     QMenu* mSwitchSIMDDispMode;
     QAction* mFollowInDump;
     QAction* wCM_Increment;

--- a/src/gui/Src/Gui/TabWidget.cpp
+++ b/src/gui/Src/Gui/TabWidget.cpp
@@ -102,6 +102,7 @@ void MHTabWidget::DetachTab(int index, QPoint & dropPoint)
     detachedWidget->setWindowTitle(tabText(index));
     detachedWidget->setWindowIcon(tabIcon(index));
     detachedWidget->mNativeName = mNativeNames[index];
+    mNativeNames.removeAt(index);
 
     // Remove from tab bar
     QWidget* tearOffWidget = widget(index);
@@ -181,13 +182,13 @@ MHTabBar* MHTabWidget::tabBar() const
 
 QString MHTabWidget::getNativeName(int index)
 {
-    if(index < count())
+    if(index < QTabWidget::count())
     {
         return mNativeNames.at(index);
     }
     else
     {
-        MHDetachedWindow* window = dynamic_cast<MHDetachedWindow*>(widget(index)->parent());
+        MHDetachedWindow* window = dynamic_cast<MHDetachedWindow*>(m_Windows.at(index - QTabWidget::count())->parent());
         if(window)
             return window->mNativeName;
         else


### PR DESCRIPTION
Follow in dump N now behaves correctly. Registers view can use the tab name of dump tabs, instead of "Dump n"