### PR TITLE
DBG: Fix mapped area overrun in ReadDebugDirectory

### DIFF
--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -387,7 +387,11 @@ void ReadDebugDirectory(MODINFO & Info, ULONG_PTR FileMapVA)
                     FALSE,
                     IMAGE_DIRECTORY_ENTRY_DEBUG,
                     &debugDirSize);
-    if(debugDirSize == 0 || debugDir == nullptr)
+    if(debugDirSize == 0 || debugDir == nullptr ||
+       // Check if debugDir fits into the mapped area
+       (ULONG_PTR)debugDir + debugDirSize > FileMapVA + Info.loadedSize ||
+       // Check for ULONG_PTR wraparound (e.g. when debugDirSize == 0xfffff000)
+       (ULONG_PTR)debugDir + debugDirSize < (ULONG_PTR)debugDir)
         return;
 
     struct CV_HEADER


### PR DESCRIPTION
This PR fixes #2065.
`ReadDebugDirectory` could scan past the end of the mapped PE file if the Debug Directory's size is bogus, e.g. 0xfffff000. This PR adds a check for `debugDir + debugDirSize` not pointing out of the mapped image.
There is also an additional check that detects unsigned integer wraparounds, in this case with size 0xfffff000 the calculation would wrap around to 4096 bytes before debugDir which would be inside the mapped area.