### PR TITLE
MSVC 2017 compile fixes

### DIFF
--- a/src/gui/Src/Disassembler/CsQBeaEngine.cpp
+++ b/src/gui/Src/Disassembler/CsQBeaEngine.cpp
@@ -271,9 +271,9 @@ Instruction_t CsQBeaEngine::DecodeDataAt(byte_t* data, duint size, duint origBas
     //tokenize
     CapstoneTokenizer::InstructionToken cap;
 
-    auto & infoIter = dataInstMap.find(type);
+    auto infoIter = dataInstMap.constFind(type);
     if(infoIter == dataInstMap.end())
-        infoIter = dataInstMap.find(enc_byte);
+        infoIter = dataInstMap.constFind(enc_byte);
 
     int len = mEncodeMap->getDataSize(origBase + origInstRVA, 1);
 

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -123,6 +123,17 @@ void BreakpointsView::updateColors()
     updateBreakpointsSlot();
 }
 
+struct Hax
+{
+    const bool & greater;
+    const QString & s;
+    Hax(const bool & greater, const QString & s) : greater(greater), s(s) { }
+    bool operator<(const Hax & b)
+    {
+        return greater ? this->s > b.s : this->s < b.s;
+    }
+};
+
 void BreakpointsView::reloadData()
 {
     if(mSort.first != -1) //re-sort if the user wants to sort
@@ -135,16 +146,7 @@ void BreakpointsView::reloadData()
             auto aBp = &mBps.at(a.at(ColAddr).userdata), bBp = &mBps.at(b.at(ColAddr).userdata);
             auto aType = aBp->type, bType = bBp->type;
             auto aHeader = aBp->addr || aBp->active, bHeader = bBp->addr || bBp->active;
-            struct Hax
-            {
-                const bool & greater;
-                const QString & s;
-                Hax(const bool & greater, const QString & s) : greater(greater), s(s) { }
-                bool operator<(const Hax & b)
-                {
-                    return greater ? this->s > b.s : this->s < b.s;
-                }
-            } aHax(greater, a.at(col).text), bHax(greater, b.at(col).text);
+            Hax aHax(greater, a.at(col).text), bHax(greater, b.at(col).text);
             return std::tie(aType, aHeader, aHax) < std::tie(bType, bHeader, bHax);
         });
     }

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -123,17 +123,6 @@ void BreakpointsView::updateColors()
     updateBreakpointsSlot();
 }
 
-struct Hax
-{
-    const bool & greater;
-    const QString & s;
-    Hax(const bool & greater, const QString & s) : greater(greater), s(s) { }
-    bool operator<(const Hax & b)
-    {
-        return greater ? this->s > b.s : this->s < b.s;
-    }
-};
-
 void BreakpointsView::reloadData()
 {
     if(mSort.first != -1) //re-sort if the user wants to sort
@@ -146,7 +135,16 @@ void BreakpointsView::reloadData()
             auto aBp = &mBps.at(a.at(ColAddr).userdata), bBp = &mBps.at(b.at(ColAddr).userdata);
             auto aType = aBp->type, bType = bBp->type;
             auto aHeader = aBp->addr || aBp->active, bHeader = bBp->addr || bBp->active;
-            Hax aHax(greater, a.at(col).text), bHax(greater, b.at(col).text);
+            struct Hax
+            {
+                const bool & greater;
+                const QString & s;
+                Hax(const bool & greater, const QString & s) : greater(greater), s(s) { }
+                bool operator<(const Hax & b)
+                {
+                    return greater ? s > b.s : s < b.s;
+                }
+            } aHax(greater, a.at(col).text), bHax(greater, b.at(col).text);
             return std::tie(aType, aHeader, aHax) < std::tie(bType, bHeader, bHax);
         });
     }


### PR DESCRIPTION
This PR fixes the following 2 compile errors that occur when building using the MSVC2017 toolchain in Qt Creator:

1. Trying to bind an rvalue to non-const reference:
`..\gui\Src\Disassembler\CsQBeaEngine.cpp(274): error C2440: 'initializing': cannot convert from 'QHash<ENCODETYPE,CsQBeaEngine::DataInstructionInfo>::iterator' to 'QHash<ENCODETYPE,CsQBeaEngine::DataInstructionInfo>::iterator &'
..\gui\Src\Disassembler\CsQBeaEngine.cpp(274): note: A non-const reference may only be bound to an lvalue`

2. Declaring a struct inside a lambda function:
`..\gui\Src\Gui\BreakpointsView.cpp(145): error C2327: 'BreakpointsView::reloadData::<lambda_14f74381a4291d4224dc2543f7a47ae4>::__this': is not a type name, static, or enumerator
..\gui\Src\Gui\BreakpointsView.cpp(145): error C2065: '__this': undeclared identifier
..\gui\Src\Gui\BreakpointsView.cpp(145): error C2227: left of '->s' must point to class/struct/union/generic type
..\gui\Src\Gui\BreakpointsView.cpp(145): note: type is 'unknown-type'`

The second one seems to be a compiler error. MSVC gets confused when this is referenced in the member function of a struct that was declared inside a lambda which also captures this.
As a workaround I removed the unnecessary this-> references in the operator<.