### PR TITLE
Build date plugin export

### DIFF
--- a/src/dbg/_plugins.cpp
+++ b/src/dbg/_plugins.cpp
@@ -187,3 +187,8 @@ PLUG_IMPEXP bool _plugin_unregisterformatfunction(int pluginHandle, const char* 
 {
     return pluginformatfuncunregister(pluginHandle, type);
 }
+
+PLUG_IMPEXP const char* _plugin_getbuilddate()
+{
+    return __DATE__;
+}

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -319,6 +319,7 @@ PLUG_IMPEXP bool _plugin_load(const char* pluginName);
 PLUG_IMPEXP duint _plugin_hash(const void* data, duint size);
 PLUG_IMPEXP bool _plugin_registerformatfunction(int pluginHandle, const char* type, CBPLUGINFORMATFUNCTION cbFunction, void* userdata);
 PLUG_IMPEXP bool _plugin_unregisterformatfunction(int pluginHandle, const char* type);
+PLUG_IMPEXP const char* _plugin_getbuilddate();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi,
I'm the dude with the updater plugin. I used the modified file date of "x64dbg.exe" previously to compare it with the latest snapshots timestamp. I think it would be nicer to comare it against the build date so I added a plugin export for that.