### PR TITLE
Let goto file offset dialog has a init value of current selected address

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -1003,6 +1003,17 @@ void CPUDisassembly::gotoFileOffsetSlot()
     mGotoOffset->fileOffset = true;
     mGotoOffset->modName = QString(modname);
     mGotoOffset->setWindowTitle(tr("Goto File Offset in ") + QString(modname));
+    QString offsetOfSelected;
+    prepareDataRange(getSelectionStart(), getSelectionEnd(), [&](int, const Instruction_t & inst)
+    {
+        duint addr = rvaToVa(inst.rva);
+        duint offset = DbgFunctions()->VaToFileOffset(addr);
+        if(offset)
+            offsetOfSelected = ToHexString(offset);
+        return false;
+    });
+    if(!offsetOfSelected.isEmpty())
+        mGotoOffset->setInitialExpression(offsetOfSelected);
     if(mGotoOffset->exec() != QDialog::Accepted)
         return;
     duint value = DbgValFromString(mGotoOffset->expressionText.toUtf8().constData());

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -585,6 +585,10 @@ void CPUDump::gotoFileOffsetSlot()
     mGotoOffset->fileOffset = true;
     mGotoOffset->modName = QString(modname);
     mGotoOffset->setWindowTitle(tr("Goto File Offset in %1").arg(QString(modname)));
+    duint addr = rvaToVa(getInitialSelection());
+    duint offset = DbgFunctions()->VaToFileOffset(addr);
+    if(offset)
+        mGotoOffset->setInitialExpression(ToHexString(offset));
     if(mGotoOffset->exec() != QDialog::Accepted)
         return;
     duint value = DbgValFromString(mGotoOffset->expressionText.toUtf8().constData());


### PR DESCRIPTION
like IDA, set init value of current selected address. It's convenient when there is no shortcut binding for copy file offset, but goto file offset having a shortcut CTRL+SHIFT+G, you can press CTRL+SHIFT+G and CTRL+C to copy file file offset of current selected address in CPU disassembler or dump window.