### PR TITLE
Fixed incorrect error message when memory could not be allocated

### DIFF
--- a/src/dbg/_global.cpp
+++ b/src/dbg/_global.cpp
@@ -43,9 +43,9 @@ void* emalloc(size_t size, const char* reason)
 #endif //ENABLE_MEM_TRACE
     if(!a)
     {
-        wchar_t size[25];
-        swprintf_s(size, L"%p bytes", size);
-        MessageBoxW(0, L"Could not allocate memory (minidump will be created)", size, MB_ICONERROR);
+        wchar_t sizeString[25];
+        swprintf_s(sizeString, L"%p bytes", size);
+        MessageBoxW(0, L"Could not allocate memory (minidump will be created)", sizeString, MB_ICONERROR);
         __debugbreak();
         ExitProcess(1);
     }


### PR DESCRIPTION
It was printing pointer to stack instead of size