### PR TITLE
Fix process cookie on attach

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1714,7 +1714,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     if(ModNameFromAddr(duint(base), modname, true) && scmp(modname, "ntdll.dll"))
     {
         if(settingboolget("Misc", "QueryProcessCookie"))
-            cookie.HandleNtdllLoad();
+            cookie.HandleNtdllLoad(bIsAttached);
         if(settingboolget("Misc", "TransparentExceptionStepping"))
             exceptionDispatchAddr = DbgValFromString("ntdll:KiUserExceptionDispatcher");
     }

--- a/src/dbg/debugger_cookie.h
+++ b/src/dbg/debugger_cookie.h
@@ -9,10 +9,10 @@ struct CookieQuery
     bool removeAddrBp = false;
     bool removeRetBp = false;
 
-    void HandleNtdllLoad()
+    void HandleNtdllLoad(bool isAttached)
     {
         *this = CookieQuery();
-        if(valfromstring("ntdll.dll:NtQueryInformationProcess", &addr))
+        if(!isAttached && valfromstring("ntdll.dll:NtQueryInformationProcess", &addr))
         {
             if(!BpGet(addr, BPNORMAL, nullptr, nullptr))
             {

--- a/src/dbg/debugger_cookie.h
+++ b/src/dbg/debugger_cookie.h
@@ -12,14 +12,19 @@ struct CookieQuery
     void HandleNtdllLoad(bool isAttached)
     {
         *this = CookieQuery();
-        if(!isAttached && valfromstring("ntdll.dll:NtQueryInformationProcess", &addr))
+        ULONG returnSize = 0;
+        NTSTATUS status = NtQueryInformationProcess(fdProcessInfo->hProcess, ProcessCookie, &cookie, sizeof(cookie), &returnSize);
+        if(!NT_SUCCESS(status))
         {
-            if(!BpGet(addr, BPNORMAL, nullptr, nullptr))
+            if(!isAttached && valfromstring("ntdll.dll:NtQueryInformationProcess", &addr))
             {
-                if(SetBPX(addr, UE_BREAKPOINT, (void*)cbUserBreakpoint))
-                    removeAddrBp = true;
-                else
-                    addr = 0;
+                if(!BpGet(addr, BPNORMAL, nullptr, nullptr))
+                {
+                    if(SetBPX(addr, UE_BREAKPOINT, (void*)cbUserBreakpoint))
+                        removeAddrBp = true;
+                    else
+                        addr = 0;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes issue #2164 .
CookieQuery will first try querying the process cookie when creating a process or attaching, using NtQueryInformationProcess, which should succeed on Windows >= 8. If it does not succeed we add the breakpoints to NtQueryInformationProcess only when attaching.