### PR TITLE
GUI: fix negative zero floating point display

### DIFF
--- a/src/gui/Src/Gui/EditFloatRegister.cpp
+++ b/src/gui/Src/Gui/EditFloatRegister.cpp
@@ -363,7 +363,7 @@ void EditFloatRegister::reloadFloatData(QLineEdit & txtbox, char* Data)
 {
     if(mutex != &txtbox)
     {
-        txtbox.setText(QString().number(*(float*)Data));
+        txtbox.setText(ToFloatString(Data));
     }
 }
 
@@ -371,7 +371,7 @@ void EditFloatRegister::reloadDoubleData(QLineEdit & txtbox, char* Data)
 {
     if(mutex != &txtbox)
     {
-        txtbox.setText(QString().number(*(double*)Data));
+        txtbox.setText(ToDoubleString(Data));
     }
 }
 

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1662,18 +1662,20 @@ static QString composeRegTextXMM(const char* value, RegistersView::SIMD_REG_DISP
     {
         const double* dbl_values = reinterpret_cast<const double*>(value);
         if(bFpuRegistersLittleEndian)
-            valueText = QString::number(dbl_values[0]) + ' ' + QString::number(dbl_values[1]);
+            valueText = ToDoubleString(&dbl_values[0]) + ' ' + ToDoubleString(&dbl_values[1]);
         else // Big Endian
-            valueText = QString::number(dbl_values[1]) + ' ' + QString::number(dbl_values[0]);
+            valueText = ToDoubleString(&dbl_values[1]) + ' ' + ToDoubleString(&dbl_values[0]);
     }
     break;
     case RegistersView::SIMD_REG_DISP_FLOAT:
     {
         const float* flt_values = reinterpret_cast<const float*>(value);
         if(bFpuRegistersLittleEndian)
-            valueText = QString::number(flt_values[0]) + ' ' + QString::number(flt_values[1]) + ' ' + QString::number(flt_values[2]) + ' ' + QString::number(flt_values[3]);
+            valueText = ToFloatString(&flt_values[0]) + ' ' + ToFloatString(&flt_values[1]) + ' '
+                      + ToFloatString(&flt_values[2]) + ' ' + ToFloatString(&flt_values[3]);
         else // Big Endian
-            valueText = QString::number(flt_values[3]) + ' ' + QString::number(flt_values[2]) + ' ' + QString::number(flt_values[1]) + ' ' + QString::number(flt_values[0]);
+            valueText = ToFloatString(&flt_values[3]) + ' ' + ToFloatString(&flt_values[2]) + ' '
+                      + ToFloatString(&flt_values[1]) + ' ' + ToFloatString(&flt_values[0]);
     }
     break;
     case RegistersView::SIMD_REG_DISP_WORD_HEX:

--- a/src/gui/Src/Gui/WatchView.cpp
+++ b/src/gui/Src/Gui/WatchView.cpp
@@ -51,7 +51,7 @@ void WatchView::updateWatch()
             break;
         case WATCHVARTYPE::TYPE_FLOAT:
             setCellContent(i, 3, "FLOAT");
-            setCellContent(i, 2, QString::number(*(float*)&WatchList[i].value));
+            setCellContent(i, 2, ToFloatString(&WatchList[i].value));
             break;
         case WATCHVARTYPE::TYPE_ASCII:
             setCellContent(i, 3, "ASCII");

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -4,7 +4,7 @@
 #include "MiscUtil.h"
 #include "ldconvert.h"
 
-QString ToLongDoubleString(void* buffer)
+QString ToLongDoubleString(const void* buffer)
 {
     char str[32];
     ld2str(buffer, str);
@@ -40,7 +40,7 @@ QString EscapeCh(QChar ch)
     }
 }
 
-QString GetDataTypeString(void* buffer, duint size, ENCODETYPE type)
+QString GetDataTypeString(const void* buffer, duint size, ENCODETYPE type)
 {
     switch(type)
     {

--- a/src/gui/Src/Utils/StringUtil.h
+++ b/src/gui/Src/Utils/StringUtil.h
@@ -71,11 +71,11 @@ inline QString ToWordString(unsigned short Value)
 }
 
 template<typename T>
-inline QString ToFloatingString(const void* buffer)
+inline QString ToFloatingString(const void* buffer, int precision)
 {
     auto value = *(const T*)buffer;
     std::stringstream wFloatingStr;
-    wFloatingStr << std::setprecision(std::numeric_limits<T>::digits10) << value;
+    wFloatingStr << std::setprecision(precision) << value;
     return QString::fromStdString(wFloatingStr.str());
 }
 
@@ -86,14 +86,14 @@ inline QString ToIntegralString(const void* buffer)
     return ToLongLongHexString(value);
 }
 
-inline QString ToFloatString(const void* buffer)
+inline QString ToFloatString(const void* buffer, int precision = std::numeric_limits<float>::digits10)
 {
-    return ToFloatingString<float>(buffer);
+    return ToFloatingString<float>(buffer, precision);
 }
 
-inline QString ToDoubleString(const void* buffer)
+inline QString ToDoubleString(const void* buffer, int precision = std::numeric_limits<double>::digits10)
 {
-    return ToFloatingString<double>(buffer);
+    return ToFloatingString<double>(buffer, precision);
 }
 
 QString ToLongDoubleString(const void* buffer);

--- a/src/gui/Src/Utils/StringUtil.h
+++ b/src/gui/Src/Utils/StringUtil.h
@@ -71,36 +71,36 @@ inline QString ToWordString(unsigned short Value)
 }
 
 template<typename T>
-inline QString ToFloatingString(void* buffer)
+inline QString ToFloatingString(const void* buffer)
 {
-    auto value = *(T*)buffer;
+    auto value = *(const T*)buffer;
     std::stringstream wFloatingStr;
     wFloatingStr << std::setprecision(std::numeric_limits<T>::digits10) << value;
     return QString::fromStdString(wFloatingStr.str());
 }
 
 template<typename T>
-inline QString ToIntegralString(void* buffer)
+inline QString ToIntegralString(const void* buffer)
 {
-    auto value = *(T*)buffer;
+    auto value = *(const T*)buffer;
     return ToLongLongHexString(value);
 }
 
-inline QString ToFloatString(void* buffer)
+inline QString ToFloatString(const void* buffer)
 {
     return ToFloatingString<float>(buffer);
 }
 
-inline QString ToDoubleString(void* buffer)
+inline QString ToDoubleString(const void* buffer)
 {
     return ToFloatingString<double>(buffer);
 }
 
-QString ToLongDoubleString(void* buffer);
+QString ToLongDoubleString(const void* buffer);
 
 QString ToDateString(const QDate & date);
 
-QString GetDataTypeString(void* buffer, duint size, ENCODETYPE type);
+QString GetDataTypeString(const void* buffer, duint size, ENCODETYPE type);
 
 inline QDate GetCompileDate()
 {


### PR DESCRIPTION
This PR fixes issue #1816 .
QString::number doesn't support displaying -0.0, so I converted all usages on the GUI to ToFloatString/ToDoubleString. This fixes the floating point display in the MMX/XMM/YMM editor, in the registers view in SIMD float/double mode, and in the Watch window for floating point type watchpoints.
To support this all void* buffer based StringUtil functions are now const correct, and ToFloatString/ToDoubleString got an optional precision parameter, which is set to the previously used value by default.

One noteable change is that ToDoubleString has 15 digits of precision by default, while QString::number only had 6 (the same as ToFloatString has). With the new precision parameter we can set it back to 6 if necessary, but I think the more precision the better 😃
The only place where the added precision could cause problems is the newly added SIMD mode of the RegistersView, @torusrxxx could you also take a look to see if it matches your design for displaying the FPU registers? 