### PR TITLE
FIXED: Uninitialized variable when calculating registers view height

### DIFF
--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1447,10 +1447,11 @@ void RegistersView::fontsUpdatedSlot()
     wRowsHeight = (wRowsHeight % 2) == 0 ? wRowsHeight : wRowsHeight + 1;
     mRowHeight = wRowsHeight;
     mCharWidth = QFontMetrics(this->font()).averageCharWidth();
-    //adjust the height of the area.
-    setFixedHeight(getEstimateHeight());
+
     //reload layout because the layout is dependent on the font.
     InitMappings();
+    //adjust the height of the area.
+    setFixedHeight(getEstimateHeight());
     reload();
 }
 


### PR DESCRIPTION
_InitMappings()_ is now called before _getEstimateHeight()_.

_getEstimateHeight()_ calculates the height of the registers view. The calculation is based on _mRowsNeeded_ which is set in InitMappings(). However, _getEstimateHeight()_  was called before _InitMappings()_ and therefore the calculation was based on an uninitialized variable.