### PR TITLE
GUI: handle highlighting segment registers in RegistersView

### DIFF
--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1689,6 +1689,8 @@ void RegistersView::mousePressEvent(QMouseEvent* event)
                     CPUDisassemblyView->hightlightToken(CapstoneTokenizer::SingleToken(CapstoneTokenizer::TokenType::XmmRegister, mRegisterMapping.constFind(r).value()));
                 else if(mFPUYMM.contains(r))
                     CPUDisassemblyView->hightlightToken(CapstoneTokenizer::SingleToken(CapstoneTokenizer::TokenType::YmmRegister, mRegisterMapping.constFind(r).value()));
+                else if(mSEGMENTREGISTER.contains(r))
+                    CPUDisassemblyView->hightlightToken(CapstoneTokenizer::SingleToken(CapstoneTokenizer::TokenType::MemorySegment, mRegisterMapping.constFind(r).value()));
                 else
                     mSelected = r;
             }


### PR DESCRIPTION
This PR fixes issue #1333. It should be now possible to change the CPU view into highlight mode (H key) and select one of the segment registers in the Registers View.