### PR TITLE
Fixed a crash when tracing into far jump

### DIFF
--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -218,6 +218,10 @@ static void HandleCapstoneOperand(const Zydis & cp, int opindex, DISASM_ARGTYPE*
         *argType = arg_normal;
         break;
 
+    case ZYDIS_OPERAND_TYPE_POINTER:
+        *argType = arg_normal;
+        break;
+
     case ZYDIS_OPERAND_TYPE_MEMORY:
     {
         *argType = arg_memory;

--- a/src/dbg/commands/cmd-undocumented.cpp
+++ b/src/dbg/commands/cmd-undocumented.cpp
@@ -295,6 +295,9 @@ bool cbInstrZydis(int argc, char* argv[])
                                  mem.disp.value);
         }
         break;
+        case ZYDIS_OPERAND_TYPE_POINTER:
+            dprintf_untranslated("pointer: %X:%p\n", op.ptr.segment, op.ptr.offset);
+            break;
         }
     }
 

--- a/src/dbg/disasm_helper.cpp
+++ b/src/dbg/disasm_helper.cpp
@@ -182,6 +182,11 @@ static void HandleCapstoneOperand(Zydis & cp, int opindex, DISASM_ARG* arg, bool
     }
     break;
 
+    case ZYDIS_OPERAND_TYPE_POINTER:
+        arg->type = arg_normal;
+        arg->value = op.ptr.offset;
+        break;
+
     default:
         break;
     }


### PR DESCRIPTION
Previously when you trace while recording a trace over a far jump, such as an API call, x32dbg crashes.