### PR TITLE
Do not keep duplicate process and initial thread handles around

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1457,6 +1457,8 @@ static void cbExitProcess(EXIT_PROCESS_DEBUG_INFO* ExitProcess)
     _dbg_animatestop(); // Stop animating
     //unload main module
     SafeSymUnloadModule64(fdProcessInfo->hProcess, pCreateProcessBase);
+    //cleanup dbghelp
+    SafeSymCleanup(fdProcessInfo->hProcess);
     //history
     dbgcleartracestate();
     dbgClearRtuBreakpoints();
@@ -2734,10 +2736,6 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     stopInfo.reserved = 0;
     plugincbcall(CB_STOPDEBUG, &stopInfo);
 
-    //cleanup dbghelp
-    if(fdProcessInfo->hProcess != nullptr)
-        SafeSymCleanup(fdProcessInfo->hProcess);
-
     //message the user/do final stuff
     RemoveAllBreakPoints(UE_OPTION_REMOVEALL); //remove all breakpoints
     {
@@ -2757,6 +2755,7 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     GuiSetDebugState(stopped);
     GuiUpdateAllViews();
     dputs(QT_TRANSLATE_NOOP("DBG", "Debugging stopped!"));
+    fdProcessInfo->hProcess = fdProcessInfo->hThread = nullptr;
     varset("$hp", (duint)0, true);
     varset("$pid", (duint)0, true);
     if(hProcessToken)

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -56,7 +56,6 @@ static bool bFreezeStack = false;
 static std::vector<ExceptionRange> ignoredExceptionRange;
 static HANDLE hEvent = 0;
 static duint tidToResume = 0;
-static HANDLE hProcess = 0;
 static HANDLE hMemMapThread = 0;
 static bool bStopMemMapThread = false;
 static HANDLE hTimeWastedCounterThread = 0;
@@ -1987,7 +1986,6 @@ static void cbAttachDebugger()
         cmddirectexec(StringUtils::sprintf("resumethread %p", tidToResume).c_str());
         tidToResume = 0;
     }
-    hProcess = fdProcessInfo->hProcess;
     varset("$hp", (duint)fdProcessInfo->hProcess, true);
     varset("$pid", fdProcessInfo->dwProcessId, true);
 }
@@ -2722,7 +2720,6 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     }
     else
     {
-        hProcess = fdProcessInfo->hProcess;
         DebugLoop();
     }
 
@@ -2732,7 +2729,8 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     plugincbcall(CB_STOPDEBUG, &stopInfo);
 
     //cleanup dbghelp
-    SafeSymCleanup(hProcess);
+    if(fdProcessInfo->hProcess != nullptr)
+        SafeSymCleanup(fdProcessInfo->hProcess);
 
     //message the user/do final stuff
     RemoveAllBreakPoints(UE_OPTION_REMOVEALL); //remove all breakpoints

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1315,6 +1315,10 @@ void cbTraceOverIntoTraceRecordStep()
 
 static void cbCreateProcess(CREATE_PROCESS_DEBUG_INFO* CreateProcessInfo)
 {
+    fdProcessInfo->hProcess = CreateProcessInfo->hProcess;
+    fdProcessInfo->hThread = CreateProcessInfo->hThread;
+    varset("$hp", (duint)fdProcessInfo->hProcess, true);
+
     void* base = CreateProcessInfo->lpBaseOfImage;
 
     char DebugFileName[deflen] = "";
@@ -2720,6 +2724,10 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     }
     else
     {
+        //close the process and thread handles we got back from CreateProcess, to prevent duplicating the ones we will receive in cbCreateProcess
+        CloseHandle(fdProcessInfo->hProcess);
+        CloseHandle(fdProcessInfo->hThread);
+        fdProcessInfo->hProcess = fdProcessInfo->hThread = nullptr;
         DebugLoop();
     }
 

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1990,7 +1990,6 @@ static void cbAttachDebugger()
         cmddirectexec(StringUtils::sprintf("resumethread %p", tidToResume).c_str());
         tidToResume = 0;
     }
-    varset("$hp", (duint)fdProcessInfo->hProcess, true);
     varset("$pid", fdProcessInfo->dwProcessId, true);
 }
 
@@ -2662,7 +2661,6 @@ static void debugLoopFunction(void* lpParameter, bool attach)
         }
 
         //set script variables
-        varset("$hp", (duint)fdProcessInfo->hProcess, true);
         varset("$pid", fdProcessInfo->dwProcessId, true);
 
         if(!OpenProcessToken(fdProcessInfo->hProcess, TOKEN_ALL_ACCESS, &hProcessToken))


### PR DESCRIPTION
See #1759 for discussion (but scroll to the bottom, that ticket discusses like 3 separate bugs in one thread).

In the case that x64dbg starts the debuggee process, it keeps two unneeded handles around with `PROCESS_ALL_ACCESS` and `THREAD_ALL_ACCESS` rights respectively. These are duplicated in `nt!DbgkpOpenHandles` when the first debug event (`CREATE_PROCESS_DEBUG_EVENT`) is sent. The latter two handles are automatically closed by kernel32 after `EXIT_PROCESS_DEBUG_EVENT` is handled. The original handles from `CreateProcess` (done by TitanEngine) are never closed however. You can check this by starting a debug session, stopping the process, restarting the session, and so on: Process Hacker will show a leaked process handle in x64dbg.exe to a non-existent process for each session that was started.

This PR closes the initial handles received from `CreateProcess` just before calling `DebugLoop()`. `cbCreateProcess` then sets `fdProcessInfo->hProcess` and `fdProcessInfo->hThread` to the new handle values before doing anything else. This does mean there is a tiny window during which these handles are NULL, but as they aren't sent to plugins I don't think this is an issue.

The call to `SafeSymCleanup()` has been moved to `cbExitProcess`, so that this always happens before the debuggee process has terminated. This fixes a crash that can occur if you close x32dbg (but strangely not x64dbg?) while the debuggee is still running.