### PR TITLE
DBG: fix getting raw int value for float typed watch points

### DIFF
--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -24,7 +24,9 @@ WatchExpr::WatchExpr(const char* name, const char* expression, WATCHVARTYPE type
 duint WatchExpr::getIntValue()
 {
     duint origVal = currValue;
-    if(varType == WATCHVARTYPE::TYPE_UINT || varType == WATCHVARTYPE::TYPE_INT || varType == WATCHVARTYPE::TYPE_ASCII || varType == WATCHVARTYPE::TYPE_UNICODE)
+    if(varType == WATCHVARTYPE::TYPE_UINT || varType == WATCHVARTYPE::TYPE_INT ||
+       varType == WATCHVARTYPE::TYPE_FLOAT ||
+       varType == WATCHVARTYPE::TYPE_ASCII || varType == WATCHVARTYPE::TYPE_UNICODE)
     {
         duint val;
         bool ok = expr.Calculate(val, varType == WATCHVARTYPE::TYPE_INT, false);


### PR DESCRIPTION
Floating point watch points seem to have been broken for a while, this PR fixes the missing enum in the DBG-side evaluation of such  watch points.
To test this simply add a floating point watch point at the top of the stack:
AddWatch dword(rsp),float

And also follow the stack in a Dump using float display. The watch and the dump values should always match when the watch's UI is updated.