### PR TITLE
Close, stop and delete current trace file

### DIFF
--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -934,8 +934,7 @@ void TraceBrowser::closeDeleteSlot()
     {
         if(DbgValFromString("tr.runtraceenabled()") == 1)
             DbgCmdExecDirect("StopRunTrace");
-        if(mTraceFile->Delete() == false)
-            SimpleErrorBox(this, tr("Error"), "del error");
+        mTraceFile->Delete();
         delete mTraceFile;
         mTraceFile = nullptr;
         reloadData();

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -446,6 +446,10 @@ void TraceBrowser::setupRightClickContextMenu()
     {
         return mTraceFile != nullptr;
     });
+    mMenuBuilder->addAction(makeAction(DIcon("fatal-error.png"), tr("Close and delete"), SLOT(closeDeleteSlot())), [this](QMenu*)
+    {
+        return mTraceFile != nullptr;
+    });
     mMenuBuilder->addSeparator();
     auto isValid = [this](QMenu*)
     {
@@ -919,6 +923,19 @@ void TraceBrowser::closeFileSlot()
     delete mTraceFile;
     mTraceFile = nullptr;
     reloadData();
+}
+
+void TraceBrowser::closeDeleteSlot()
+{
+    QMessageBox msgbox(QMessageBox::Critical, tr("Close and delete"), tr("Are you really going to delete this file?"), QMessageBox::Yes | QMessageBox::Cancel, this);
+    if(msgbox.exec() == QMessageBox::Yes)
+    {
+        if(mTraceFile->Delete() == false)
+            SimpleErrorBox(this, tr("Error"), "del error");
+        delete mTraceFile;
+        mTraceFile = nullptr;
+        reloadData();
+    }
 }
 
 void TraceBrowser::parseFinishedSlot()

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -919,6 +919,8 @@ void TraceBrowser::toggleRunTraceSlot()
 
 void TraceBrowser::closeFileSlot()
 {
+    if(DbgValFromString("tr.runtraceenabled()") == 1)
+        DbgCmdExec("StopRunTrace");
     mTraceFile->Close();
     delete mTraceFile;
     mTraceFile = nullptr;
@@ -930,6 +932,8 @@ void TraceBrowser::closeDeleteSlot()
     QMessageBox msgbox(QMessageBox::Critical, tr("Close and delete"), tr("Are you really going to delete this file?"), QMessageBox::Yes | QMessageBox::Cancel, this);
     if(msgbox.exec() == QMessageBox::Yes)
     {
+        if(DbgValFromString("tr.runtraceenabled()") == 1)
+            DbgCmdExecDirect("StopRunTrace");
         if(mTraceFile->Delete() == false)
             SimpleErrorBox(this, tr("Error"), "del error");
         delete mTraceFile;

--- a/src/gui/Src/Tracer/TraceBrowser.h
+++ b/src/gui/Src/Tracer/TraceBrowser.h
@@ -106,6 +106,7 @@ public slots:
     void openSlot(const QString & fileName);
     void toggleRunTraceSlot();
     void closeFileSlot();
+    void closeDeleteSlot();
     void parseFinishedSlot();
     void tokenizerConfigUpdatedSlot();
 

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -42,6 +42,7 @@ bool TraceFileReader::Open(const QString & fileName)
         emit parseFinished();
         return false;
     }
+
 }
 
 void TraceFileReader::Close()
@@ -60,6 +61,23 @@ void TraceFileReader::Close()
     error = false;
 }
 
+bool TraceFileReader::Delete()
+{
+    if(parser != NULL)
+    {
+        parser->requestInterruption();
+        parser->wait();
+    }
+    bool value = traceFile.remove();
+    progress.store(0);
+    length = 0;
+    fileIndex.clear();
+    hashValue = 0;
+    EXEPath.clear();
+    error = false;
+    return value;
+}
+
 void TraceFileReader::parseFinishedSlot()
 {
     if(!error)
@@ -74,27 +92,27 @@ void TraceFileReader::parseFinishedSlot()
     //GuiAddLogMessage(QString("%1;%2;%3\r\n").arg(i.first).arg(i.second.first).arg(i.second.second).toUtf8().constData());
 }
 
-bool TraceFileReader::isError()
+bool TraceFileReader::isError() const
 {
     return error;
 }
 
-int TraceFileReader::Progress()
+int TraceFileReader::Progress() const
 {
     return progress.load();
 }
 
-unsigned long long TraceFileReader::Length()
+unsigned long long TraceFileReader::Length() const
 {
     return length;
 }
 
-duint TraceFileReader::HashValue()
+duint TraceFileReader::HashValue() const
 {
     return hashValue;
 }
 
-QString TraceFileReader::ExePath()
+QString TraceFileReader::ExePath() const
 {
     return EXEPath;
 }

--- a/src/gui/Src/Tracer/TraceFileReader.h
+++ b/src/gui/Src/Tracer/TraceFileReader.h
@@ -17,18 +17,19 @@ public:
     TraceFileReader(QObject* parent = NULL);
     bool Open(const QString & fileName);
     void Close();
-    bool isError();
-    int Progress();
+    bool Delete();
+    bool isError() const;
+    int Progress() const;
 
-    unsigned long long Length();
+    unsigned long long Length() const;
 
     REGDUMP Registers(unsigned long long index);
     void OpCode(unsigned long long index, unsigned char* buffer, int* opcodeSize);
     DWORD ThreadId(unsigned long long index);
     int MemoryAccessCount(unsigned long long index);
     void MemoryAccessInfo(unsigned long long index, duint* address, duint* oldMemory, duint* newMemory, bool* isValid);
-    duint HashValue();
-    QString ExePath();
+    duint HashValue() const;
+    QString ExePath() const;
 
     void purgeLastPage();
 


### PR DESCRIPTION
Previously when you close a trace file, it will not stop recording a trace. Now it does. Added a new action to close and delete current trace to save your disk space.