### PR TITLE
GUI: add ascii/unicode column on cpu stack widget

### DIFF
--- a/src/gui/Src/BasicView/HexDump.h
+++ b/src/gui/Src/BasicView/HexDump.h
@@ -73,6 +73,7 @@ public:
     struct ColumnDescriptor
     {
         bool isData = true;
+        bool invertData = false;
         int itemCount = 16;
         int separator = 0;
         QTextCodec* textCodec = nullptr; //name of the text codec (leave empty if you want to keep your sanity)

--- a/src/gui/Src/Gui/CPUStack.h
+++ b/src/gui/Src/Gui/CPUStack.h
@@ -73,6 +73,8 @@ public slots:
     void followInMemoryMapSlot();
     void followInDumpSlot();
     void updateSlot();
+    void triggerAsciiColumnSlot();
+    void triggerUnicodeColumnSlot();
 
 private:
     duint mCsp;
@@ -81,6 +83,8 @@ private:
     QAction* mFreezeStack;
     QAction* mFollowStack;
     QAction* mFollowDisasm;
+    QAction* mTriggerAsciiCol = nullptr;
+    QAction* mTriggerUnicodeCol = nullptr;
     QList<QAction*> mFollowInDumpActions;
     QMenu* mPluginMenu;
 
@@ -100,6 +104,14 @@ private:
 
     std::vector<CPUCallStack> mCallstack;
     static int CPUStack::getCurrentFrame(const std::vector<CPUStack::CPUCallStack> & mCallstack, duint wVA);
+
+    void setupColumns();
+    void setupAddressColumn(int);
+    void setupAsciiColumn(int);
+    void setupUnicodeColumn(int);
+    void setupCommentColumn();
+    bool showAsciiColumn();
+    bool showUnicodeColumn();
 };
 
 #endif // CPUSTACK_H

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -306,7 +306,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
 
     QMap<QString, duint> guiUint;
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUDisassembly", 4);
-    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUStack", 3);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUStack", 4);
     for(int i = 1; i <= 5; i++)
         AbstractTableView::setupColumnConfigDefaultValue(guiUint, QString("CPUDump%1").arg(i), 4);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Watch1", 6);
@@ -614,6 +614,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ActionWatchDwordQword", Shortcut({tr("Actions"), tr("Watch DWORD/QWORD")}));
     defaultShortcuts.insert("ActionCopyFileOffset", Shortcut({tr("Actions"), tr("Copy File Offset")}));
     defaultShortcuts.insert("ActionToggleRunTrace", Shortcut({tr("Actions"), tr("Start or Stop Run Trace")}));
+    defaultShortcuts.insert("ActionTriggerAsciiColumn", Shortcut({tr("Actions"), tr("Show/Hide ASCII dump column on CPU stack window")}));
+    defaultShortcuts.insert("ActionTriggerUnicodeColumn", Shortcut({tr("Actions"), tr("Show/Hide Unicode dump column on CPU stack window")}));
 
     Shortcuts = defaultShortcuts;
 


### PR DESCRIPTION
Feature for #1957

There's a few small things that could be added here. Currently, no settings are saved when the columns are shown/hidden. I am not sure if this is something I should add.

Also, to properly show the ascii/unicode strings on stack, I had to use `std::reverse`. Since performance is a top priority here, I am not sure if this is the way to go with the strings. Another option would be to implement reverse inserts on the `getColumnRichText()` functions based on parameters to avoid having to call `std::reverse`.

Let me know what you think.