### PR TITLE
ZYDIS: Use ZydisOperandAction as an enum instead of a flag

### DIFF
--- a/src/dbg/commands/cmd-undocumented.cpp
+++ b/src/dbg/commands/cmd-undocumented.cpp
@@ -245,15 +245,23 @@ bool cbInstrZydis(int argc, char* argv[])
     dprintf_untranslated("imm[0].offset: %d, imm[0].size: %d\n", instr->raw.imm[0].offset, instr->raw.imm[0].size);
     dprintf_untranslated("imm[1].offset: %d, imm[1].size: %d\n", instr->raw.imm[1].offset, instr->raw.imm[1].size);
     dprintf_untranslated("size: %d, id: %d, opcount: %d\n", cp.Size(), cp.GetId(), instr->operandCount);
-    auto rwstr = [](uint8_t access)
+    auto rwstr = [](uint8_t action)
     {
-        if(access & ZYDIS_OPERAND_ACTION_READ && access & ZYDIS_OPERAND_ACTION_WRITE)
-            return "read+write";
-        if(access & ZYDIS_OPERAND_ACTION_READ)
+        switch(action)
+        {
+        case ZYDIS_OPERAND_ACTION_READ:
+        case ZYDIS_OPERAND_ACTION_CONDREAD:
             return "read";
-        if(access & ZYDIS_OPERAND_ACTION_WRITE)
+        case ZYDIS_OPERAND_ACTION_WRITE:
+        case ZYDIS_OPERAND_ACTION_CONDWRITE:
             return "write";
-        return "???";
+        case ZYDIS_OPERAND_ACTION_READWRITE:
+        case ZYDIS_OPERAND_ACTION_READ_CONDWRITE:
+        case ZYDIS_OPERAND_ACTION_CONDREAD_WRITE:
+            return "read+write";
+        default:
+            return "???";
+        }
     };
     auto vis = [](uint8_t visibility)
     {

--- a/src/zydis_wrapper/zydis_wrapper.cpp
+++ b/src/zydis_wrapper/zydis_wrapper.cpp
@@ -873,10 +873,22 @@ void Zydis::RegInfo(uint8_t regs[ZYDIS_REGISTER_MAX_VALUE + 1]) const
         {
         case ZYDIS_OPERAND_TYPE_REGISTER:
         {
-            if(op.action & ZYDIS_OPERAND_ACTION_MASK_READ)
+            switch (op.action)
+            {
+            case ZYDIS_OPERAND_ACTION_READ:
+            case ZYDIS_OPERAND_ACTION_CONDREAD:
                 regs[op.reg.value] |= RAIRead;
-            if(op.action & ZYDIS_OPERAND_ACTION_MASK_WRITE)
+                break;
+            case ZYDIS_OPERAND_ACTION_WRITE:
+            case ZYDIS_OPERAND_ACTION_CONDWRITE:
                 regs[op.reg.value] |= RAIWrite;
+                break;
+            case ZYDIS_OPERAND_ACTION_READWRITE:
+            case ZYDIS_OPERAND_ACTION_READ_CONDWRITE:
+            case ZYDIS_OPERAND_ACTION_CONDREAD_WRITE:
+                regs[op.reg.value] |= RAIRead | RAIWrite;
+                break;
+            }
             regs[op.reg.value] |= op.visibility == ZYDIS_OPERAND_VISIBILITY_HIDDEN ?
                                   RAIImplicit : RAIExplicit;
         }


### PR DESCRIPTION
This PR fixes issue #2047 .  The ZydisOperandAction was used incorrectly in Zydis::RegInfo which is used by the RegistersView on the GUI side, and also by the undocumented zydis command (however there only a few edge cases were wrong due to different usage).