### PR TITLE
GUI: #811 - Sidebar jump direction color differentiation.

### DIFF
--- a/src/gui/Src/Gui/AppearanceDialog.cpp
+++ b/src/gui/Src/Gui/AppearanceDialog.cpp
@@ -452,6 +452,10 @@ void AppearanceDialog::colorInfoListInit()
     colorInfoListAppend(tr("Conditional Jump Lines (no jump)"), "SideBarConditionalJumpLineFalseColor", "");
     colorInfoListAppend(tr("Unconditional Jump Lines (jump)"), "SideBarUnconditionalJumpLineTrueColor", "");
     colorInfoListAppend(tr("Unconditional Jump Lines (no jump)"), "SideBarUnconditionalJumpLineFalseColor", "");
+    colorInfoListAppend(tr("Conditional Jump Backwards Lines (jump)"), "SideBarConditionalJumpLineTrueBackwardsColor", "");
+    colorInfoListAppend(tr("Conditional Jump Backwards Lines (no jump)"), "SideBarConditionalJumpLineFalseBackwardsColor", "");
+    colorInfoListAppend(tr("Unconditional Jump Backwards Lines (jump)"), "SideBarUnconditionalJumpLineTrueBackwardsColor", "");
+    colorInfoListAppend(tr("Unconditional Jump Backwards Lines (no jump)"), "SideBarUnconditionalJumpLineFalseBackwardsColor", "");
     colorInfoListAppend(tr("Jump Lines (executing)"), "SideBarJumpLineExecuteColor", "");
     colorInfoListAppend(tr("Code Folding Checkbox Color"), "SideBarCheckBoxForeColor", "SideBarCheckBoxBackColor");
     colorInfoListAppend(tr("Background"), "SideBarBackgroundColor", "");

--- a/src/gui/Src/Gui/CPUSideBar.h
+++ b/src/gui/Src/Gui/CPUSideBar.h
@@ -98,6 +98,10 @@ private:
     QColor mUnconditionalJumpLineFalseColor;
     QColor mConditionalJumpLineTrueColor;
     QColor mUnconditionalJumpLineTrueColor;
+    QColor mConditionalJumpLineFalseBackwardsColor;
+    QColor mUnconditionalJumpLineFalseBackwardsColor;
+    QColor mConditionalJumpLineTrueBackwardsColor;
+    QColor mUnconditionalJumpLineTrueBackwardsColor;
 
     QColor mBulletBreakpointColor;
     QColor mBulletBookmarkColor;
@@ -112,6 +116,8 @@ private:
 
     QPen mUnconditionalPen;
     QPen mConditionalPen;
+    QPen mUnconditionalBackwardsPen;
+    QPen mConditionalBackwardsPen;
 };
 
 #endif // CPUSIDEBAR_H

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -81,9 +81,13 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultColors.insert("SideBarCipLabelBackgroundColor", QColor("#4040FF"));
     defaultColors.insert("SideBarBackgroundColor", QColor("#FFF8F0"));
     defaultColors.insert("SideBarConditionalJumpLineTrueColor", QColor("#FF0000"));
-    defaultColors.insert("SideBarConditionalJumpLineFalseColor", QColor("#808080"));
+    defaultColors.insert("SideBarConditionalJumpLineFalseColor", QColor("#00BBFF"));
     defaultColors.insert("SideBarUnconditionalJumpLineTrueColor", QColor("#FF0000"));
-    defaultColors.insert("SideBarUnconditionalJumpLineFalseColor", QColor("#808080"));
+    defaultColors.insert("SideBarUnconditionalJumpLineFalseColor", QColor("#00BBFF"));
+    defaultColors.insert("SideBarConditionalJumpLineTrueBackwardsColor", QColor("#FF0000"));
+    defaultColors.insert("SideBarConditionalJumpLineFalseBackwardsColor", QColor("#FFA500"));
+    defaultColors.insert("SideBarUnconditionalJumpLineTrueBackwardsColor", QColor("#FF0000"));
+    defaultColors.insert("SideBarUnconditionalJumpLineFalseBackwardsColor", QColor("#FFA500"));
     defaultColors.insert("SideBarBulletColor", QColor("#808080"));
     defaultColors.insert("SideBarBulletBreakpointColor", QColor("#FF0000"));
     defaultColors.insert("SideBarBulletDisabledBreakpointColor", QColor("#00AA00"));


### PR DESCRIPTION
This resolves #811.
Forward and backwards jumps use cyan and orange respectively.
Cyan/orange were chosen over red/green to aid red/green colorblindness as well as any positive/negative connotations based on green/red.
All executing jumps still show as red regardless of direction.
Existing configurations will use their defined color for forwards, and orange for backwards.