### PR TITLE
Add DLL ordinal to symbol table and fix symbol table comparator

### DIFF
--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -598,6 +598,7 @@ typedef struct SYMBOLINFO_
     SYMBOLTYPE type;
     bool freeDecorated;
     bool freeUndecorated;
+    DWORD ordinal;
 } SYMBOLINFO;
 
 typedef struct

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -1189,6 +1189,7 @@ void MODIMPORT::convertToGuiSymbol(duint base, SYMBOLINFO* info) const
     info->decoratedSymbol = (char*)name.c_str();
     info->undecoratedSymbol = (char*)undecoratedName.c_str();
     info->freeDecorated = info->freeUndecorated = false;
+    info->ordinal = 0;
 }
 
 void MODEXPORT::convertToGuiSymbol(duint base, SYMBOLINFO* info) const
@@ -1198,4 +1199,5 @@ void MODEXPORT::convertToGuiSymbol(duint base, SYMBOLINFO* info) const
     info->decoratedSymbol = (char*)name.c_str();
     info->undecoratedSymbol = (char*)undecoratedName.c_str();
     info->freeDecorated = info->freeUndecorated = false;
+    info->ordinal = ordinal;
 }

--- a/src/dbg/symbolsourcebase.h
+++ b/src/dbg/symbolsourcebase.h
@@ -28,6 +28,7 @@ struct SymbolInfo : SymbolInfoGui
         info->undecoratedSymbol = (char*)this->undecoratedName.c_str();
         info->type = sym_symbol;
         info->freeDecorated = info->freeUndecorated = false;
+        info->ordinal = 0;
     }
 };
 

--- a/src/gui/Src/Gui/ZehSymbolTable.h
+++ b/src/gui/Src/Gui/ZehSymbolTable.h
@@ -31,6 +31,7 @@ private:
     {
         ColAddr,
         ColType,
+        ColOrdinal,
         ColDecorated,
         ColUndecorated
     };

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -313,7 +313,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Privilege", 2);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "LocalVarsView", 3);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Module", 4);
-    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Symbol", 4);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Symbol", 5);
     guiUint.insert("SIMDRegistersDisplayMode", 0);
     addWindowPosConfig(guiUint, "AssembleDialog");
     addWindowPosConfig(guiUint, "AttachDialog");


### PR DESCRIPTION
This PR fixes issue #1997 and also fixes the symbol table comparator for descending sort. Previously the comparator wasn't a strict weak ordering, and it failed the msvc debug checks on equal keys.

This PR changes the bridge API for DbgGetSymbolInfo by adding a DWORD ordinal member to the SYMBOLINFO struct. I'm not sure how desirable this is, it would at least require the pluginsdk to be updated as well (maybe there is a more compatible way to pass the ordinal that I haven't figured out).