### PR TITLE
Filter traced instructions

### DIFF
--- a/src/dbg/label.cpp
+++ b/src/dbg/label.cpp
@@ -83,11 +83,11 @@ bool LabelGet(duint Address, char* Text)
         if(found == tempLabels.end())
             return false;
         if(Text)
-            strcpy_s(Text, MAX_LABEL_SIZE, found->second.c_str());
+            strncpy_s(Text, MAX_LABEL_SIZE, found->second.c_str(), _TRUNCATE);
         return true;
     }
     if(Text)
-        strcpy_s(Text, MAX_LABEL_SIZE, label.text.c_str());
+        strncpy_s(Text, MAX_LABEL_SIZE, label.text.c_str(), _TRUNCATE);
     return true;
 }
 

--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -324,7 +324,7 @@ static bool IgnoreThisRead(HANDLE hProcess, LPVOID lpBaseAddress, LPVOID lpBuffe
     if(fnQueryWorkingSetEx(hProcess, &wsi, sizeof(wsi)) && !wsi.VirtualAttributes.Valid)
     {
         MEMORY_BASIC_INFORMATION mbi;
-        if(VirtualQueryEx(hProcess, wsi.VirtualAddress, &mbi, sizeof(mbi)) && mbi.State == MEM_COMMIT && mbi.Type == MEM_PRIVATE)
+        if(VirtualQueryEx(hProcess, wsi.VirtualAddress, &mbi, sizeof(mbi)) && mbi.State == MEM_COMMIT/* && mbi.Type == MEM_PRIVATE*/)
         {
             memset(lpBuffer, 0, nSize);
             if(lpNumberOfBytesRead)

--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -175,8 +175,8 @@ void MemUpdateMap()
                 if(start < secEnd && end > secStart) //the section and memory overlap
                 {
                     if(infoOffset)
-                        infoOffset += sprintf_s(currentPage.info + infoOffset, sizeof(currentPage.info) - infoOffset, ",");
-                    infoOffset += sprintf_s(currentPage.info + infoOffset, sizeof(currentPage.info) - infoOffset, " \"%s\"", currentSection.name);
+                        infoOffset += _snprintf_s(currentPage.info + infoOffset, sizeof(currentPage.info) - infoOffset, _TRUNCATE, ",");
+                    infoOffset += _snprintf_s(currentPage.info + infoOffset, sizeof(currentPage.info) - infoOffset, _TRUNCATE, " \"%s\"", currentSection.name);
                 }
             }
         }

--- a/src/gui/Src/Gui/SimpleFilterDialog.cpp
+++ b/src/gui/Src/Gui/SimpleFilterDialog.cpp
@@ -1,0 +1,86 @@
+#include "SimpleFilterDialog.h"
+#include "ui_SimpleFilterDialog.h"
+
+SimpleFilterDialog::SimpleFilterDialog(QWidget* parent) :
+    QDialog(parent),
+    ui(new Ui::SimpleFilterDialog)
+{
+    ui->setupUi(this);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::MSWindowsFixedSizeDialogHint);
+
+    mMnemonicFilterText = "";
+    minVA = 0;
+    maxVA = std::numeric_limits<duint>::max();
+
+    ui->lineEdit_mnemonic->setFocus();
+}
+
+SimpleFilterDialog::~SimpleFilterDialog()
+{
+    delete ui;
+}
+
+void SimpleFilterDialog::initInputWidgets()
+{
+    ui->lineEdit_mnemonic->setText(mMnemonicFilterText);
+    if(maxVA < std::numeric_limits<duint>::max())
+    {
+        ui->lineEdit_max_va->setText(QString::number(maxVA, 16));
+    }
+
+    if(minVA > 0)
+    {
+        ui->lineEdit_min_va->setText(QString::number(minVA, 16));
+    }
+}
+
+void SimpleFilterDialog::on_lineEdit_mnemonic_textChanged(const QString & arg1)
+{
+    mMnemonicFilterText = arg1;
+}
+
+void SimpleFilterDialog::on_lineEdit_max_va_textEdited(const QString & arg1)
+{
+    bool success = false;
+    duint va = arg1.toULongLong(&success, 16);
+
+    if(success
+            && arg1.length() <= 16
+            && arg1.length() > 0)
+    {
+        mPreviousMaxVaText = arg1;
+        maxVA = va;
+    }
+    else if(arg1.length() <= 0)
+    {
+        mPreviousMaxVaText = "";
+        maxVA = std::numeric_limits<quint64>::max();
+    }
+    else
+    {
+        ui->lineEdit_max_va->setText(mPreviousMaxVaText);
+    }
+}
+
+void SimpleFilterDialog::on_lineEdit_min_va_textEdited(const QString & arg1)
+{
+    bool success = false;
+    duint va = arg1.toULongLong(&success, 16);
+
+    if(success
+            && arg1.length() <= 16
+            && arg1.length() > 0)
+    {
+        mPreviousMinVaText = arg1;
+        minVA = va;
+    }
+    else if(arg1.length() <= 0)
+    {
+        mPreviousMinVaText = "";
+        minVA = 0;
+    }
+    else
+    {
+        ui->lineEdit_min_va->setText(mPreviousMinVaText);
+    }
+}

--- a/src/gui/Src/Gui/SimpleFilterDialog.h
+++ b/src/gui/Src/Gui/SimpleFilterDialog.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QDialog>
+
+#include "dbg_types.h"
+
+namespace Ui
+{
+    class SimpleFilterDialog;
+}
+
+class SimpleFilterDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SimpleFilterDialog(QWidget* parent = nullptr);
+    ~SimpleFilterDialog();
+
+    void initInputWidgets();
+
+    QString mMnemonicFilterText;
+    duint maxVA;
+    duint minVA;
+
+private slots:
+    void on_lineEdit_mnemonic_textChanged(const QString & arg1);
+    void on_lineEdit_max_va_textEdited(const QString & arg1);
+    void on_lineEdit_min_va_textEdited(const QString & arg1);
+
+private:
+    Ui::SimpleFilterDialog* ui;
+
+    QString mPreviousMaxVaText;
+    QString mPreviousMinVaText;
+};

--- a/src/gui/Src/Gui/SimpleFilterDialog.ui
+++ b/src/gui/Src/Gui/SimpleFilterDialog.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SimpleFilterDialog</class>
+ <widget class="QDialog" name="SimpleFilterDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>276</width>
+    <height>106</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Trace Filter</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>-70</x>
+     <y>70</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="lineEdit_mnemonic">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>40</y>
+     <width>260</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="placeholderText">
+    <string>Instruction</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="lineEdit_min_va">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>120</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="placeholderText">
+    <string>Min. VA</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="lineEdit_max_va">
+   <property name="geometry">
+    <rect>
+     <x>150</x>
+     <y>10</y>
+     <width>120</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="placeholderText">
+    <string>Max. VA</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="va_range_dash">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>10</y>
+     <width>16</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>-</string>
+   </property>
+  </widget>
+ </widget>
+ <tabstops>
+  <tabstop>lineEdit_mnemonic</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SimpleFilterDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SimpleFilterDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/Src/Tracer/TraceBrowser.h
+++ b/src/gui/Src/Tracer/TraceBrowser.h
@@ -39,6 +39,17 @@ private:
         Memory,
         Comments
     };
+
+    struct DisplayDataEntry
+    {
+        duint va;
+        Instruction_t instruction;
+        unsigned char opcodes[16];
+        int opcodeSize = 0;
+        int traceFileIndex = 0;
+    };
+
+
     void setupRightClickContextMenu();
     void makeVisible(duint index);
     QString getAddrText(dsint cur_addr, char label[MAX_LABEL_SIZE], bool getLabel);
@@ -113,6 +124,14 @@ private:
     QColor mCommentBackgroundColor;
     QColor mDisassemblyRelocationUnderlineColor;
 
+    unsigned long long mDisplayLastTraceSize = -1;
+    QVector<DisplayDataEntry> mDisplayDataEntries;
+
+    QString mInstructionFilterText;
+
+    duint mMinVAFilter;
+    duint mMaxVAFilter;
+
 signals:
     void displayReferencesWidget();
 
@@ -148,6 +167,8 @@ public slots:
     void updateSlot(); //debug
 
     void toggleAutoDisassemblyFollowSelectionSlot();
+    void simpleInstructionFilterSlot();
+    void clearSimpleInstructionFilterSlot();
 };
 
 #endif //TRACEBROWSER_H

--- a/src/gui/x64dbg.pro
+++ b/src/gui/x64dbg.pro
@@ -183,7 +183,8 @@ SOURCES += \
     Src/BasicView/AbstractStdTable.cpp \
     Src/Gui/ZehSymbolTable.cpp \
     Src/BasicView/StdSearchListView.cpp \
-    Src/BasicView/StdTableSearchList.cpp
+    Src/BasicView/StdTableSearchList.cpp \
+    Src/Gui/SimpleFilterDialog.cpp
 
 
 HEADERS += \
@@ -305,6 +306,7 @@ HEADERS += \
     Src/BasicView/StdSearchListView.h \
     Src/Gui/FileLines.h \
     Src/BasicView/StdTableSearchList.h \
+    Src/Gui/SimpleFilterDialog.h \
     Src/Utils/MethodInvoker.h
     
 
@@ -343,7 +345,8 @@ FORMS += \
     Src/Gui/SimpleTraceDialog.ui \
     Src/Gui/MessagesBreakpoints.ui \
     Src/Gui/AboutDialog.ui \
-    Src/Gui/ComboBoxDialog.ui
+    Src/Gui/ComboBoxDialog.ui \
+    Src/Gui/SimpleFilterDialog.ui
 
 ##
 ## Libraries


### PR DESCRIPTION
Added the ability to filter the data displayed in the trace file browser by instruction.

For now it's just filter by instruction as string, there's no validation yet.

Filter can be applied (and removed) via context menu.