### PR TITLE
Fix standard conformance issues

### DIFF
--- a/src/gui/Src/Disassembler/QBeaEngine.cpp
+++ b/src/gui/Src/Disassembler/QBeaEngine.cpp
@@ -271,7 +271,7 @@ Instruction_t QBeaEngine::DecodeDataAt(byte_t* data, duint size, duint origBase,
     //tokenize
     CapstoneTokenizer::InstructionToken cap;
 
-    auto & infoIter = dataInstMap.find(type);
+    auto infoIter = dataInstMap.find(type);
     if(infoIter == dataInstMap.end())
         infoIter = dataInstMap.find(enc_byte);
 

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -2065,7 +2065,7 @@ void MainWindow::onMenuCustomized()
         QMenu* currentMenu = menus[i];
         QMenu* moreCommands = nullptr;
         bool moreCommandsUsed = false;
-        QList<QAction*> & list = currentMenu->actions();
+        QList<QAction*> list = currentMenu->actions();
         moreCommands = list.last()->menu();
         if(moreCommands && moreCommands->title().compare(tr("More Commands")) == 0)
         {

--- a/src/gui/Src/Gui/TabWidget.cpp
+++ b/src/gui/Src/Gui/TabWidget.cpp
@@ -89,7 +89,7 @@ void MHTabWidget::AttachTab(QWidget* parent)
 }
 
 // Convert a tab to an external window
-void MHTabWidget::DetachTab(int index, QPoint & dropPoint)
+void MHTabWidget::DetachTab(int index, const QPoint & dropPoint)
 {
     Q_UNUSED(dropPoint);
     // Create the window

--- a/src/gui/Src/Gui/TabWidget.h
+++ b/src/gui/Src/Gui/TabWidget.h
@@ -37,7 +37,7 @@ signals:
 
 public slots:
     void AttachTab(QWidget* parent);
-    void DetachTab(int index, QPoint &);
+    void DetachTab(int index, const QPoint &);
     void MoveTab(int fromIndex, int toIndex);
     void DeleteTab(int index);
     void tabMoved(int from, int to);

--- a/src/gui/Src/Utils/MiscUtil.cpp
+++ b/src/gui/Src/Utils/MiscUtil.cpp
@@ -24,6 +24,18 @@ QByteArray & ByteReverse(QByteArray & array)
     return array;
 }
 
+QByteArray ByteReverse(QByteArray && array)
+{
+    int length = array.length();
+    for(int i = 0; i < length / 2; i++)
+    {
+        char temp = array[i];
+        array[i] = array[length - i - 1];
+        array[length - i - 1] = temp;
+    }
+    return array;
+}
+
 bool SimpleInputBox(QWidget* parent, const QString & title, QString defaultValue, QString & output, const QString & placeholderText, QIcon* icon)
 {
     LineEditDialog mEdit(parent);

--- a/src/gui/Src/Utils/MiscUtil.h
+++ b/src/gui/Src/Utils/MiscUtil.h
@@ -9,6 +9,7 @@ class QByteArray;
 
 void SetApplicationIcon(WId winId);
 QByteArray & ByteReverse(QByteArray & array);
+QByteArray ByteReverse(QByteArray && array);
 bool SimpleInputBox(QWidget* parent, const QString & title, QString defaultValue, QString & output, const QString & placeholderText, QIcon* icon = nullptr);
 bool SimpleChoiceBox(QWidget* parent, const QString & title, QString defaultValue, const QStringList & choices, QString & output, bool editable, const QString & placeholderText, QIcon* icon = nullptr, int minimumContentsLength = -1);
 void SimpleErrorBox(QWidget* parent, const QString & title, const QString & text);


### PR DESCRIPTION
Catching temporaries by a non-const reference is a VS extension and it'd fail to compile in a newer VS versions by default (tested in  VS2017).