### PR TITLE
Small code improvement

### DIFF
--- a/src/dbg/command.cpp
+++ b/src/dbg/command.cpp
@@ -140,7 +140,7 @@ COMMAND* cmdget(const char* cmd)
     strcpy_s(new_cmd, deflen, cmd);
     int len = (int)strlen(new_cmd);
     int start = 0;
-    while(new_cmd[start] != ' ' && start < len)
+    while(start < len && new_cmd[start] != ' ')
         start++;
     new_cmd[start] = 0;
     COMMAND* found = cmdfind(new_cmd, 0);

--- a/src/dbg/stringutils.cpp
+++ b/src/dbg/stringutils.cpp
@@ -368,7 +368,10 @@ String StringUtils::sprintf(_Printf_format_string_ const char* format, ...)
 
     char sbuffer[64] = "";
     if(_vsnprintf_s(sbuffer, _TRUNCATE, format, args) != -1)
+    {
+        va_end(args);
         return sbuffer;
+    }
 
     std::vector<char> buffer(256, '\0');
     while(true)
@@ -393,7 +396,10 @@ WString StringUtils::sprintf(_Printf_format_string_ const wchar_t* format, ...)
 
     wchar_t sbuffer[64] = L"";
     if(_vsnwprintf_s(sbuffer, _TRUNCATE, format, args) != -1)
+    {
+        va_end(args);
         return sbuffer;
+    }
 
     std::vector<wchar_t> buffer(256, L'\0');
     while(true)

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -1894,7 +1894,7 @@ bool valfromstring(const char* string, duint* value, bool silent, bool baseonly,
 static bool longEnough(const char* str, size_t min_length)
 {
     size_t length = 0;
-    while(str[length] && length < min_length)
+    while(length < min_length && str[length])
         length++;
     if(length == min_length)
         return true;

--- a/src/gui/Src/Gui/LocalVarsView.cpp
+++ b/src/gui/Src/Gui/LocalVarsView.cpp
@@ -188,7 +188,7 @@ void LocalVarsView::updateSlot()
             unsigned char* buffer = new unsigned char[end - start + 16];
             if(!DbgMemRead(start, buffer, end - start + 16)) //failed to read memory for analyzing
             {
-                delete buffer;
+                delete[] buffer;
                 setRowCount(0);
                 return;
             }
@@ -234,7 +234,7 @@ void LocalVarsView::updateSlot()
                 }
                 address += dis.Size();
             }
-            delete buffer;
+            delete[] buffer;
             int rows = 0;
             for(int i = 0; i < ArchValue(8, 16); i++)
                 rows += usedOffsets[i].size();


### PR DESCRIPTION
I've found some issues with Cppcheck and prepared this simple patch and list of interesting errors (most of raw results I filtered, e.g. related to a different argument names in header/cpp files).
It could be great if you can review both of it

[src/gui/Src/Gui/DisassemblyPopup.cpp:121]: (warning, inconclusive) Access of moved variable instruction.
[src/gui/Src/BasicView/AbstractTableView.cpp:1137]: (style) Condition 'totalWidth<=this->viewport()->width()' is always true
[src/gui/Src/Gui/CPUStack.cpp:639]: (style) Redundant condition: If 'frame > 0', the comparison 'frame != -1' is always true.
[src/dbg/module.cpp:63]: (error) Using 'memset' on struct that contains a 'std::vector'.
[src/dbg/symbolinfo.cpp:160]: (style, inconclusive) Checking if unsigned variable 'modList.size()' is less than zero. This might be a false warning.


[src/dbg/disasm_helper.cpp:350]: (style) Variable 'unicodeLength' is assigned a value that is never used.
[src/gui/Src/Gui/AssembleDialog.cpp:108]: (style) Variable 'validInstruction' is assigned a value that is never used.
[src/dbg/expressionparser.cpp:505]: (warning) Suspicious code: sign conversion of ~ in calculation, even though ~ can have a negative value
[src/gui/Src/Gui/RegistersView.cpp:1852]: (style) Variable 'isCharacter' is assigned a value that is never used.


[src/dbg/analysis/CodeFollowPass.h:17]: (style) Unused private function: 'CodeFollowPass::GetReferenceOperand'
[src/dbg/analysis/CodeFollowPass.h:18]: (style) Unused private function: 'CodeFollowPass::GetMemoryOperand'
[src/dbg/analysis/FunctionPass.h:30]:   (style) Unused private function: 'FunctionPass::EnumerateFunctionRuntimeEntries64'
[src/gui/Src/Disassembler/capstone_gui.h:187]: (style) Unused private function: 'CapstoneTokenizer::tokenizePrefix'