### PR TITLE
Fix a bug in symbol view

### DIFF
--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -186,7 +186,6 @@ void SearchListView::searchTextChanged(const QString & arg1)
         mCurList = mList;
     }
 
-    mCurList->setSingleSelection(0);
     mSearchList->setRowCount(0);
     int rows = mList->getRowCount();
     int columns = mList->getColumnCount();
@@ -203,6 +202,7 @@ void SearchListView::searchTextChanged(const QString & arg1)
 
     mSearchList->reloadData();
 
+    bool hasSetSingleSelection = false;
     if(!mLastFirstColValue.isEmpty())
     {
         rows = mCurList->getRowCount();
@@ -219,10 +219,13 @@ void SearchListView::searchTextChanged(const QString & arg1)
                     mCurList->setTableOffset(cur);
                 }
                 mCurList->setSingleSelection(i);
+                hasSetSingleSelection = true;
                 break;
             }
         }
     }
+    if(!hasSetSingleSelection)
+        mCurList->setSingleSelection(0);
 
     if(rows == 0)
         emit emptySearchResult();


### PR DESCRIPTION
In some case, the right panel in symbol view are wrong when text changed in filter textbox of left panel.
![1](https://user-images.githubusercontent.com/367894/32777662-09ff34b6-c972-11e7-8629-bb2c4b65097c.png)
![2](https://user-images.githubusercontent.com/367894/32777679-18358490-c972-11e7-83f7-e53bda510c50.png)
`mCurList->setSingleSelection` cause the update in right panel, and should be called after `mSearchList->reloadData()`. 
Also prevent double call setSingleSelection to improve performance.