### PR TITLE
DBG: fix saving CPUDump and mmap dump to file

### DIFF
--- a/src/dbg/commands/cmd-memory-operations.cpp
+++ b/src/dbg/commands/cmd-memory-operations.cpp
@@ -165,7 +165,7 @@ bool cbInstrSavedata(int argc, char* argv[])
         return false;
     }
 
-    String name = stringformatinline(argv[1]);
+    String name = argv[1];
     if(name == ":memdump:")
         name = StringUtils::sprintf("%s\\memdumps\\memdump_%X_%p_%x.bin", szProgramDir, fdProcessInfo->dwProcessId, addr, size);
 

--- a/src/dbg/commands/cmd-memory-operations.cpp
+++ b/src/dbg/commands/cmd-memory-operations.cpp
@@ -165,7 +165,7 @@ bool cbInstrSavedata(int argc, char* argv[])
         return false;
     }
 
-    String name = argv[1];
+    String name = stringformatinline(argv[1]);
     if(name == ":memdump:")
         name = StringUtils::sprintf("%s\\memdumps\\memdump_%X_%p_%x.bin", szProgramDir, fdProcessInfo->dwProcessId, addr, size);
 

--- a/src/dbg/stringformat.cpp
+++ b/src/dbg/stringformat.cpp
@@ -173,7 +173,6 @@ static String handleFormatString(const String & formatString, const FormatValueV
 
 String stringformat(String format, const FormatValueVector & values)
 {
-    StringUtils::ReplaceAll(format, "\\n", "\n");
     int len = (int)format.length();
     String output;
     String formatString;
@@ -247,7 +246,6 @@ static String handleFormatStringInline(const String & formatString)
 
 String stringformatinline(String format)
 {
-    StringUtils::ReplaceAll(format, "\\n", "\n");
     int len = (int)format.length();
     String output;
     String formatString;


### PR DESCRIPTION
fixes #1778 

`stringformatinline(argv[1])` was replacing a file path with \\n with a newline. For example, C:\Users\Desktop\Me\nogood.bin would cause `name = "C:\\Users\\Desktop\\Me\nogood.bin"`.