### PR TITLE
Remember navigation source in graph history

### DIFF
--- a/src/gui/Src/Gui/DisassemblerGraphView.cpp
+++ b/src/gui/Src/Gui/DisassemblerGraphView.cpp
@@ -719,11 +719,12 @@ void DisassemblerGraphView::mouseDoubleClickEvent(QMouseEvent* event)
     }
     else
     {
+        duint instr = this->getInstrForMouseEvent(event);
+
         //Add address to history
         if(!mHistoryLock)
-            mHistory.addVaToHistory(addr);
+            mHistory.addVaToHistory(instr);
 
-        duint instr = this->getInstrForMouseEvent(event);
         DbgCmdExec(QString("graph dis.branchdest(%1), silent").arg(ToPtrString(instr)).toUtf8().constData());
     }
 }

--- a/src/gui/Src/Gui/DisassemblerGraphView.cpp
+++ b/src/gui/Src/Gui/DisassemblerGraphView.cpp
@@ -1783,8 +1783,13 @@ void DisassemblerGraphView::keyPressEvent(QKeyEvent* event)
         DbgCmdExec(QString("graph dis.brtrue(%1), silent").arg(ToPtrString(cur_instr)).toUtf8().constData());
     else if(key == Qt::Key_Right)
         DbgCmdExec(QString("graph dis.brfalse(%1), silent").arg(ToPtrString(cur_instr)).toUtf8().constData());
-    if(key == Qt::Key_Return || key == Qt::Key_Enter)
+    else if(key == Qt::Key_Return || key == Qt::Key_Enter)
+    {
+        //Add address to history
+        if(!mHistoryLock)
+            mHistory.addVaToHistory(cur_instr);
         DbgCmdExec(QString("graph dis.branchdest(%1), silent").arg(ToPtrString(cur_instr)).toUtf8().constData());
+    }
 }
 
 void DisassemblerGraphView::followDisassemblerSlot()

--- a/src/gui/Src/Gui/DisassemblerGraphView.cpp
+++ b/src/gui/Src/Gui/DisassemblerGraphView.cpp
@@ -141,7 +141,6 @@ duint DisassemblerGraphView::get_cursor_pos()
 
 void DisassemblerGraphView::set_cursor_pos(duint addr)
 {
-    Q_UNUSED(addr);
     if(!this->navigate(addr))
     {
         //TODO: show in hex editor?
@@ -720,6 +719,10 @@ void DisassemblerGraphView::mouseDoubleClickEvent(QMouseEvent* event)
     }
     else
     {
+        //Add address to history
+        if(!mHistoryLock)
+            mHistory.addVaToHistory(addr);
+
         duint instr = this->getInstrForMouseEvent(event);
         DbgCmdExec(QString("graph dis.branchdest(%1), silent").arg(ToPtrString(instr)).toUtf8().constData());
     }


### PR DESCRIPTION
If you follow a jump or a call, and click on '-', you don't go back to the jump or the call (as in the regular CPU view), but to a previous, non-relevant command in the graph. This commit tries to fix this.

I haven't compiled or checked this. Please verify, or I'll do it myself later.

__Edit:__ Tested AppVeyor's build, seems to be working.