### PR TITLE
GUI: Fix build for latest Qt

### DIFF
--- a/src/gui/Src/Gui/AppearanceDialog.h
+++ b/src/gui/Src/Gui/AppearanceDialog.h
@@ -1,6 +1,7 @@
 #ifndef APPEARANCEDIALOG_H
 #define APPEARANCEDIALOG_H
 
+#include <QAction>
 #include <QDialog>
 #include <QMap>
 

--- a/src/gui/Src/Gui/WordEditDialog.h
+++ b/src/gui/Src/Gui/WordEditDialog.h
@@ -1,6 +1,7 @@
 #ifndef WORDEDITDIALOG_H
 #define WORDEDITDIALOG_H
 
+#include <QValidator>
 #include <QDialog>
 #include <QPushButton>
 #include "Imports.h"


### PR DESCRIPTION
I think this was introduced in Qt11. I saw a similar error in RPCS3 repo regarding forward declaration.

If anyone else could validate that it doesn't build on 5.11.1 without this fix would be great as I don't work on C++ that much.

Happy Hacktoberfest!