### PR TITLE
Add tokenizer support for pointer operands

### DIFF
--- a/src/gui/Src/Disassembler/QBeaEngine.cpp
+++ b/src/gui/Src/Disassembler/QBeaEngine.cpp
@@ -200,7 +200,7 @@ Instruction_t QBeaEngine::DisassembleAt(byte_t* data, duint size, duint origBase
 
     auto branchType = Instruction_t::None;
     Instruction_t wInst;
-    if(success && (cp.IsBranchType(Zydis::BTJmp | Zydis::BTCall | Zydis::BTRet | Zydis::BTLoop)))
+    if(success && cp.IsBranchType(Zydis::BTJmp | Zydis::BTCall | Zydis::BTRet | Zydis::BTLoop))
     {
         wInst.branchDestination = DbgGetBranchDestination(origBase + origInstRVA);
         if(cp.IsBranchType(Zydis::BTUncondJmp))

--- a/src/gui/Src/Disassembler/capstone_gui.cpp
+++ b/src/gui/Src/Disassembler/capstone_gui.cpp
@@ -448,10 +448,10 @@ bool CapstoneTokenizer::tokenizeOperand(const ZydisDecodedOperand & op)
         return tokenizeImmOperand(op);
     case ZYDIS_OPERAND_TYPE_MEMORY:
         return tokenizeMemOperand(op);
-    case ZYDIS_OPERAND_TYPE_UNUSED:
-        return tokenizeInvalidOperand(op);
+    case ZYDIS_OPERAND_TYPE_POINTER:
+        return tokenizePtrOperand(op);
     default:
-        return false;
+        return tokenizeInvalidOperand(op);
     }
 }
 
@@ -590,6 +590,19 @@ bool CapstoneTokenizer::tokenizeMemOperand(const ZydisDecodedOperand & op)
 
     //closing bracket
     addToken(bracketsType, "]");
+    return true;
+}
+
+bool CapstoneTokenizer::tokenizePtrOperand(const ZydisDecodedOperand & op)
+{
+    auto segValue = TokenValue(2, op.ptr.segment);
+    addToken(TokenType::MemorySegment, printValue(segValue, true, _maxModuleLength), segValue);
+
+    addToken(TokenType::Uncategorized, ":");
+
+    auto offsetValue = TokenValue(_cp.GetInstr()->operandWidth, op.ptr.offset);
+    addToken(TokenType::Address, printValue(offsetValue, true, _maxModuleLength), offsetValue);
+
     return true;
 }
 

--- a/src/gui/Src/Disassembler/capstone_gui.cpp
+++ b/src/gui/Src/Disassembler/capstone_gui.cpp
@@ -600,7 +600,7 @@ bool CapstoneTokenizer::tokenizePtrOperand(const ZydisDecodedOperand & op)
 
     addToken(TokenType::Uncategorized, ":");
 
-    auto offsetValue = TokenValue(_cp.GetInstr()->operandWidth, op.ptr.offset);
+    auto offsetValue = TokenValue(_cp.GetInstr()->operandWidth / 8, op.ptr.offset);
     addToken(TokenType::Address, printValue(offsetValue, true, _maxModuleLength), offsetValue);
 
     return true;

--- a/src/gui/Src/Disassembler/capstone_gui.h
+++ b/src/gui/Src/Disassembler/capstone_gui.h
@@ -201,6 +201,7 @@ private:
     bool tokenizeRegOperand(const ZydisDecodedOperand & op);
     bool tokenizeImmOperand(const ZydisDecodedOperand & op);
     bool tokenizeMemOperand(const ZydisDecodedOperand & op);
+    bool tokenizePtrOperand(const ZydisDecodedOperand & op);
     bool tokenizeInvalidOperand(const ZydisDecodedOperand & op);
 };
 


### PR DESCRIPTION
```
<Baboon> hi
<Baboon> it seems that jmp far are not correctly decoded by x64
<Baboon> (10/10/2017 version, didn't test the latest)
[...]
<Baboon> I'll download the last version
<Baboon> last version, same bug : "\xEA\xEF\xB5\x0D\x77\x33\x00"
<Baboon> got an empty string instead of /b meta
```

This fixes the issue.