### PR TITLE
Use keys to select in dump

### DIFF
--- a/src/gui/Src/BasicView/AbstractStdTable.cpp
+++ b/src/gui/Src/BasicView/AbstractStdTable.cpp
@@ -590,12 +590,12 @@ void AbstractStdTable::setSingleSelection(int index)
     emit selectionChangedSignal(index);
 }
 
-int AbstractStdTable::getInitialSelection()
+int AbstractStdTable::getInitialSelection() const
 {
     return mSelection.firstSelectedIndex;
 }
 
-QList<int> AbstractStdTable::getSelection()
+QList<int> AbstractStdTable::getSelection() const
 {
     QList<int> selection;
     selection.reserve(mSelection.toIndex - mSelection.fromIndex);
@@ -657,7 +657,7 @@ void AbstractStdTable::selectAll()
     emit selectionChangedSignal(index);
 }
 
-bool AbstractStdTable::isSelected(int base, int offset)
+bool AbstractStdTable::isSelected(int base, int offset) const
 {
     int wIndex = base + offset;
 

--- a/src/gui/Src/BasicView/AbstractStdTable.h
+++ b/src/gui/Src/BasicView/AbstractStdTable.h
@@ -27,14 +27,14 @@ public:
     void expandTop();
     void expandBottom();
     void setSingleSelection(int index);
-    int getInitialSelection();
-    QList<int> getSelection();
+    int getInitialSelection() const;
+    QList<int> getSelection() const;
     void selectStart();
     void selectEnd();
     void selectNext();
     void selectPrevious();
     void selectAll();
-    bool isSelected(int base, int offset);
+    bool isSelected(int base, int offset) const;
     bool scrollSelect(int offset);
 
     // Data Management

--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -1567,22 +1567,22 @@ void Disassembly::setSingleSelection(dsint index)
     emit selectionChanged(rvaToVa(index));
 }
 
-dsint Disassembly::getInitialSelection()
+dsint Disassembly::getInitialSelection() const
 {
     return mSelection.firstSelectedIndex;
 }
 
-dsint Disassembly::getSelectionSize()
+dsint Disassembly::getSelectionSize() const
 {
     return mSelection.toIndex - mSelection.fromIndex + 1;
 }
 
-dsint Disassembly::getSelectionStart()
+dsint Disassembly::getSelectionStart() const
 {
     return mSelection.fromIndex;
 }
 
-dsint Disassembly::getSelectionEnd()
+dsint Disassembly::getSelectionEnd() const
 {
     return mSelection.toIndex;
 }
@@ -1670,7 +1670,7 @@ bool Disassembly::isSelected(dsint base, dsint offset)
         return false;
 }
 
-bool Disassembly::isSelected(QList<Instruction_t>* buffer, int index)
+bool Disassembly::isSelected(QList<Instruction_t>* buffer, int index) const
 {
     if(buffer->size() > 0 && index >= 0 && index < buffer->size())
     {
@@ -1685,7 +1685,7 @@ bool Disassembly::isSelected(QList<Instruction_t>* buffer, int index)
     }
 }
 
-duint Disassembly::getSelectedVa()
+duint Disassembly::getSelectedVa() const
 {
     // Wrapper around commonly used code:
     // Converts the selected index to a valid virtual address
@@ -2010,12 +2010,12 @@ const duint Disassembly::getBase() const
     return mMemPage->getBase();
 }
 
-duint Disassembly::getSize()
+duint Disassembly::getSize() const
 {
     return mMemPage->getSize();
 }
 
-duint Disassembly::getTableOffsetRva()
+duint Disassembly::getTableOffsetRva() const
 {
     return mInstBuffer.size() ? mInstBuffer.at(0).rva : 0;
 }
@@ -2056,14 +2056,14 @@ void Disassembly::historyNext()
     GuiUpdateAllViews();
 }
 
-bool Disassembly::historyHasPrevious()
+bool Disassembly::historyHasPrevious() const
 {
     if(!mCurrentVa || !mVaHistory.size()) //we are at the earliest history entry
         return false;
     return true;
 }
 
-bool Disassembly::historyHasNext()
+bool Disassembly::historyHasNext() const
 {
     int size = mVaHistory.size();
     if(!size || mCurrentVa >= mVaHistory.size() - 1) //we are at the newest history entry
@@ -2164,7 +2164,7 @@ bool Disassembly::hightlightToken(const CapstoneTokenizer::SingleToken & token)
     return true;
 }
 
-bool Disassembly::isHighlightMode()
+bool Disassembly::isHighlightMode() const
 {
     return mHighlightingMode;
 }

--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -61,15 +61,15 @@ public:
     // Selection Management
     void expandSelectionUpTo(dsint to);
     void setSingleSelection(dsint index);
-    dsint getInitialSelection();
-    dsint getSelectionSize();
-    dsint getSelectionStart();
-    dsint getSelectionEnd();
+    dsint getInitialSelection() const;
+    dsint getSelectionSize() const;
+    dsint getSelectionStart() const;
+    dsint getSelectionEnd() const;
     void selectNext(bool expand);
     void selectPrevious(bool expand);
     bool isSelected(dsint base, dsint offset);
-    bool isSelected(QList<Instruction_t>* buffer, int index);
-    duint getSelectedVa();
+    bool isSelected(QList<Instruction_t>* buffer, int index) const;
+    duint getSelectedVa() const;
 
     // Update/Reload/Refresh/Repaint
     void prepareData() override;
@@ -79,15 +79,15 @@ public:
     duint rvaToVa(dsint rva) const;
     void disassembleClear();
     const duint getBase() const;
-    duint getSize();
-    duint getTableOffsetRva();
+    duint getSize() const;
+    duint getTableOffsetRva() const;
 
     // history management
     void historyClear();
     void historyPrevious();
     void historyNext();
-    bool historyHasPrevious();
-    bool historyHasNext();
+    bool historyHasPrevious() const;
+    bool historyHasNext() const;
 
     //disassemble
     void disassembleAt(dsint parVA, dsint parCIP, bool history, dsint newTableOffset);
@@ -106,7 +106,7 @@ public:
     void unfold(dsint rva);
     void ShowDisassemblyPopup(duint addr, int x, int y);
     bool hightlightToken(const CapstoneTokenizer::SingleToken & token);
-    bool isHighlightMode();
+    bool isHighlightMode() const;
 
 signals:
     void selectionChanged(dsint parVA);

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -4,6 +4,13 @@
 #include "StringUtil.h"
 #include <QMessageBox>
 
+static int getStringMaxLength(HexDump::DataDescriptor desc);
+static int byteStringMaxLength(HexDump::ByteViewMode mode);
+static int wordStringMaxLength(HexDump::WordViewMode mode);
+static int dwordStringMaxLength(HexDump::DwordViewMode mode);
+static int qwordStringMaxLength(HexDump::QwordViewMode mode);
+static int twordStringMaxLength(HexDump::TwordViewMode mode);
+
 HexDump::HexDump(QWidget* parent)
     : AbstractTableView(parent)
 {
@@ -168,17 +175,17 @@ void HexDump::gotoNextSlot()
     printDumpAt(mHistory.historyNext());
 }
 
-duint HexDump::rvaToVa(dsint rva)
+duint HexDump::rvaToVa(dsint rva) const
 {
     return mMemPage->va(rva);
 }
 
-duint HexDump::getTableOffsetRva()
+duint HexDump::getTableOffsetRva() const
 {
     return getTableOffset() * getBytePerRowCount() - mByteOffset;
 }
 
-QString HexDump::makeAddrText(duint va)
+QString HexDump::makeAddrText(duint va) const
 {
     char label[MAX_LABEL_SIZE] = "";
     QString addrText = "";
@@ -667,22 +674,22 @@ void HexDump::setSingleSelection(dsint rva)
     emit selectionUpdated();
 }
 
-dsint HexDump::getInitialSelection()
+dsint HexDump::getInitialSelection() const
 {
     return mSelection.firstSelectedIndex;
 }
 
-dsint HexDump::getSelectionStart()
+dsint HexDump::getSelectionStart() const
 {
     return mSelection.fromIndex;
 }
 
-dsint HexDump::getSelectionEnd()
+dsint HexDump::getSelectionEnd() const
 {
     return mSelection.toIndex;
 }
 
-bool HexDump::isSelected(dsint rva)
+bool HexDump::isSelected(dsint rva) const
 {
     return rva >= mSelection.fromIndex && rva <= mSelection.toIndex;
 }
@@ -1083,37 +1090,37 @@ int HexDump::getSizeOf(DataSize size)
     return int(size);
 }
 
-int HexDump::getStringMaxLength(DataDescriptor desc)
+static int getStringMaxLength(HexDump::DataDescriptor desc)
 {
     int wLength = 0;
 
     switch(desc.itemSize)
     {
-    case Byte:
+    case HexDump::Byte:
     {
         wLength = byteStringMaxLength(desc.byteMode);
     }
     break;
 
-    case Word:
+    case HexDump::Word:
     {
         wLength = wordStringMaxLength(desc.wordMode);
     }
     break;
 
-    case Dword:
+    case HexDump::Dword:
     {
         wLength = dwordStringMaxLength(desc.dwordMode);
     }
     break;
 
-    case Qword:
+    case HexDump::Qword:
     {
         wLength = qwordStringMaxLength(desc.qwordMode);
     }
     break;
 
-    case Tword:
+    case HexDump::Tword:
     {
         wLength = twordStringMaxLength(desc.twordMode);
     }
@@ -1129,31 +1136,31 @@ int HexDump::getStringMaxLength(DataDescriptor desc)
     return wLength;
 }
 
-int HexDump::byteStringMaxLength(ByteViewMode mode)
+static int byteStringMaxLength(HexDump::ByteViewMode mode)
 {
     int wLength = 0;
 
     switch(mode)
     {
-    case HexByte:
+    case HexDump::HexByte:
     {
         wLength = 2;
     }
     break;
 
-    case AsciiByte:
+    case HexDump::AsciiByte:
     {
         wLength = 0;
     }
     break;
 
-    case SignedDecByte:
+    case HexDump::SignedDecByte:
     {
         wLength = 4;
     }
     break;
 
-    case UnsignedDecByte:
+    case HexDump::UnsignedDecByte:
     {
         wLength = 3;
     }
@@ -1169,31 +1176,31 @@ int HexDump::byteStringMaxLength(ByteViewMode mode)
     return wLength;
 }
 
-int HexDump::wordStringMaxLength(WordViewMode mode)
+static int wordStringMaxLength(HexDump::WordViewMode mode)
 {
     int wLength = 0;
 
     switch(mode)
     {
-    case HexWord:
+    case HexDump::HexWord:
     {
         wLength = 4;
     }
     break;
 
-    case UnicodeWord:
+    case HexDump::UnicodeWord:
     {
         wLength = 0;
     }
     break;
 
-    case SignedDecWord:
+    case HexDump::SignedDecWord:
     {
         wLength = 6;
     }
     break;
 
-    case UnsignedDecWord:
+    case HexDump::UnsignedDecWord:
     {
         wLength = 5;
     }
@@ -1209,31 +1216,31 @@ int HexDump::wordStringMaxLength(WordViewMode mode)
     return wLength;
 }
 
-int HexDump::dwordStringMaxLength(DwordViewMode mode)
+static int dwordStringMaxLength(HexDump::DwordViewMode mode)
 {
     int wLength = 0;
 
     switch(mode)
     {
-    case HexDword:
+    case HexDump::HexDword:
     {
         wLength = 8;
     }
     break;
 
-    case SignedDecDword:
+    case HexDump::SignedDecDword:
     {
         wLength = 11;
     }
     break;
 
-    case UnsignedDecDword:
+    case HexDump::UnsignedDecDword:
     {
         wLength = 10;
     }
     break;
 
-    case FloatDword:
+    case HexDump::FloatDword:
     {
         wLength = 13;
     }
@@ -1249,31 +1256,31 @@ int HexDump::dwordStringMaxLength(DwordViewMode mode)
     return wLength;
 }
 
-int HexDump::qwordStringMaxLength(QwordViewMode mode)
+static int qwordStringMaxLength(HexDump::QwordViewMode mode)
 {
     int wLength = 0;
 
     switch(mode)
     {
-    case HexQword:
+    case HexDump::HexQword:
     {
         wLength = 16;
     }
     break;
 
-    case SignedDecQword:
+    case HexDump::SignedDecQword:
     {
         wLength = 20;
     }
     break;
 
-    case UnsignedDecQword:
+    case HexDump::UnsignedDecQword:
     {
         wLength = 20;
     }
     break;
 
-    case DoubleQword:
+    case HexDump::DoubleQword:
     {
         wLength = 23;
     }
@@ -1289,13 +1296,13 @@ int HexDump::qwordStringMaxLength(QwordViewMode mode)
     return wLength;
 }
 
-int HexDump::twordStringMaxLength(TwordViewMode mode)
+static int twordStringMaxLength(HexDump::TwordViewMode mode)
 {
     int wLength = 0;
 
     switch(mode)
     {
-    case FloatTword:
+    case HexDump::FloatTword:
     {
         wLength = 29;
     }
@@ -1311,7 +1318,7 @@ int HexDump::twordStringMaxLength(TwordViewMode mode)
     return wLength;
 }
 
-int HexDump::getItemIndexFromX(int x)
+int HexDump::getItemIndexFromX(int x) const
 {
     int wColIndex = getColumnIndexFromX(x);
 
@@ -1354,12 +1361,12 @@ dsint HexDump::getItemStartingAddress(int x, int y)
     return wStartingAddress;
 }
 
-int HexDump::getBytePerRowCount()
+int HexDump::getBytePerRowCount() const
 {
     return mDescriptor.at(0).itemCount * getSizeOf(mDescriptor.at(0).data.itemSize);
 }
 
-int HexDump::getItemPixelWidth(ColumnDescriptor desc)
+int HexDump::getItemPixelWidth(ColumnDescriptor desc) const
 {
     int wCharWidth = getCharWidth();
     int wItemPixWidth = getStringMaxLength(desc.data) * wCharWidth + wCharWidth;

--- a/src/gui/Src/BasicView/HexDump.h
+++ b/src/gui/Src/BasicView/HexDump.h
@@ -101,35 +101,28 @@ public:
     // Selection Management
     void expandSelectionUpTo(dsint rva);
     void setSingleSelection(dsint rva);
-    dsint getInitialSelection();
-    dsint getSelectionStart();
-    dsint getSelectionEnd();
-    bool isSelected(dsint rva);
+    dsint getInitialSelection() const;
+    dsint getSelectionStart() const;
+    dsint getSelectionEnd() const;
+    bool isSelected(dsint rva) const;
 
     virtual void getColumnRichText(int col, dsint rva, RichTextPainter::List & richText);
-    int getSizeOf(DataSize size);
+
+    static int getSizeOf(DataSize size);
 
     void toString(DataDescriptor desc, duint rva, byte_t* data, RichTextPainter::CustomRichText_t & richText);
 
     void byteToString(duint rva, byte_t byte, ByteViewMode mode, RichTextPainter::CustomRichText_t & richText);
     void wordToString(duint rva, uint16 word, WordViewMode mode, RichTextPainter::CustomRichText_t & richText);
-    void dwordToString(duint rva, uint32 dword, DwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
-    void qwordToString(duint rva, uint64 qword, QwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
-    void twordToString(duint rva, void* tword, TwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
+    static void dwordToString(duint rva, uint32 dword, DwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
+    static void qwordToString(duint rva, uint64 qword, QwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
+    static void twordToString(duint rva, void* tword, TwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
 
-    int getStringMaxLength(DataDescriptor desc);
-
-    int byteStringMaxLength(ByteViewMode mode);
-    int wordStringMaxLength(WordViewMode mode);
-    int dwordStringMaxLength(DwordViewMode mode);
-    int qwordStringMaxLength(QwordViewMode mode);
-    int twordStringMaxLength(TwordViewMode mode);
-
-    int getItemIndexFromX(int x);
+    int getItemIndexFromX(int x) const;
     dsint getItemStartingAddress(int x, int y);
 
-    int getBytePerRowCount();
-    int getItemPixelWidth(ColumnDescriptor desc);
+    int getBytePerRowCount() const;
+    int getItemPixelWidth(ColumnDescriptor desc) const;
 
     //descriptor management
     void appendDescriptor(int width, QString title, bool clickable, ColumnDescriptor descriptor);
@@ -137,9 +130,10 @@ public:
     void clearDescriptors();
 
     void printDumpAt(dsint parVA, bool select, bool repaint = true, bool updateTableOffset = true);
-    duint rvaToVa(dsint rva);
-    duint getTableOffsetRva();
-    QString makeAddrText(duint va);
+    duint rvaToVa(dsint rva) const;
+
+    duint getTableOffsetRva() const;
+    QString makeAddrText(duint va) const;
     QString makeCopyText();
 
     void setupCopyMenu();

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1792,10 +1792,13 @@ void RegistersView::paintEvent(QPaintEvent* event)
 
 void RegistersView::keyPressEvent(QKeyEvent* event)
 {
-    if(!DbgIsDebugging())
-        return;
-    if(event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
-        wCM_Modify->trigger();
+    if(DbgIsDebugging())
+    {
+        int key = event->key();
+        if(key == Qt::Key_Enter || key == Qt::Key_Return)
+            wCM_Modify->trigger();
+    }
+    QScrollArea::keyPressEvent(event);
 }
 
 QSize RegistersView::sizeHint() const

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -32,7 +32,9 @@ public:
     enum REGISTER_NAME
     {
         CAX, CCX, CDX, CBX, CDI, CBP, CSI, CSP,
+#ifdef _WIN64
         R8, R9, R10, R11, R12, R13, R14, R15,
+#endif //_WIN64
         CIP,
         EFLAGS, CF, PF, AF, ZF, SF, TF, IF, DF, OF,
         GS, FS, ES, DS, CS, SS,
@@ -58,11 +60,14 @@ public:
         // MMX and XMM
         MM0, MM1, MM2, MM3, MM4, MM5, MM6, MM7,
         XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7,
+#ifdef _WIN64
         XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15,
+#endif //_WIN64
         // YMM
-        YMM0, YMM1, YMM2, YMM3, YMM4, YMM5, YMM6, YMM7, YMM8,
-        YMM9, YMM10, YMM11, YMM12, YMM13, YMM14, YMM15,
-
+        YMM0, YMM1, YMM2, YMM3, YMM4, YMM5, YMM6, YMM7,
+#ifdef _WIN64
+        YMM8, YMM9, YMM10, YMM11, YMM12, YMM13, YMM14, YMM15,
+#endif //_WIN64
         UNKNOWN
     };
 


### PR DESCRIPTION
Arrow keys are now used to select in dump, not scroll in dump. Dump will scroll when selection is out of viewport. Shift key is to be supported.