### PR TITLE
GUI: fix Follow From context menu in CallStackView

### DIFF
--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -28,11 +28,11 @@ void CallStackView::setupContextMenu()
     });
     QIcon icon = DIcon(ArchValue("processor32.png", "processor64.png"));
     mMenuBuilder->addAction(makeAction(icon, tr("Follow &Address"), SLOT(followAddress())));
-    mMenuBuilder->addAction(makeAction(icon, tr("Follow &To"), SLOT(followTo())), [this](QMenu*)
+    mMenuBuilder->addAction(makeAction(icon, tr("Follow &To"), SLOT(followTo())));
+    QAction* mFollowFrom = mMenuBuilder->addAction(makeAction(icon, tr("Follow &From"), SLOT(followFrom())), [this](QMenu*)
     {
         return !getCellContent(getInitialSelection(), 2).isEmpty();
     });
-    QAction* mFollowFrom = mMenuBuilder->addAction(makeAction(icon, tr("Follow &From"), SLOT(followFrom())));
     mFollowFrom->setShortcutContext(Qt::WidgetShortcut);
     mFollowFrom->setShortcut(QKeySequence("enter"));
     connect(this, SIGNAL(enterPressedSignal()), this, SLOT(followFrom()));


### PR DESCRIPTION
This PR fixes GUI issue in #2180 .
Moved the MenuBuilder::BuildCallback from the "Follow To" context menu to the "Follow From" context menu.