### PR TITLE
add the expression function matchstrA and matchstrW.

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -791,6 +791,8 @@ static void cbGenericBreakpoint(BP_TYPE bptype, void* ExceptionAddress = nullptr
     if(bptype == BPNORMAL && cookie.HandleBreakpoint(CIP))
         return;
 
+    MemUpdateMap();
+
     BREAKPOINT* bpPtr = nullptr;
     //NOTE: this locking is very tricky, make sure you understand it before modifying anything
     EXCLUSIVE_ACQUIRE(LockBreakpoints);

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -133,6 +133,8 @@ void ExpressionFunctions::Init()
 
     //Undocumented
     RegisterEasy("bpgoto", bpgoto);
+    RegisterEasy("matchstrA,matchstr", MatchStrA); //match string with regex
+    RegisterEasy("matchstrW", MatchStrW); //match string with regex
 }
 
 bool ExpressionFunctions::Register(const String & name, int argc, const CBEXPRESSIONFUNCTION & cbFunction, void* userdata)

--- a/src/dbg/exprfunc.h
+++ b/src/dbg/exprfunc.h
@@ -70,4 +70,6 @@ namespace Exprfunc
     duint argset(duint index, duint value);
 
     duint bpgoto(duint cip);
+    duint MatchStrA(duint src, duint patstr);
+    duint MatchStrW(duint src, duint patstr);
 }

--- a/src/dbg/stringutils.cpp
+++ b/src/dbg/stringutils.cpp
@@ -377,6 +377,26 @@ WString StringUtils::LocalCpToUtf16(const char* str)
     return convertedString;
 }
 
+String StringUtils::Utf16ToLocalCp(const WString & str)
+{
+    return Utf16ToLocalCp(str.c_str());
+}
+
+String StringUtils::Utf16ToLocalCp(const wchar_t* str)
+{
+    String convertedString;
+    if(!str || !*str)
+        return convertedString;
+    int requiredSize = WideCharToMultiByte(CP_ACP, 0, str, -1, nullptr, 0, NULL, NULL);
+    if(requiredSize > 0)
+    {
+        convertedString.resize(requiredSize - 1);
+        if(!WideCharToMultiByte(CP_ACP, 0, str, -1, (char*)convertedString.c_str(), requiredSize, NULL, NULL))
+            convertedString.clear();
+    }
+    return convertedString;
+}
+
 //Taken from: https://stackoverflow.com/a/24315631
 void StringUtils::ReplaceAll(String & s, const String & from, const String & to)
 {
@@ -464,6 +484,14 @@ String StringUtils::ToLower(const String & s)
     for(size_t i = 0; i < result.size(); i++)
         result[i] = tolower(result[i]);
     return result;
+}
+
+int StringUtils::iFind(const String & s, const String & strfind)
+{
+    auto pos = ToLower(s).find(ToLower(strfind));
+    if(pos == String::npos)
+        return -1;
+    return pos;
 }
 
 bool StringUtils::StartsWith(const String & str, const String & prefix)

--- a/src/dbg/stringutils.h
+++ b/src/dbg/stringutils.h
@@ -31,6 +31,8 @@ public:
     static String LocalCpToUtf8(const char* str);
     static WString LocalCpToUtf16(const String & wstr);
     static WString LocalCpToUtf16(const char* wstr);
+    static String Utf16ToLocalCp(const WString & str);
+    static String Utf16ToLocalCp(const wchar_t* str);
     static void ReplaceAll(String & s, const String & from, const String & to);
     static void ReplaceAll(WString & s, const WString & from, const WString & to);
     static String vsprintf(_In_z_ _Printf_format_string_ const char* format, va_list args);
@@ -38,6 +40,7 @@ public:
     static WString vsprintf(_In_z_ _Printf_format_string_ const wchar_t* format, va_list args);
     static WString sprintf(_In_z_ _Printf_format_string_ const wchar_t* format, ...);
     static String ToLower(const String & s);
+    static int iFind(const String & s, const String & strfind);
     static bool StartsWith(const String & str, const String & prefix);
     static bool EndsWith(const String & str, const String & suffix);
     static bool FromHex(const String & text, std::vector<unsigned char> & data, bool reverse = false);

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -21,6 +21,8 @@
 
 static bool dosignedcalc = false;
 
+#define  MAX_TMP_PARAM  5
+static std::string tmpFuncParams[MAX_TMP_PARAM + 1];
 /**
 \brief Returns whether we do signed or unsigned calculations.
 \return true if we do signed calculations, false for unsigned calculationss.
@@ -1709,6 +1711,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
         return false;
 
     if(string[0] == '['
+            || (string[0] == '#' && isdigit(string[1]) && string[2] == ':')
             || (isdigitduint(string[0]) && string[1] == ':' && string[2] == '[')
             || (string[1] == 's' && (string[0] == 'c' || string[0] == 'd' || string[0] == 'e' || string[0] == 'f' || string[0] == 'g' || string[0] == 's') && string[2] == ':' && string[3] == '[') //memory location
             || strstr(string, "byte:[")
@@ -1737,6 +1740,18 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             int new_size = string[0] - '0';
             if(new_size < read_size)
                 read_size = new_size;
+        }
+        else if(string[0] == '#' && string[2] == ':')
+        {
+            int ipos = string[1] - '0';
+            if(ipos > MAX_TMP_PARAM) ipos = MAX_TMP_PARAM;
+            tmpFuncParams[ipos] = string + 3;
+            if(value_size)
+                *value_size = read_size;
+            if(isvar)
+                *isvar = true;
+            *value = (duint)(tmpFuncParams[ipos].c_str());
+            return true;
         }
         else if(string[1] == 's' && string[2] == ':')
         {


### PR DESCRIPTION
Use conditional breakpoints like this
matchstrW([esp+4], #0:"filename") or matchstrA([esp+4], #0:"filename")
Fixed a read memory failure when the breakpoint was broken because the memory page information was not updated.