### PR TITLE
DBG: Fix function boundary computation when getting x64 stack frames

### DIFF
--- a/src/dbg/stackinfo.cpp
+++ b/src/dbg/stackinfo.cpp
@@ -162,15 +162,12 @@ static PVOID CALLBACK StackSymFunctionTableAccess64(HANDLE hProcess, DWORD64 Add
         return nullptr;
 
     DWORD rva = DWORD(AddrBase - info->base);
-    RUNTIME_FUNCTION needle;
-    needle.BeginAddress = rva;
-    needle.EndAddress = rva;
-    needle.UnwindData = 0;
-    auto found = binary_find(info->runtimeFunctions.begin(), info->runtimeFunctions.end(), needle, [](const RUNTIME_FUNCTION & a, const RUNTIME_FUNCTION & b)
+    auto found = std::lower_bound(info->runtimeFunctions.begin(), info->runtimeFunctions.end(), rva, [](const RUNTIME_FUNCTION & a, const DWORD & rva)
     {
-        return a.EndAddress < b.BeginAddress;
+        return a.EndAddress <= rva;
     });
-    if(found != info->runtimeFunctions.end())
+
+    if(found != info->runtimeFunctions.end() && rva >= found->BeginAddress)
         return &found->BeginAddress;
 #endif // _WIN64
 


### PR DESCRIPTION
Fixes #2254.

The function end address in the `RUNTIME_FUNCTION` struct points to one byte beyond the last instruction of the function (like STL ranges).

The current lookup method results in incorrect stack frames on entry into a function "B" that starts immediately after another function "A", resulting in function A's unwind metadata incorrectly getting used to unwind the stack instead of function B's.

**Existing behavior:**
Find `func` where:
`func.BeginAddress <= rva <= func.EndAddress`

**New behavior:**
Find `func` where:
`func.BeginAddress <= rva < func.EndAddress`