### PR TITLE
Add DbgGetRegDumpEx to bridge API

### DIFF
--- a/src/bridge/_global.h
+++ b/src/bridge/_global.h
@@ -29,7 +29,7 @@ typedef bool (*DBGADDRINFOGET)(duint addr, SEGMENTREG segment, BRIDGE_ADDRINFO* 
 typedef bool (*DBGADDRINFOSET)(duint addr, BRIDGE_ADDRINFO* addrinfo);
 typedef bool(*DBGENCODETYPESET)(duint addr, duint size, ENCODETYPE type);
 typedef BPXTYPE(*DBGBPGETTYPEAT)(duint addr);
-typedef bool (*DBGGETREGDUMP)(REGDUMP* regdump);
+typedef bool (*DBGGETREGDUMP)(REGDUMP* regdump, size_t size);
 typedef bool (*DBGVALTOSTRING)(const char* string, duint value);
 typedef bool (*DBGMEMISVALIDREADPTR)(duint addr);
 typedef int (*DBGGETBPLIST)(BPXTYPE type, BPMAP* bplist);

--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -465,7 +465,12 @@ BRIDGE_IMPEXP duint DbgValFromString(const char* string)
 
 BRIDGE_IMPEXP bool DbgGetRegDump(REGDUMP* regdump)
 {
-    return _dbg_getregdump(regdump);
+    return _dbg_getregdump(regdump, sizeof(REGDUMP));
+}
+
+BRIDGE_IMPEXP bool DbgGetRegDumpEx(REGDUMP* regdump, size_t size)
+{
+    return _dbg_getregdump(regdump, size);
 }
 
 // FIXME all

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -757,6 +757,12 @@ typedef struct
 
 typedef struct
 {
+    DWORD code;
+    char name[128];
+} LASTSTATUS;
+
+typedef struct
+{
     REGISTERCONTEXT regcontext;
     FLAGS flags;
     X87FPUREGISTER x87FPURegisters[8];
@@ -766,6 +772,19 @@ typedef struct
     X87CONTROLWORDFIELDS x87ControlWordFields;
     LASTERROR lastError;
 } REGDUMP;
+
+typedef struct
+{
+    REGISTERCONTEXT regcontext;
+    FLAGS flags;
+    X87FPUREGISTER x87FPURegisters[8];
+    unsigned long long mmx[8];
+    MXCSRFIELDS MxCsrFields;
+    X87STATUSWORDFIELDS x87StatusWordFields;
+    X87CONTROLWORDFIELDS x87ControlWordFields;
+    LASTERROR lastError;
+    LASTSTATUS lastStatus;
+} REGDUMP_V2;
 
 typedef struct
 {
@@ -926,6 +945,7 @@ BRIDGE_IMPEXP bool DbgGetModuleAt(duint addr, char* text);
 BRIDGE_IMPEXP BPXTYPE DbgGetBpxTypeAt(duint addr);
 BRIDGE_IMPEXP duint DbgValFromString(const char* string);
 BRIDGE_IMPEXP bool DbgGetRegDump(REGDUMP* regdump);
+BRIDGE_IMPEXP bool DbgGetRegDumpEx(REGDUMP* regdump, size_t size);
 BRIDGE_IMPEXP bool DbgValToString(const char* string, duint value);
 BRIDGE_IMPEXP bool DbgMemIsValidReadPtr(duint addr);
 BRIDGE_IMPEXP int DbgGetBpList(BPXTYPE type, BPMAP* list);

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -627,11 +627,14 @@ static void TranslateTitanFpuRegisters(const x87FPURegister_t titanFpu[8], X87FP
         TranslateTitanFpuRegister(&titanFpu[i], &fpu[i]);
 }
 
-extern "C" DLL_EXPORT bool _dbg_getregdump(REGDUMP* regdump)
+extern "C" DLL_EXPORT bool _dbg_getregdump(REGDUMP* regdump, size_t size)
 {
+    if(size != sizeof(REGDUMP) && size != sizeof(REGDUMP_V2))
+        return false;
+
     if(!DbgIsDebugging())
     {
-        memset(regdump, 0, sizeof(REGDUMP));
+        memset(regdump, 0, size);
         return true;
     }
 
@@ -663,6 +666,12 @@ extern "C" DLL_EXPORT bool _dbg_getregdump(REGDUMP* regdump)
     lastError.code = ThreadGetLastError(ThreadGetId(hActiveThread));
     strncpy_s(lastError.name, ErrorCodeToName(lastError.code).c_str(), _TRUNCATE);
     regdump->lastError = lastError;
+
+    if(size >= sizeof(REGDUMP_V2))
+    {
+        REGDUMP_V2* regdumpV2 = (REGDUMP_V2*)regdump;
+        // TODO: retrieve name of lastStatus
+    }
 
     return true;
 }

--- a/src/dbg/_exports.h
+++ b/src/dbg/_exports.h
@@ -20,7 +20,7 @@ DLL_EXPORT bool _dbg_addrinfoget(duint addr, SEGMENTREG segment, BRIDGE_ADDRINFO
 DLL_EXPORT bool _dbg_addrinfoset(duint addr, BRIDGE_ADDRINFO* addrinfo);
 DLL_EXPORT bool _dbg_encodetypeset(duint addr, duint size, ENCODETYPE type);
 DLL_EXPORT int _dbg_bpgettypeat(duint addr);
-DLL_EXPORT bool _dbg_getregdump(REGDUMP* regdump);
+DLL_EXPORT bool _dbg_getregdump(REGDUMP* regdump, size_t size);
 DLL_EXPORT bool _dbg_valtostring(const char* string, duint value);
 DLL_EXPORT int _dbg_getbplist(BPXTYPE type, BPMAP* list);
 DLL_EXPORT duint _dbg_getbranchdestination(duint addr);


### PR DESCRIPTION
This PR adds `DbgGetRegDumpEx` to the public bridge API (prerequisite for implementing #1776 without breaking compatibility with existing plugins).

There is some minor unavoidable overlap between the two PRs such as adding `LASTSTATUS` to bridgemain.h. Calling `DbgGetRegDumpEx` with `sizeof(REGDUMP_V2)` also currently doesn't do anything useful, I've left that for the other PR which I can rebase after this is merged.