### PR TITLE
Allow editing and removing inactive breakpoints

### DIFF
--- a/src/dbg/breakpoint.cpp
+++ b/src/dbg/breakpoint.cpp
@@ -228,12 +228,13 @@ bool BpUpdateDllPath(const char* module1, BREAKPOINT** newBpInfo)
     EXCLUSIVE_ACQUIRE(LockBreakpoints);
     for(auto & i : breakpoints)
     {
-        if(i.second.type == BPDLL && i.second.enabled)
+        BREAKPOINT & bpRef = i.second;
+        if(bpRef.type == BPDLL && bpRef.enabled)
         {
-            if(_stricmp(i.second.mod, module1) == 0)
+            if(_stricmp(bpRef.mod, module1) == 0)
             {
                 BREAKPOINT temp;
-                temp = i.second;
+                temp = bpRef;
                 strcpy_s(temp.mod, module1);
                 temp.addr = ModHashFromName(module1);
                 breakpoints.erase(i.first);
@@ -241,15 +242,15 @@ bool BpUpdateDllPath(const char* module1, BREAKPOINT** newBpInfo)
                 *newBpInfo = &newItem.first->second;
                 return true;
             }
-            const char* dashPos = max(strrchr(i.second.mod, '\\'), strrchr(i.second.mod, '/'));
+            const char* dashPos = max(strrchr(bpRef.mod, '\\'), strrchr(bpRef.mod, '/'));
             if(dashPos == nullptr)
-                dashPos = i.second.mod;
+                dashPos = bpRef.mod;
             else
                 dashPos += 1;
             if(dashPos1 != nullptr && _stricmp(dashPos, dashPos1 + 1) == 0) // filename matches
             {
                 BREAKPOINT temp;
-                temp = i.second;
+                temp = bpRef;
                 strcpy_s(temp.mod, dashPos1 + 1);
                 temp.addr = ModHashFromName(dashPos1 + 1);
                 breakpoints.erase(i.first);

--- a/src/dbg/breakpoint.cpp
+++ b/src/dbg/breakpoint.cpp
@@ -219,7 +219,7 @@ bool BpGet(duint Address, BP_TYPE Type, const char* Name, BREAKPOINT* Bp)
             }
             else
             {
-                duint base = ModBaseFromName(DLLName);
+                duint base = ModBaseFromName(DLLName + 1);
                 Address += base ? base : ModHashFromName(DLLName + 1);
             }
 

--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -108,7 +108,7 @@ SearchListView::SearchListView(bool EnableRegex, QWidget* parent, bool EnableLoc
     connect(mSearchList, SIGNAL(doubleClickedSignal()), this, SLOT(doubleClickedSlot()));
     connect(mSearchBox, SIGNAL(textChanged(QString)), this, SLOT(searchTextChanged(QString)));
     connect(mRegexCheckbox, SIGNAL(stateChanged(int)), this, SLOT(on_checkBoxRegex_stateChanged(int)));
-    connect(mLockCheckbox, SIGNAL(toggled(bool)), this, SLOT(on_checkBoxLock_toggled(bool)));
+    connect(mLockCheckbox, SIGNAL(toggled(bool)), mSearchBox, SLOT(setDisabled(bool)));
 
     // List input should always be forwarded to the filter edit
     mSearchList->setFocusProxy(mSearchBox);
@@ -266,13 +266,23 @@ void SearchListView::doubleClickedSlot()
 
 void SearchListView::on_checkBoxRegex_stateChanged(int state)
 {
-    Q_UNUSED(state);
-    refreshSearchList();
-}
+    QString tooltip;
+    switch(state)
+    {
+    default:
+    case Qt::Unchecked:
+        //No tooltip
+        break;
+    case Qt::Checked:
+        tooltip = tr("Use case sensitive regular expression");
+        break;
+    case Qt::PartiallyChecked:
+        tooltip = tr("Use case insensitive regular expression");
+        break;
+    }
+    mRegexCheckbox->setToolTip(tooltip);
 
-void SearchListView::on_checkBoxLock_toggled(bool checked)
-{
-    mSearchBox->setDisabled(checked);
+    refreshSearchList();
 }
 
 bool SearchListView::isSearchBoxLocked()

--- a/src/gui/Src/BasicView/SearchListView.h
+++ b/src/gui/Src/BasicView/SearchListView.h
@@ -39,7 +39,6 @@ private slots:
     void doubleClickedSlot();
     void searchSlot();
     void on_checkBoxRegex_stateChanged(int state);
-    void on_checkBoxLock_toggled(bool checked);
 
 signals:
     void enterPressedSignal();

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -585,7 +585,7 @@ void BreakpointsView::removeBreakpointSlot()
             if(bp.active)
                 Breakpoints::removeBP(bp);
             else
-                DbgCmdExec(QString("bc \"%1\":$%2").arg(bp.mod).arg(ToHexString(bp.addr)));
+                DbgCmdExec(QString().sprintf("bc \"%s\":$%X", bp.mod, bp.addr));
         }
     }
 }
@@ -601,7 +601,7 @@ void BreakpointsView::editBreakpointSlot()
 {
     if(!isValidBp())
         return;
-    auto & bp = selectedBp();
+    const BRIDGEBP & bp = selectedBp();
     if(bp.type == bp_dll)
     {
         Breakpoints::editBP(bp_dll, bp.mod, this);
@@ -609,7 +609,60 @@ void BreakpointsView::editBreakpointSlot()
     else if(bp.active || bp.type == bp_exception)
     {
         Breakpoints::editBP(bp.type, ToPtrString(bp.addr), this);
-    } //TODO: edit inactive breakpoints
+    }
+    else
+    {
+        QString addrText = QString().sprintf("\"%s\":$%X", bp.mod, bp.addr);
+        EditBreakpointDialog dialog(this, bp);
+        if(dialog.exec() != QDialog::Accepted)
+            return;
+        auto exec = [](const QString & command)
+        {
+            DbgCmdExecDirect(command.toUtf8().constData());
+        };
+        const BRIDGEBP & newBp = dialog.getBp();
+        switch(bp.type)
+        {
+        case bp_normal:
+            exec(QString("SetBreakpointName %1, \"%2\"").arg(addrText).arg(newBp.name));
+            exec(QString("SetBreakpointCondition %1, \"%2\"").arg(addrText).arg(newBp.breakCondition));
+            exec(QString("SetBreakpointLog %1, \"%2\"").arg(addrText).arg(newBp.logText));
+            exec(QString("SetBreakpointLogCondition %1, \"%2\"").arg(addrText).arg(newBp.logCondition));
+            exec(QString("SetBreakpointCommand %1, \"%2\"").arg(addrText).arg(newBp.commandText));
+            exec(QString("SetBreakpointCommandCondition %1, \"%2\"").arg(addrText).arg(newBp.commandCondition));
+            exec(QString("ResetBreakpointHitCount %1, %2").arg(addrText).arg(ToPtrString(newBp.hitCount)));
+            exec(QString("SetBreakpointFastResume %1, %2").arg(addrText).arg(newBp.fastResume));
+            exec(QString("SetBreakpointSilent %1, %2").arg(addrText).arg(newBp.silent));
+            exec(QString("SetBreakpointSingleshoot %1, %2").arg(addrText).arg(newBp.singleshoot));
+            break;
+        case bp_hardware:
+            exec(QString("SetHardwareBreakpointName %1, \"%2\"").arg(addrText).arg(newBp.name));
+            exec(QString("SetHardwareBreakpointCondition %1, \"%2\"").arg(addrText).arg(newBp.breakCondition));
+            exec(QString("SetHardwareBreakpointLog %1, \"%2\"").arg(addrText).arg(newBp.logText));
+            exec(QString("SetHardwareBreakpointLogCondition %1, \"%2\"").arg(addrText).arg(newBp.logCondition));
+            exec(QString("SetHardwareBreakpointCommand %1, \"%2\"").arg(addrText).arg(newBp.commandText));
+            exec(QString("SetHardwareBreakpointCommandCondition %1, \"%2\"").arg(addrText).arg(newBp.commandCondition));
+            exec(QString("ResetHardwareBreakpointHitCount %1, %2").arg(addrText).arg(ToPtrString(newBp.hitCount)));
+            exec(QString("SetHardwareBreakpointFastResume %1, %2").arg(addrText).arg(newBp.fastResume));
+            exec(QString("SetHardwareBreakpointSilent %1, %2").arg(addrText).arg(newBp.silent));
+            exec(QString("SetHardwareBreakpointSingleshoot %1, %2").arg(addrText).arg(newBp.singleshoot));
+            break;
+        case bp_memory:
+            exec(QString("SetMemoryBreakpointName %1, \"\"%2\"\"").arg(addrText).arg(newBp.name));
+            exec(QString("SetMemoryBreakpointCondition %1, \"%2\"").arg(addrText).arg(newBp.breakCondition));
+            exec(QString("SetMemoryBreakpointLog %1, \"%2\"").arg(addrText).arg(newBp.logText));
+            exec(QString("SetMemoryBreakpointLogCondition %1, \"%2\"").arg(addrText).arg(newBp.logCondition));
+            exec(QString("SetMemoryBreakpointCommand %1, \"%2\"").arg(addrText).arg(newBp.commandText));
+            exec(QString("SetMemoryBreakpointCommandCondition %1, \"%2\"").arg(addrText).arg(newBp.commandCondition));
+            exec(QString("ResetMemoryBreakpointHitCount %1, %2").arg(addrText).arg(ToPtrString(newBp.hitCount)));
+            exec(QString("SetMemoryBreakpointFastResume %1, %2").arg(addrText).arg(newBp.fastResume));
+            exec(QString("SetMemoryBreakpointSilent %1, %2").arg(addrText).arg(newBp.silent));
+            exec(QString("SetMemoryBreakpointSingleshoot %1, %2").arg(addrText).arg(newBp.singleshoot));
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 void BreakpointsView::resetHitCountBreakpointSlot()

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -577,7 +577,7 @@ void BreakpointsView::followBreakpointSlot()
 void BreakpointsView::removeBreakpointSlot()
 {
     for(int i : getSelection())
-        if(isValidBp(i))
+        if(isValidBp(i)) //TODO: remove inactive breakpoints
             Breakpoints::removeBP(selectedBp(i));
 }
 
@@ -593,7 +593,14 @@ void BreakpointsView::editBreakpointSlot()
     if(!isValidBp())
         return;
     auto & bp = selectedBp();
-    Breakpoints::editBP(bp.type, bp.type == bp_dll ? bp.mod : ToPtrString(bp.addr), this);
+    if(bp.type == bp_dll)
+    {
+        Breakpoints::editBP(bp_dll, bp.mod, this);
+    }
+    else if(bp.active || bp.type == bp_exception)
+    {
+        Breakpoints::editBP(bp.type, ToPtrString(bp.addr), this);
+    } //TODO: edit inactive breakpoints
 }
 
 void BreakpointsView::resetHitCountBreakpointSlot()

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -1,4 +1,5 @@
 #include "BreakpointsView.h"
+#include "EditBreakpointDialog.h"
 #include "Bridge.h"
 #include "MenuBuilder.h"
 #include "Breakpoints.h"
@@ -577,8 +578,16 @@ void BreakpointsView::followBreakpointSlot()
 void BreakpointsView::removeBreakpointSlot()
 {
     for(int i : getSelection())
-        if(isValidBp(i)) //TODO: remove inactive breakpoints
-            Breakpoints::removeBP(selectedBp(i));
+    {
+        if(isValidBp(i))
+        {
+            const BRIDGEBP & bp = selectedBp(i);
+            if(bp.active)
+                Breakpoints::removeBP(bp);
+            else
+                DbgCmdExec(QString("bc \"%1\":$%2").arg(bp.mod).arg(ToHexString(bp.addr)));
+        }
+    }
 }
 
 void BreakpointsView::toggleBreakpointSlot()

--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -5,7 +5,6 @@
 #include "Bridge.h"
 #include "YaraRuleSelectionDialog.h"
 #include "EntropyDialog.h"
-#include "LineEditDialog.h"
 #include "BrowseDialog.h"
 #include <QVBoxLayout>
 #include <QProcess>
@@ -503,12 +502,13 @@ void SymbolView::moduleContextMenu(QMenu* wMenu)
 
 void SymbolView::moduleFollow()
 {
-    DbgCmdExecDirect(QString("disasm " + mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 0) + "+1000").toUtf8().constData());
+    DbgCmdExec(QString("disasm " + mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 0) + "+1000").toUtf8().constData());
 }
 
 void SymbolView::moduleEntryFollow()
 {
-    DbgCmdExecDirect(QString("disasm " + mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 1) + ":entry").toUtf8().constData());
+    //Test case: libstdc++-6.dll
+    DbgCmdExec(QString("disasm \"" + mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 1) + "\":entry").toUtf8().constData());
 }
 
 void SymbolView::moduleCopyPath()
@@ -563,7 +563,6 @@ void SymbolView::moduleDownloadAllSymbols()
 
 void SymbolView::moduleLoad()
 {
-    QString cmd;
     if(!DbgIsDebugging())
         return;
 
@@ -576,7 +575,6 @@ void SymbolView::moduleLoad()
 
 void SymbolView::moduleFree()
 {
-    QString cmd;
     if(!DbgIsDebugging())
         return;
 
@@ -698,18 +696,14 @@ void SymbolView::moduleSetUser()
 
 void SymbolView::moduleSetParty()
 {
-    LineEditDialog mLineEdit(this);
     int party;
     duint modbase = DbgValFromString(mModuleList->mCurList->getCellContent(mModuleList->mCurList->getInitialSelection(), 0).toUtf8().constData());
     party = DbgFunctions()->ModGetParty(modbase);
-    mLineEdit.setWindowIcon(DIcon("bookmark.png"));
-    mLineEdit.setWindowTitle(tr("Mark the party of the module as"));
-    mLineEdit.setText(QString::number(party));
-    mLineEdit.setPlaceholderText(tr("0 is user module, 1 is system module."));
-    if(mLineEdit.exec() == QDialog::Accepted)
+    QString mLineEditeditText;
+    if(SimpleInputBox(this, tr("Mark the party of the module as"), QString::number(party), mLineEditeditText, tr("0 is user module, 1 is system module."), &DIcon("bookmark.png")))
     {
         bool ok;
-        party = mLineEdit.editText.toInt(&ok);
+        party = mLineEditeditText.toInt(&ok);
         int i = mModuleList->mCurList->getInitialSelection();
         if(ok)
         {
@@ -729,11 +723,7 @@ void SymbolView::moduleSetParty()
             mModuleList->mCurList->reloadData();
         }
         else
-        {
-            QMessageBox msg(QMessageBox::Critical, tr("Error"), tr("The party number can only be an integer"));
-            msg.setWindowIcon(DIcon("compile-error.png"));
-            msg.exec();
-        }
+            SimpleErrorBox(this, tr("Error"), tr("The party number can only be an integer"));
     }
 }
 


### PR DESCRIPTION
This is a tracking branch. Currently it adds a special format DLL:$RVA that BpGet recognizes even if DLL is not loaded, so commands like "bpc" can remove these breakpoints. GUI is under development.

Other bugs fixed:
* Allow going to entrypoint of libstdc++-6.dll in SymbolsView