### PR TITLE
improved sorting in handles tab

### DIFF
--- a/src/gui/Src/Gui/HandlesView.cpp
+++ b/src/gui/Src/Gui/HandlesView.cpp
@@ -20,9 +20,9 @@ HandlesView::HandlesView(QWidget* parent) : QWidget(parent)
     mHandlesTable->setDisassemblyPopupEnabled(false);
     int wCharWidth = mHandlesTable->getCharWidth();
     mHandlesTable->addColumnAt(8 + 16 * wCharWidth, tr("Type"), true);
-    mHandlesTable->addColumnAt(8 + 8 * wCharWidth, tr("Type number"), true);
-    mHandlesTable->addColumnAt(8 + sizeof(duint) * 2 * wCharWidth, tr("Handle"), true);
-    mHandlesTable->addColumnAt(8 + 16 * wCharWidth, tr("Access"), true);
+    mHandlesTable->addColumnAt(8 + 8 * wCharWidth, tr("Type number"), true, "", SortBy::AsHex);
+    mHandlesTable->addColumnAt(8 + sizeof(duint) * 2 * wCharWidth, tr("Handle"), true, "", SortBy::AsHex);
+    mHandlesTable->addColumnAt(8 + 16 * wCharWidth, tr("Access"), true, "", SortBy::AsHex);
     mHandlesTable->addColumnAt(8 + wCharWidth * 20, tr("Name"), true);
     mHandlesTable->loadColumnFromConfig("Handle");
 
@@ -33,13 +33,13 @@ HandlesView::HandlesView(QWidget* parent) : QWidget(parent)
     mWindowsTable->setDrawDebugOnly(true);
     wCharWidth = mWindowsTable->getCharWidth();
     mWindowsTable->addColumnAt(8 + sizeof(duint) * 2 * wCharWidth, tr("Proc"), true);
-    mWindowsTable->addColumnAt(8 + 8 * wCharWidth, tr("Handle"), true);
+    mWindowsTable->addColumnAt(8 + 8 * wCharWidth, tr("Handle"), true, "", SortBy::AsHex);
     mWindowsTable->addColumnAt(8 + 120 * wCharWidth, tr("Title"), true);
     mWindowsTable->addColumnAt(8 + 40 * wCharWidth, tr("Class"), true);
     mWindowsTable->addColumnAt(8 + 8 * wCharWidth, tr("Thread"), true);
-    mWindowsTable->addColumnAt(8 + 16 * wCharWidth, tr("Style"), true);
-    mWindowsTable->addColumnAt(8 + 16 * wCharWidth, tr("StyleEx"), true);
-    mWindowsTable->addColumnAt(8 + 8 * wCharWidth, tr("Parent"), true);
+    mWindowsTable->addColumnAt(8 + 16 * wCharWidth, tr("Style"), true, "", SortBy::AsHex);
+    mWindowsTable->addColumnAt(8 + 16 * wCharWidth, tr("StyleEx"), true, "", SortBy::AsHex);
+    mWindowsTable->addColumnAt(8 + 8 * wCharWidth, tr("Parent"), true, "", SortBy::AsHex);
     mWindowsTable->addColumnAt(8 + 20 * wCharWidth, tr("Size"), true);
     mWindowsTable->addColumnAt(8 + 6 * wCharWidth, tr("Enable"), true);
     mWindowsTable->loadColumnFromConfig("Window");

--- a/src/gui/Src/Gui/HandlesView.h
+++ b/src/gui/Src/Gui/HandlesView.h
@@ -12,7 +12,7 @@ class LabeledSplitter;
 class StdSearchListView;
 class QMenu;
 
-class HandlesView : public QWidget
+class HandlesView : public QWidget, public StdTable
 {
     Q_OBJECT
 public:

--- a/src/gui/Src/Gui/HandlesView.h
+++ b/src/gui/Src/Gui/HandlesView.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include "Imports.h"
+#include "StdTable.h"
 
 class StdTable;
 class ReferenceView;


### PR DESCRIPTION
Noticed that sorting in the handles tab is kinda strange.

I came across a ReadFile WinAPI call and wanted to know which file belongs to the handle ID.
Take a look at this picture (clicked the 'Handle' column to sort by handle id's)
![handles](https://user-images.githubusercontent.com/8084390/60195940-661ac180-983c-11e9-9acf-854563d242eb.png)

The application itself doesn't do anything wrong (sorting the strings) but I would never expect 1C to be at this position.

The only thing left are the lines 433 and 435
I would like to change line 433 from
`mWindowsTable->setCellContent(i, 4, ToHexString(windows[i].threadId));`
to
`mWindowsTable->setCellContent(i, 4, ToPtrString(windows[i].threadId));`

But I don't know if this would be best practice.
For line 435, numbers should be sorted correctly when interpreted as strings?
`mWindowsTable->setCellContent(i, 4, QString::number(windows[i].threadId));`
