### PR TITLE
Mapped Shortcuts Do Not Match Keys Pressed #2176

### DIFF
--- a/src/gui/Src/BasicView/ShortcutEdit.cpp
+++ b/src/gui/Src/BasicView/ShortcutEdit.cpp
@@ -63,10 +63,6 @@ void ShortcutEdit::keyPressEvent(QKeyEvent* event)
         }
     }
 
-    // replace Backtab with Shift+Tab
-    if((keyInt & Qt::Key_Backtab) == Qt::Key_Backtab)
-        keyInt = (keyInt & ~Qt::Key_Backtab) | Qt::SHIFT | Qt::Key_Tab;
-
     // display key combination
     setText(QKeySequence(keyInt).toString(QKeySequence::NativeText));
     // do not forward keypress-event

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -39,6 +39,8 @@ void CPUInfoBox::setupContextMenu()
     mCopyAddressAction = makeAction(tr("Address"), SLOT(copyAddress()));
     mCopyRvaAction = makeAction(tr("RVA"), SLOT(copyRva()));
     mCopyOffsetAction = makeAction(tr("File Offset"), SLOT(copyOffset()));
+    mCopyLineAction = makeAction(tr("Copy Line"), SLOT(copyLineSlot()));
+    setupShortcuts();
 }
 
 int CPUInfoBox::getHeight()
@@ -689,4 +691,10 @@ void CPUInfoBox::copyOffset()
 void CPUInfoBox::doubleClickedSlot()
 {
     followInDump(curAddr);
+}
+
+void CPUInfoBox::setupShortcuts()
+{
+    mCopyLineAction->setShortcut(ConfigShortcut("ActionCopyLine"));
+    addAction(mCopyLineAction);
 }

--- a/src/gui/Src/Gui/CPUInfoBox.h
+++ b/src/gui/Src/Gui/CPUInfoBox.h
@@ -41,12 +41,13 @@ private:
     QString getInfoLine(int line);
     void clear();
     void setupContextMenu();
-
+    void setupShortcuts();
     XrefBrowseDialog* mXrefDlg = nullptr;
 
     QAction* mCopyAddressAction;
     QAction* mCopyRvaAction;
     QAction* mCopyOffsetAction;
+    QAction* mCopyLineAction;
 };
 
 #endif // INFOBOX_H

--- a/src/gui/Src/Gui/ShortcutsDialog.cpp
+++ b/src/gui/Src/Gui/ShortcutsDialog.cpp
@@ -12,7 +12,7 @@ ShortcutsDialog::ShortcutsDialog(QWidget* parent) : QDialog(parent), ui(new Ui::
 
     // x64 has no model-view-controler pattern
     QStringList tblHeader;
-    tblHeader << tr("Instruction") << tr("Shortcut");
+    tblHeader << tr("Action") << tr("Shortcut");
 
     currentRow = 0;
 
@@ -54,7 +54,8 @@ void ShortcutsDialog::showShortcutsFiltered(const QString & actionName)
         ui->tblShortcuts->setItem(row, 1, shortcutKey);
         row++;
     }
-    ui->tblShortcuts->setSortingEnabled(true);}
+    ui->tblShortcuts->setSortingEnabled(true);
+}
 
 void ShortcutsDialog::filterShortcutsByName(const QString & nameFilter, QMap<QString, Configuration::Shortcut> & mapToFill)
 {

--- a/src/gui/Src/Gui/ShortcutsDialog.cpp
+++ b/src/gui/Src/Gui/ShortcutsDialog.cpp
@@ -34,7 +34,6 @@ ShortcutsDialog::ShortcutsDialog(QWidget* parent) : QDialog(parent), ui(new Ui::
     connect(ui->tblShortcuts, SIGNAL(itemSelectionChanged()), this, SLOT(syncTextfield()));
     connect(ui->shortcutEdit, SIGNAL(askForSave()), this, SLOT(updateShortcut()));
     connect(this, SIGNAL(rejected()), this, SLOT(rejectedSlot()));
-    connect(ui->bntClearFilter, SIGNAL(released()), this, SLOT(on_btnClearFilter()));
     connect(ui->filterEdit, SIGNAL(textChanged(const QString &)), this, SLOT(on_FilterTextChanged(const QString &)));
 }
 
@@ -42,38 +41,30 @@ void ShortcutsDialog::showShortcutsFiltered(const QString & actionName)
 {
     QMap<QString, Configuration::Shortcut> shorcutsToShow;
     filterShortcutsByName(actionName, shorcutsToShow);
-    renderShortcuts(shorcutsToShow);
-}
-
-void ShortcutsDialog::filterShortcutsByName(const QString & nameFilter, QMap<QString, Configuration::Shortcut> & mapToFill)
-{
-    for(QMap<QString, Configuration::Shortcut>::iterator i = Config()->Shortcuts.begin();
-            i != Config()->Shortcuts.end();
-            ++i)
-    {
-        if(i.value().Name.contains(nameFilter, Qt::CaseInsensitive) || nameFilter == QString())
-        {
-            mapToFill.insert(i.value().Name, i.value());
-        }
-    }
-}
-
-void ShortcutsDialog::renderShortcuts(QMap<QString, Configuration::Shortcut> & shortcuts)
-{
     ui->tblShortcuts->clearContents();
-    ui->tblShortcuts->setRowCount(shortcuts.count());
+    ui->tblShortcuts->setRowCount(shorcutsToShow.count());
     currentRow = 0;
 
     int row = 0;
-    for(QMap<QString, Configuration::Shortcut>::const_iterator it = shortcuts.begin(); it != shortcuts.end();
-            ++it, row++)
+    for(auto shortcut : shorcutsToShow)
     {
-        QTableWidgetItem* shortcutName = new QTableWidgetItem(it.value().Name);
-        QTableWidgetItem* shortcutKey = new QTableWidgetItem(it.value().Hotkey.toString(QKeySequence::NativeText));
+        QTableWidgetItem* shortcutName = new QTableWidgetItem(shortcut.Name);
+        QTableWidgetItem* shortcutKey = new QTableWidgetItem(shortcut.Hotkey.toString(QKeySequence::NativeText));
         ui->tblShortcuts->setItem(row, 0, shortcutName);
         ui->tblShortcuts->setItem(row, 1, shortcutKey);
+        row++;
     }
-    ui->tblShortcuts->setSortingEnabled(true);
+    ui->tblShortcuts->setSortingEnabled(true);}
+
+void ShortcutsDialog::filterShortcutsByName(const QString & nameFilter, QMap<QString, Configuration::Shortcut> & mapToFill)
+{
+    for(auto shortcut : Config()->Shortcuts)
+    {
+        if(shortcut.Name.contains(nameFilter, Qt::CaseInsensitive) || nameFilter == QString())
+        {
+            mapToFill.insert(shortcut.Name, shortcut);
+        }
+    }
 }
 
 void ShortcutsDialog::updateShortcut()
@@ -163,11 +154,11 @@ void ShortcutsDialog::syncTextfield()
     if(indexes.count() < 1)
         return;
     currentRow = indexes.at(0).row();
-    for(QMap<QString, Configuration::Shortcut>::iterator i = Config()->Shortcuts.begin(); i != Config()->Shortcuts.end(); ++i)
+    for(auto shortcut : Config()->Shortcuts)
     {
-        if(i.value().Name == ui->tblShortcuts->item(currentRow, 0)->text())
+        if(shortcut.Name == ui->tblShortcuts->item(currentRow, 0)->text())
         {
-            currentShortcut = i.value();
+            currentShortcut = shortcut;
             break;
         }
     }
@@ -190,12 +181,6 @@ void ShortcutsDialog::on_btnSave_clicked()
 void ShortcutsDialog::rejectedSlot()
 {
     Config()->readShortcuts();
-}
-
-void ShortcutsDialog::on_btnClearFilter()
-{
-    ui->filterEdit->clear();
-    showShortcutsFiltered(QString());
 }
 
 void ShortcutsDialog::on_FilterTextChanged(const QString & actionName)

--- a/src/gui/Src/Gui/ShortcutsDialog.h
+++ b/src/gui/Src/Gui/ShortcutsDialog.h
@@ -28,10 +28,14 @@ private slots:
     void on_btnSave_clicked();
     void on_btnClearShortcut_clicked();
     void rejectedSlot();
-
+    void on_btnClearFilter();
+    void on_FilterTextChanged(const QString & actionName);
 private:
     Ui::ShortcutsDialog* ui;
     QMap<QString, Configuration::Shortcut> ShortcutsBackup;
+    void filterShortcutsByName(const QString & nameFilter, QMap<QString, Configuration::Shortcut> & mapToFill);
+    void renderShortcuts(QMap<QString, Configuration::Shortcut> & shortcuts);
+    void showShortcutsFiltered(const QString & actionName);
 };
 
 #endif // SHORTCUTSDIALOG_H

--- a/src/gui/Src/Gui/ShortcutsDialog.h
+++ b/src/gui/Src/Gui/ShortcutsDialog.h
@@ -28,13 +28,12 @@ private slots:
     void on_btnSave_clicked();
     void on_btnClearShortcut_clicked();
     void rejectedSlot();
-    void on_btnClearFilter();
     void on_FilterTextChanged(const QString & actionName);
+
 private:
     Ui::ShortcutsDialog* ui;
     QMap<QString, Configuration::Shortcut> ShortcutsBackup;
     void filterShortcutsByName(const QString & nameFilter, QMap<QString, Configuration::Shortcut> & mapToFill);
-    void renderShortcuts(QMap<QString, Configuration::Shortcut> & shortcuts);
     void showShortcutsFiltered(const QString & actionName);
 };
 

--- a/src/gui/Src/Gui/ShortcutsDialog.ui
+++ b/src/gui/Src/Gui/ShortcutsDialog.ui
@@ -21,7 +21,7 @@
    <item>
     <widget class="QLineEdit" name="filterEdit">
      <property name="placeholderText">
-      <string>Instruction name filter</string>
+      <string>Action filter</string>
      </property>
     </widget>
    </item>

--- a/src/gui/Src/Gui/ShortcutsDialog.ui
+++ b/src/gui/Src/Gui/ShortcutsDialog.ui
@@ -22,6 +22,25 @@
     <widget class="QTableWidget" name="tblShortcuts"/>
    </item>
    <item>
+    <widget class="QGroupBox" name="filterBox">
+     <property name="title">
+      <string>Filter</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QLineEdit" name="filterEdit"/>
+      </item>
+      <item>
+       <widget class="QPushButton" name="bntClearFilter">
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Shortcut</string>

--- a/src/gui/Src/Gui/ShortcutsDialog.ui
+++ b/src/gui/Src/Gui/ShortcutsDialog.ui
@@ -19,45 +19,37 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLineEdit" name="filterEdit">
+     <property name="placeholderText">
+      <string>Instruction name filter</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableWidget" name="tblShortcuts"/>
    </item>
    <item>
-    <widget class="QGroupBox" name="filterBox">
-     <property name="title">
-      <string>Filter</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <item>
-       <widget class="QLineEdit" name="filterEdit"/>
-      </item>
-      <item>
-       <widget class="QPushButton" name="bntClearFilter">
-        <property name="text">
-         <string>Clear</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Shortcut</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="ShortcutEdit" name="shortcutEdit"/>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnClearShortcut">
-        <property name="text">
-         <string>Clear</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Shortcut</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="ShortcutEdit" name="shortcutEdit"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnClearShortcut">
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -78,6 +70,9 @@
       <widget class="QPushButton" name="btnSave">
        <property name="text">
         <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -565,6 +565,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ActionCopyAddress", Shortcut({tr("Actions"), tr("Copy Address")}, "Alt+INS"));
     defaultShortcuts.insert("ActionCopyRva", Shortcut({tr("Actions"), tr("Copy RVA")}, ""));
     defaultShortcuts.insert("ActionCopySymbol", Shortcut({tr("Actions"), tr("Copy Symbol")}, "Ctrl+S"));
+    defaultShortcuts.insert("ActionCopyLine", Shortcut({tr("Actions"), tr("Copy Line")}, ""));
     defaultShortcuts.insert("ActionLoadScript", Shortcut({tr("Actions"), tr("Load Script")}, "Ctrl+O"));
     defaultShortcuts.insert("ActionReloadScript", Shortcut({tr("Actions"), tr("Reload Script")}, "Ctrl+R"));
     defaultShortcuts.insert("ActionUnloadScript", Shortcut({tr("Actions"), tr("Unload Script")}, "Ctrl+U"));


### PR DESCRIPTION
Like discussed in the issue, the Qt keys are not bitflags so we can't do binary logic. Moreover the TAB key changes focus so it shouldn't be even possibile to have it bound to some action if said binding is set through the UI (same reasoning applies to BACKTAB).