### PR TITLE
fix stack trace in x64

### DIFF
--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -90,6 +90,9 @@ struct MODINFO
     std::vector<MODSECTIONINFO> sections;
     std::vector<MODRELOCATIONINFO> relocations;
     std::vector<duint> tlsCallbacks;
+#if _WIN64
+    std::vector<RUNTIME_FUNCTION> runtimeFunctions; //sorted by (begin, end)
+#endif // _WIN64
 
     MODEXPORT entrySymbol;
 


### PR DESCRIPTION
`StackWalk64` with `SymFunctionTableAccess` would be incorrect if `SymInitializeW` & `SymLoadModuleEx` is not called for specific module.

According to my research, `SymLoadModuleEx` would read UNWIND_INFO resident in PE file, without which unwinding wouble fail.  Using UNWIND_INFO ,  debugger such as Windbg can do stacktrace even without pdb. UNWIND_INFO is located at `pNTHeader->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXCEPTION]`

Indeed Unwinding is quite a complex affair including function prologue and epilogue... emh. Refer to the following: 

https://github.com/dotnet/coreclr/blob/master/src/unwinder/amd64/dbs_stack_x64.cpp
