### PR TITLE
GUI: #1999 - Added restart required label for system font change

### DIFF
--- a/src/gui/Src/Gui/AppearanceDialog.ui
+++ b/src/gui/Src/Gui/AppearanceDialog.ui
@@ -1711,6 +1711,37 @@ border-width: 1px 2px 2px 1px;</string>
       <string>Log:</string>
      </property>
     </widget>
+    <widget class="QWidget" name="layoutWidget9">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>250</y>
+       <width>500</width>
+       <height>34</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="fontRestartRequiredLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelFontRestartRequired">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>*Setting requires restarting the application to take effect.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
     <zorder>layoutWidget1</zorder>
     <zorder>layoutWidget2</zorder>
     <zorder>layoutWidget3</zorder>
@@ -1726,6 +1757,7 @@ border-width: 1px 2px 2px 1px;</string>
     <zorder>labelFontHexEdit</zorder>
     <zorder>layoutWidget8</zorder>
     <zorder>labelFontLog</zorder>
+    <zorder>layoutWidget9</zorder>
    </widget>
   </widget>
   <widget class="QPushButton" name="buttonCancel">


### PR DESCRIPTION
This resolves #1999 per @mrexodia comment to open PR for adding a label.

This does not address @twifty's request to "would it be possible to resize the button bar according to the font size. Currently they are just too small. One must be very careful not to click the wrong one.".
 
Added label to bottom of appearance dialog font tab that explains that "*" denotes setting that requires app restart to take effect.
Label is word wrapped and vertical expanding to help with larger font choices.
Only English locale.

Example:
![image](https://user-images.githubusercontent.com/45076240/63387820-6fc03180-c374-11e9-849b-47ceb03baba0.png)
