### PR TITLE
DBG: more robust validation of PE directory sizes

### DIFF
--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -89,6 +89,10 @@ static void ReadExportDirectory(MODINFO & Info, ULONG_PTR FileMapVA)
             (ULONG_PTR)exportDir + exportDirSize < (ULONG_PTR)exportDir // Check for ULONG_PTR wraparound (e.g. when exportDirSize == 0xfffff000)
             || exportDir->NumberOfFunctions == 0)
         return;
+    DWORD64 totalFunctionSize = exportDir->NumberOfFunctions * sizeof(ULONG_PTR);
+    if(totalFunctionSize / exportDir->NumberOfFunctions != sizeof(ULONG_PTR) || // Check for overflow
+            totalFunctionSize > Info.loadedSize) // Check for impossible number of exports
+        return;
 
     auto rva2offset = [&Info](ULONG64 rva)
     {

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -146,7 +146,7 @@ static void ReadExportDirectory(MODINFO & Info, ULONG_PTR FileMapVA)
     for(DWORD i = 0; i < exportDir->NumberOfNames; i++)
     {
         // Check if addressOfNameOrdinals[i] is valid
-        ULONG_PTR target = (ULONG_PTR)addressOfNameOrdinals + i * sizeof(DWORD);
+        ULONG_PTR target = (ULONG_PTR)addressOfNameOrdinals + i * sizeof(WORD);
         if(target > FileMapVA + Info.loadedSize || target < (ULONG_PTR)addressOfNameOrdinals)
         {
             continue;


### PR DESCRIPTION
Ref: #2105 #2065

This is essentially the same as PR #2069, but applied to all PE directories. This fixes #2105 (at least the first attachment, likely both) without a need for `try/except` (though keeping the wrapper added in 7d53b1a doesn't hurt).