### PR TITLE
Feature to specify export function in DLL loader with arguments 

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1735,6 +1735,11 @@ BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList)
     _gui_sendmessage(GUI_GET_CURRENT_GRAPH, graphList, nullptr);
 }
 
+BRIDGE_IMPEXP void GUIShowDLLExportChooser(SYMBOLINFO* export_list, unsigned int number_of_exports)
+{
+    _gui_sendmessage(GUI_OPEN_DLL_EXPORT_CHOOSER, export_list, (void*)number_of_exports);
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInst = hinstDLL;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1179,6 +1179,7 @@ typedef enum
     GUI_UPDATE_TRACE_BROWSER,       // param1=unused,               param2=unused
     GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
     GUI_GET_CURRENT_GRAPH,          // param1=BridgeCFGraphList*,   param2=unused
+    GUI_OPEN_DLL_EXPORT_CHOOSER,    // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1359,6 +1360,7 @@ BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);
 BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
 BRIDGE_IMPEXP void GuiExecuteOnGuiThreadEx(GUICALLBACKEX cbGuiThread, void* userdata);
 BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList);
+BRIDGE_IMPEXP void GUIShowDLLExportChooser(SYMBOLINFO* exportList, unsigned int numberOfExports);
 
 #ifdef __cplusplus
 }

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -865,6 +865,13 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         BridgeResult result(BridgeResult::GraphCurrent);
         emit getCurrentGraph((BridgeCFGraphList*)param1);
         result.Wait();
+        break;
+    }
+
+    case GUI_OPEN_DLL_EXPORT_CHOOSER:
+    {
+        emit showDLLExportChooser((SYMBOLINFO*)param1, (unsigned int)param2);
+        break;
     }
     break;
     }

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -162,6 +162,7 @@ signals:
     void updateTraceBrowser();
     void symbolSelectModule(duint base);
     void getCurrentGraph(BridgeCFGraphList* graphList);
+    void showDLLExportChooser(SYMBOLINFO* export_list, unsigned int number_of_imports);
 
 private:
     CRITICAL_SECTION csBridge;

--- a/src/gui/Src/Gui/DLLExportChooser.ui
+++ b/src/gui/Src/Gui/DLLExportChooser.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DLLExportChooser</class>
+ <widget class="QDialog" name="DLLExportChooser">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>75</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Please choose the export to run</string>
+  </property>
+  <widget class="QComboBox" name="lstExports">
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>10</y>
+     <width>301</width>
+     <height>22</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>71</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Export to run:</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="btnCancel">
+   <property name="geometry">
+    <rect>
+     <x>320</x>
+     <y>40</y>
+     <width>71</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Cancel</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="btnOK">
+   <property name="geometry">
+    <rect>
+     <x>240</x>
+     <y>40</y>
+     <width>75</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>OK</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -12,6 +12,7 @@
 #include "ShortcutsDialog.h"
 #include "AttachDialog.h"
 #include "LineEditDialog.h"
+#include "DLLExportChooser.h"
 #include "StringUtil.h"
 #include "MiscUtil.h"
 #include "FavouriteTools.h"
@@ -95,6 +96,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(Bridge::getBridge(), SIGNAL(setFavouriteItemShortcut(int, QString, QString)), this, SLOT(setFavouriteItemShortcut(int, QString, QString)));
     connect(Bridge::getBridge(), SIGNAL(selectInMemoryMap(duint)), this, SLOT(displayMemMapWidget()));
     connect(Bridge::getBridge(), SIGNAL(closeApplication()), this, SLOT(close()));
+    connect(Bridge::getBridge(), SIGNAL(showDLLExportChooser(SYMBOLINFO*, unsigned int)), this, SLOT(showDLLExportChooser(SYMBOLINFO*, unsigned int)));
 
     // Setup menu API
     initMenuApi();
@@ -2203,4 +2205,10 @@ void MainWindow::on_actionPlugins_triggered()
 void MainWindow::on_actionCheckUpdates_triggered()
 {
     mUpdateChecker->checkForUpdates();
+}
+
+void MainWindow::showDLLExportChooser(SYMBOLINFO* exportList, unsigned int numberOfExports)
+{
+    DLLExportChooser dialog(this, exportList, numberOfExports);
+    dialog.exec();
 }

--- a/src/gui/Src/Gui/MainWindow.h
+++ b/src/gui/Src/Gui/MainWindow.h
@@ -156,6 +156,7 @@ public slots:
     void customizeMenu();
     void addFavouriteItem(int type, const QString & name, const QString & description);
     void setFavouriteItemShortcut(int type, const QString & name, const QString & shortcut);
+    void showDLLExportChooser(SYMBOLINFO* exportList, unsigned int numberOfExports);
 
 private:
     Ui::MainWindow* ui;

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -321,11 +321,13 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Misc", "QueryProcessCookie", &settings.miscQueryProcessCookie);
     GetSettingBool("Misc", "QueryWorkingSet", &settings.miscQueryWorkingSet);
     GetSettingBool("Misc", "TransparentExceptionStepping", &settings.miscTransparentExceptionStepping);
+    GetSettingBool("Misc", "EnableDLLExportChooser", &settings.miscEnableDLLExportChooser);
     ui->chkUtf16LogRedirect->setChecked(settings.miscUtf16LogRedirect);
     ui->chkUseLocalHelpFile->setChecked(settings.miscUseLocalHelpFile);
     ui->chkQueryProcessCookie->setChecked(settings.miscQueryProcessCookie);
     ui->chkQueryWorkingSet->setChecked(settings.miscQueryWorkingSet);
     ui->chkTransparentExceptionStepping->setChecked(settings.miscTransparentExceptionStepping);
+    ui->chkEnableDLLExportChooser->setChecked(settings.miscEnableDLLExportChooser);
 }
 
 void SettingsDialog::SaveSettings()
@@ -428,6 +430,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Misc", "QueryProcessCookie", settings.miscQueryProcessCookie);
     BridgeSettingSetUint("Misc", "QueryWorkingSet", settings.miscQueryWorkingSet);
     BridgeSettingSetUint("Misc", "TransparentExceptionStepping", settings.miscTransparentExceptionStepping);
+    BridgeSettingSetUint("Misc", "EnableDLLExportChooser", settings.miscEnableDLLExportChooser);
 
     BridgeSettingFlush();
     Config()->load();
@@ -918,4 +921,9 @@ void SettingsDialog::on_chkQueryWorkingSet_toggled(bool checked)
 void SettingsDialog::on_chkTransparentExceptionStepping_toggled(bool checked)
 {
     settings.miscTransparentExceptionStepping = checked;
+}
+
+void SettingsDialog::on_chkEnableDLLExportChooser_toggled(bool checked)
+{
+    settings.miscEnableDLLExportChooser = checked;
 }

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -98,6 +98,7 @@ private slots:
     void on_chkQueryProcessCookie_toggled(bool checked);
     void on_chkQueryWorkingSet_toggled(bool checked);
     void on_chkTransparentExceptionStepping_toggled(bool checked);
+    void on_chkEnableDLLExportChooser_toggled(bool checked);
 
 private:
     //enums
@@ -198,6 +199,7 @@ private:
         bool miscQueryProcessCookie;
         bool miscQueryWorkingSet;
         bool miscTransparentExceptionStepping;
+        bool miscEnableDLLExportChooser;
     };
 
     //variables

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>381</width>
-    <height>514</height>
+    <height>528</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,7 +33,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="tabEvents">
       <attribute name="title">
@@ -859,6 +859,13 @@
         <widget class="QCheckBox" name="chkTransparentExceptionStepping">
          <property name="text">
           <string>Transparent exception stepping*</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="chkEnableDLLExportChooser">
+         <property name="text">
+          <string>Ask which export to run when debugging a DLL.</string>
          </property>
         </widget>
        </item>

--- a/src/gui/Src/Gui/dllexportchooser.cpp
+++ b/src/gui/Src/Gui/dllexportchooser.cpp
@@ -1,0 +1,19 @@
+#include "DLLExportChooser.h"
+
+DLLExportChooser::DLLExportChooser(QWidget* parent, SYMBOLINFO* exportList, unsigned int numberOfExports) :
+    QDialog(parent),
+    ui(new Ui::DLLExportChooser),
+    exportList(exportList),
+    numberOfExports(numberOfExports)
+{
+    ui->setupUi(this);
+    for(auto i = 0 ; i < numberOfExports ; ++i)
+    {
+        ui->lstExports->addItem(exportList[i].decoratedSymbol);
+    }
+}
+
+DLLExportChooser::~DLLExportChooser()
+{
+    BridgeFree(exportList);
+}

--- a/src/gui/Src/Gui/dllexportchooser.h
+++ b/src/gui/Src/Gui/dllexportchooser.h
@@ -1,0 +1,21 @@
+#ifndef DLLEXPORTCHOOSER_H
+#define DLLEXPORTCHOOSER_H
+
+#include <QDialog>
+#include <bridge/bridgemain.h>
+#include <ui_DLLExportChooser.h>
+
+class DLLExportChooser : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DLLExportChooser(QWidget* parent, SYMBOLINFO* exportList, unsigned int numberOfExports);
+    ~DLLExportChooser();
+private:
+    Ui::DLLExportChooser* ui;
+    SYMBOLINFO* exportList;
+    unsigned int numberOfExports;
+};
+
+#endif // DLLEXPORTCHOOSER_H

--- a/src/gui/x64dbg.pro
+++ b/src/gui/x64dbg.pro
@@ -183,7 +183,8 @@ SOURCES += \
     Src/BasicView/AbstractStdTable.cpp \
     Src/Gui/ZehSymbolTable.cpp \
     Src/BasicView/StdSearchListView.cpp \
-    Src/BasicView/StdTableSearchList.cpp
+    Src/BasicView/StdTableSearchList.cpp \
+    Src/Gui/DLLExportChooser.cpp
 
 
 HEADERS += \
@@ -304,8 +305,8 @@ HEADERS += \
     Src/BasicView/AbstractSearchList.h \
     Src/BasicView/StdSearchListView.h \
     Src/Gui/FileLines.h \
-    Src/BasicView/StdTableSearchList.h
-    
+    Src/BasicView/StdTableSearchList.h \
+    Src/Gui/DLLExportChooser.h \
 
 FORMS += \
     Src/Gui/MainWindow.ui \
@@ -342,7 +343,8 @@ FORMS += \
     Src/Gui/SimpleTraceDialog.ui \
     Src/Gui/MessagesBreakpoints.ui \
     Src/Gui/AboutDialog.ui \
-    Src/Gui/ComboBoxDialog.ui
+    Src/Gui/ComboBoxDialog.ui \
+    Src/Gui/DLLExportChooser.ui \
 
 ##
 ## Libraries


### PR DESCRIPTION
See https://github.com/x64dbg/x64dbg/issues/1908

Currently a work in progress. The objective is to add a dialog that allows users to select which export they want to run when debugging a DLL.

It's still a work in progress at the moment. The general idea is:
- Add a new setting in Misc to control whether the user wants to see the dialog.
- If so, add a callback to the DLL's entrypoint BP to show the dialog.
- Let the user select the import and (in the future) add parameters.
- Change EIP to the requested DLL, allocate/push arguments and give back control to the user.

In the future, the dialog could also be extended to call arbitrary functions in a program during the debugging session.