### PR TITLE
Fixed incorrect comparator used in sorting xrefs

### DIFF
--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -257,7 +257,10 @@ void CPUInfoBox::disasmSelectionChanged(dsint parVA)
 
         std::sort(data.begin(), data.end(), [](const XREF_RECORD * A, const XREF_RECORD * B)
         {
-            return ((A->type < B->type) || (A->addr < B->addr));
+            if (A->type != B->type)
+                return (A->type < B->type);
+
+            return (A->addr < B->addr);
         });
 
         int t = XREF_NONE;

--- a/src/gui/Src/Gui/XrefBrowseDialog.cpp
+++ b/src/gui/Src/Gui/XrefBrowseDialog.cpp
@@ -58,7 +58,10 @@ void XrefBrowseDialog::setup(duint address, QString command)
 
         std::sort(data.begin(), data.end(), [](const XREF_RECORD A, const XREF_RECORD B)
         {
-            return ((A.type < B.type) || (A.addr < B.addr));
+            if (A.type != B.type)
+                return (A.type < B.type);
+
+            return (A.addr < B.addr);
         });
 
         for(duint i = 0; i < mXrefInfo.refcount; i++)


### PR DESCRIPTION
* With old comparator, items {1, 2} and {2, 1} were "less" then each other. This will cause them to sort randomly.