### PR TITLE
Smooth experience when stepping through breakpoint

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1095,6 +1095,11 @@ void cbStep()
 {
     hActiveThread = ThreadGetHandle(((DEBUG_EVENT*)GetDebugData())->dwThreadId);
     duint CIP = GetContextDataEx(hActiveThread, UE_CIP);
+
+    if(IsBPXEnabled(CIP))
+        return;
+    //TODO: hardware breakpoints
+
     if(!stepRepeat || !--stepRepeat)
     {
         DebugUpdateGuiSetStateAsync(CIP, true);


### PR DESCRIPTION
Don't press step key twice on a breakpoint. This fix can be put in "titanengine".