### PR TITLE
Added settings to hide pointer sizes and default segments

### DIFF
--- a/src/gui/Src/Disassembler/capstone_gui.h
+++ b/src/gui/Src/Disassembler/capstone_gui.h
@@ -157,7 +157,7 @@ public:
     bool Tokenize(duint addr, const unsigned char* data, int datasize, InstructionToken & instruction);
     bool TokenizeData(const QString & datatype, const QString & data, InstructionToken & instruction);
     void UpdateConfig();
-    void SetConfig(bool bUppercase, bool bTabbedMnemonic, bool bArgumentSpaces, bool bMemorySpaces, bool bNoHighlightOperands, bool bNoCurrentModuleText, bool b0xPrefixValues);
+    void SetConfig(bool bUppercase, bool bTabbedMnemonic, bool bArgumentSpaces, bool bHidePointerSizes, bool bHideNormalSegments, bool bMemorySpaces, bool bNoHighlightOperands, bool bNoCurrentModuleText, bool b0xPrefixValues);
     int Size() const;
     const Zydis & GetCapstone() const;
 
@@ -180,6 +180,8 @@ private:
     bool _bUppercase;
     bool _bTabbedMnemonic;
     bool _bArgumentSpaces;
+    bool _bHidePointerSizes;
+    bool _bHideNormalSegments;
     bool _bMemorySpaces;
     bool _bNoHighlightOperands;
     bool _bNoCurrentModuleText;

--- a/src/gui/Src/Disassembler/cs_capstone_gui.h
+++ b/src/gui/Src/Disassembler/cs_capstone_gui.h
@@ -17,7 +17,7 @@ public:
     bool Tokenize(duint addr, const unsigned char* data, int datasize, CapstoneTokenizer::InstructionToken & instruction);
     bool TokenizeData(const QString & datatype, const QString & data, CapstoneTokenizer::InstructionToken & instruction);
     void UpdateConfig();
-    void SetConfig(bool bUppercase, bool bTabbedMnemonic, bool bArgumentSpaces, bool bMemorySpaces, bool bNoHighlightOperands, bool bNoCurrentModuleText, bool b0xPrefixValues);
+    void SetConfig(bool bUppercase, bool bTabbedMnemonic, bool bArgumentSpaces, bool bHidePointerSizes, bool bHideNormalSegments, bool bMemorySpaces, bool bNoHighlightOperands, bool bNoCurrentModuleText, bool b0xPrefixValues);
     int Size() const;
     const Capstone & GetCapstone() const;
 
@@ -40,6 +40,8 @@ private:
     bool _bUppercase;
     bool _bTabbedMnemonic;
     bool _bArgumentSpaces;
+    bool _bHidePointerSizes;
+    bool _bHideNormalSegments;
     bool _bMemorySpaces;
     bool _bNoHighlightOperands;
     bool _bNoCurrentModuleText;

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -66,6 +66,8 @@ void SettingsDialog::LoadSettings()
     settings.engineVerboseExceptionLogging = true;
     settings.exceptionRanges = &realExceptionRanges;
     settings.disasmArgumentSpaces = false;
+    settings.disasmHidePointerSizes = false;
+    settings.disasmHideNormalSegments = false;
     settings.disasmMemorySpaces = false;
     settings.disasmUppercase = false;
     settings.disasmOnlyCipAutoComments = false;
@@ -194,6 +196,8 @@ void SettingsDialog::LoadSettings()
 
     //Disasm tab
     GetSettingBool("Disassembler", "ArgumentSpaces", &settings.disasmArgumentSpaces);
+    GetSettingBool("Disassembler", "HidePointerSizes", &settings.disasmHidePointerSizes);
+    GetSettingBool("Disassembler", "HideNormalSegments", &settings.disasmHideNormalSegments);
     GetSettingBool("Disassembler", "MemorySpaces", &settings.disasmMemorySpaces);
     GetSettingBool("Disassembler", "Uppercase", &settings.disasmUppercase);
     GetSettingBool("Disassembler", "OnlyCipAutoComments", &settings.disasmOnlyCipAutoComments);
@@ -206,6 +210,8 @@ void SettingsDialog::LoadSettings()
     if(BridgeSettingGetUint("Disassembler", "MaxModuleSize", &cur))
         settings.disasmMaxModuleSize = int(cur);
     ui->chkArgumentSpaces->setChecked(settings.disasmArgumentSpaces);
+    ui->chkHidePointerSizes->setChecked(settings.disasmHidePointerSizes);
+    ui->chkHideNormalSegments->setChecked(settings.disasmHideNormalSegments);
     ui->chkMemorySpaces->setChecked(settings.disasmMemorySpaces);
     ui->chkUppercase->setChecked(settings.disasmUppercase);
     ui->chkOnlyCipAutoComments->setChecked(settings.disasmOnlyCipAutoComments);
@@ -353,6 +359,8 @@ void SettingsDialog::SaveSettings()
 
     //Disasm tab
     BridgeSettingSetUint("Disassembler", "ArgumentSpaces", settings.disasmArgumentSpaces);
+    BridgeSettingSetUint("Disassembler", "HidePointerSizes", settings.disasmHidePointerSizes);
+    BridgeSettingSetUint("Disassembler", "HideNormalSegments", settings.disasmHideNormalSegments);
     BridgeSettingSetUint("Disassembler", "MemorySpaces", settings.disasmMemorySpaces);
     BridgeSettingSetUint("Disassembler", "Uppercase", settings.disasmUppercase);
     BridgeSettingSetUint("Disassembler", "OnlyCipAutoComments", settings.disasmOnlyCipAutoComments);
@@ -693,6 +701,18 @@ void SettingsDialog::on_chkArgumentSpaces_stateChanged(int arg1)
 {
     bTokenizerConfigUpdated = true;
     settings.disasmArgumentSpaces = arg1 != Qt::Unchecked;
+}
+
+void SettingsDialog::on_chkHidePointerSizes_stateChanged(int arg1)
+{
+    bTokenizerConfigUpdated = true;
+    settings.disasmHidePointerSizes = arg1 != Qt::Unchecked;
+}
+
+void SettingsDialog::on_chkHideNormalSegments_stateChanged(int arg1)
+{
+    bTokenizerConfigUpdated = true;
+    settings.disasmHideNormalSegments = arg1 != Qt::Unchecked;
 }
 
 void SettingsDialog::on_chkMemorySpaces_stateChanged(int arg1)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -63,6 +63,8 @@ private slots:
     void on_btnAddLast_clicked();
     //Disasm tab
     void on_chkArgumentSpaces_stateChanged(int arg1);
+    void on_chkHidePointerSizes_stateChanged(int arg1);
+    void on_chkHideNormalSegments_stateChanged(int arg1);
     void on_chkMemorySpaces_stateChanged(int arg1);
     void on_chkUppercase_stateChanged(int arg1);
     void on_chkOnlyCipAutoComments_stateChanged(int arg1);
@@ -159,6 +161,8 @@ private:
         //Disasm Tab
         bool disasmArgumentSpaces;
         bool disasmMemorySpaces;
+        bool disasmHidePointerSizes;
+        bool disasmHideNormalSegments;
         bool disasmUppercase;
         bool disasmOnlyCipAutoComments;
         bool disasmTabBetweenMnemonicAndArguments;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -490,6 +490,20 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkHidePointerSizes">
+         <property name="text">
+          <string>Hide pointer sizes</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="chkHideNormalSegments">
+         <property name="text">
+          <string>Only show FS/GS segments</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkMemorySpaces">
          <property name="text">
           <string>Memory Spaces</string>

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -245,6 +245,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     //bool settings
     QMap<QString, bool> disassemblyBool;
     disassemblyBool.insert("ArgumentSpaces", false);
+    disassemblyBool.insert("HidePointerSizes", false);
+    disassemblyBool.insert("HideNormalSegments", false);
     disassemblyBool.insert("MemorySpaces", false);
     disassemblyBool.insert("KeepSize", false);
     disassemblyBool.insert("FillNOPs", false);


### PR DESCRIPTION
Added two settings in the Disasm tab for hiding pointer sizes as well as segments which aren't FS or GS.

![example](https://user-images.githubusercontent.com/33558806/32692828-fd98fe32-c6d3-11e7-9af0-827bae55b379.png)
