### PR TITLE
GUI: add multiselect hotkeys to StdTable

### DIFF
--- a/src/gui/Src/BasicView/StdTable.h
+++ b/src/gui/Src/BasicView/StdTable.h
@@ -22,11 +22,16 @@ public:
 
     // Selection Management
     void expandSelectionUpTo(int to);
+    void expandUp();
+    void expandDown();
     void setSingleSelection(int index);
     int getInitialSelection();
     QList<int> getSelection();
+    void selectStart();
+    void selectEnd();
     void selectNext();
     void selectPrevious();
+    void selectAll();
     bool isSelected(int base, int offset);
     bool scrollSelect(int offset);
 
@@ -107,7 +112,7 @@ protected:
 
     SelectionData_t mSelection;
 
-    bool mIsMultiSelctionAllowed;
+    bool mIsMultiSelectionAllowed;
     bool mCopyMenuOnly;
     bool mCopyMenuDebugOnly;
     bool mIsColumnSortingAllowed;


### PR DESCRIPTION
This allows selecting multiple rows in e. g. the Breakpoints view
without having to use the mouse.

New hotkeys:
- Select all: (ctrl+a)
- Select first row (ctrl+home)
- Select last row (ctrl+end)
- Expand selection upwards (shift+up)
- Expand selection downwards (shift+down)

![capture](https://user-images.githubusercontent.com/5101884/31123630-007ddf20-a841-11e7-9804-95f82242ba2a.gif)

Related issue: #1304