### PR TITLE
DBG: add OptionalHeader.AddressOfEntryPoint to the displayed symbols

### DIFF
--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -611,6 +611,12 @@ void GetModuleInfo(MODINFO & Info, ULONG_PTR FileMapVA)
             Info.entry = 0;
     }
 
+    // Setup the pseudo entry point symbol
+    Info.entrySymbol.name = "OptionalHeader.AddressOfEntryPoint";
+    Info.entrySymbol.forwarded = false;
+    Info.entrySymbol.ordinal = 0;
+    Info.entrySymbol.rva = moduleOEP;
+
     // Enumerate all PE sections
     WORD sectionCount = Info.headers->FileHeader.NumberOfSections;
     Info.sections.clear();

--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -91,6 +91,8 @@ struct MODINFO
     std::vector<MODRELOCATIONINFO> relocations;
     std::vector<duint> tlsCallbacks;
 
+    MODEXPORT entrySymbol;
+
     std::vector<MODEXPORT> exports;
     DWORD exportOrdinalBase = 0; //ordinal - 'exportOrdinalBase' = index in 'exports'
     std::vector<size_t> exportsByName; //index in 'exports', sorted by export name

--- a/src/dbg/symbolinfo.cpp
+++ b/src/dbg/symbolinfo.cpp
@@ -66,6 +66,15 @@ void SymEnum(duint Base, CBSYMBOLENUM EnumCallback, void* UserData)
                 symbolptr.symbol = &modInfo->exports.at(i);
                 cbData.cbSymbolEnum(&symbolptr, cbData.user);
             }
+
+            // Emit pseudo entry point symbol
+            {
+                SYMBOLPTR symbolptr;
+                symbolptr.modbase = Base;
+                symbolptr.symbol = &modInfo->entrySymbol;
+                cbData.cbSymbolEnum(&symbolptr, cbData.user);
+            }
+
             for(size_t i = 0; i < modInfo->imports.size(); i++)
             {
                 SYMBOLPTR symbolptr;
@@ -85,16 +94,6 @@ void SymEnum(duint Base, CBSYMBOLENUM EnumCallback, void* UserData)
             }
         }
     }
-
-    // Emit pseudo entry point symbol
-    /*SYMBOLINFO symbol;
-    memset(&symbol, 0, sizeof(SYMBOLINFO));
-    symbol.decoratedSymbol = "OptionalHeader.AddressOfEntryPoint";
-    symbol.addr = ModEntryFromAddr(Base);
-    if(symbol.addr)
-        EnumCallback(&symbol, UserData);
-
-    SymEnumImports(Base, EnumCallback, cbData);*/
 }
 
 void SymEnumFromCache(duint Base, CBSYMBOLENUM EnumCallback, void* UserData)


### PR DESCRIPTION
This PR fixes issue #2003, the OptionalHeader.AddressOfEntryPoint display broke after the symbols ui refactor. This PR restores the original functionality using the new API.