### PR TITLE
DBG: fix invalid handle exception on terminating attach after run

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2760,7 +2760,10 @@ static void debugLoopFunction(void* lpParameter, bool attach)
     varset("$hp", (duint)0, true);
     varset("$pid", (duint)0, true);
     if(hProcessToken)
+    {
         CloseHandle(hProcessToken);
+        hProcessToken = 0;
+    }
 
     pDebuggedEntry = 0;
     pDebuggedBase = 0;


### PR DESCRIPTION
On terminating an attached process after terminating a created process will result in invalid handle exception. This is due to calling CloseHandle on the previous process's hProcessToken.