### PR TITLE
Removed backtab key substitution

### DIFF
--- a/src/gui/Src/BasicView/ShortcutEdit.cpp
+++ b/src/gui/Src/BasicView/ShortcutEdit.cpp
@@ -63,10 +63,6 @@ void ShortcutEdit::keyPressEvent(QKeyEvent* event)
         }
     }
 
-    // replace Backtab with Shift+Tab
-    if((keyInt & Qt::Key_Backtab) == Qt::Key_Backtab)
-        keyInt = (keyInt & ~Qt::Key_Backtab) | Qt::SHIFT | Qt::Key_Tab;
-
     // display key combination
     setText(QKeySequence(keyInt).toString(QKeySequence::NativeText));
     // do not forward keypress-event


### PR DESCRIPTION
Like discussed in the issue [#2176](https://github.com/x64dbg/x64dbg/issues/2176) the Qt keys are not bitflags so we can't do binary logic. Moreover the TAB key changes focus so it shouldn't be even possibile to have it bound to some action if said binding is set through the UI (same reasoning applies to BACKTAB).