### PR TITLE
Fix export name is not parsed correctly

### DIFF
--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -158,7 +158,7 @@ static void ReadExportDirectory(MODINFO & Info, ULONG_PTR FileMapVA)
         }
 
         DWORD index = addressOfNameOrdinals[i];
-        if(index < Info.exports.size()) // Silent ignore (2) by ntdll loader: bogus AddressOfNameOrdinals indices
+        if(index < exportDir->NumberOfFunctions) // Silent ignore (2) by ntdll loader: bogus AddressOfNameOrdinals indices
         {
             // Check if addressOfNames[i] is valid
             target = (ULONG_PTR)addressOfNames + i * sizeof(DWORD);


### PR DESCRIPTION
There is another bug that is not fixed in PR https://github.com/x64dbg/x64dbg/pull/2158. 

Info.exports.size() may be less than exportDir->NumberOfFunctions, so the export name is not displayed correctly when addressOfNameOrdinals[i] is greater than or equal to Info.exports.size().

Look into the issue https://github.com/x64dbg/x64dbg/issues/2139, view the last export symbol of libeay321.dll in x64dbg(ordinal 4789), the correct one should be "ossl_safe_getenv".