### PR TITLE
Enable int3 skipping swallow exception

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1009,7 +1009,6 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
         bUndecorateSymbolNames = settingboolget("Engine", "UndecorateSymbolNames");
         bEnableSourceDebugging = settingboolget("Engine", "EnableSourceDebugging");
         bTraceRecordEnabledDuringTrace = settingboolget("Engine", "TraceRecordEnabledDuringTrace");
-        bSkipInt3Stepping = settingboolget("Engine", "SkipInt3Stepping");
         bIgnoreInconsistentBreakpoints = settingboolget("Engine", "IgnoreInconsistentBreakpoints");
         bNoForegroundWindow = settingboolget("Gui", "NoForegroundWindow");
         bVerboseExceptionLogging = settingboolget("Engine", "VerboseExceptionLogging");

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -17,10 +17,17 @@
 #include "exception.h"
 #include "stringformat.h"
 
+// optionally allow int3 skipping, disabled unless specified to avoid anti-debug
+duint bSkipInt3 = (duint)false;
+
 static bool skipInt3Stepping(int argc, char* argv[])
 {
-    if(!bSkipInt3Stepping || dbgisrunning() || getLastExceptionInfo().ExceptionRecord.ExceptionCode != EXCEPTION_BREAKPOINT)
+    bool Skip = bSkipInt3;
+    bSkipInt3 = false;
+
+    if(!Skip || dbgisrunning() || getLastExceptionInfo().ExceptionRecord.ExceptionCode != EXCEPTION_BREAKPOINT)
         return false;
+
     duint cip = GetContextDataEx(hActiveThread, UE_CIP);
     unsigned char data[MAX_DISASM_BUFFER];
     MemRead(cip, data, sizeof(data));
@@ -281,6 +288,7 @@ bool cbDebugRun(int argc, char* argv[])
 
 bool cbDebugErun(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     HistoryClear();
     if(!dbgisrunning())
         dbgsetskipexceptions(true);
@@ -294,6 +302,7 @@ bool cbDebugErun(int argc, char* argv[])
 
 bool cbDebugSerun(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     cbDebugContinue(argc, argv);
     return cbDebugRunInternal(argc, argv);
 }
@@ -381,12 +390,14 @@ bool cbDebugStepInto(int argc, char* argv[])
 
 bool cbDebugeStepInto(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     dbgsetskipexceptions(true);
     return cbDebugStepInto(argc, argv);
 }
 
 bool cbDebugseStepInto(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     cbDebugContinue(argc, argv);
     return cbDebugStepInto(argc, argv);
 }
@@ -409,12 +420,14 @@ bool cbDebugStepOver(int argc, char* argv[])
 
 bool cbDebugeStepOver(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     dbgsetskipexceptions(true);
     return cbDebugStepOver(1, argv);
 }
 
 bool cbDebugseStepOver(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     cbDebugContinue(argc, argv);
     return cbDebugStepOver(argc, argv);
 }
@@ -435,6 +448,7 @@ bool cbDebugStepOut(int argc, char* argv[])
 
 bool cbDebugeStepOut(int argc, char* argv[])
 {
+    bSkipInt3 = true;
     dbgsetskipexceptions(true);
     return cbDebugStepOut(argc, argv);
 }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -82,7 +82,6 @@ HANDLE hProcessToken;
 bool bUndecorateSymbolNames = true;
 bool bEnableSourceDebugging = false;
 bool bTraceRecordEnabledDuringTrace = true;
-bool bSkipInt3Stepping = false;
 bool bIgnoreInconsistentBreakpoints = false;
 bool bNoForegroundWindow = false;
 bool bVerboseExceptionLogging = true;

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -119,7 +119,6 @@ extern char szSymbolCachePath[MAX_PATH];
 extern bool bUndecorateSymbolNames;
 extern bool bEnableSourceDebugging;
 extern bool bTraceRecordEnabledDuringTrace;
-extern bool bSkipInt3Stepping;
 extern bool bIgnoreInconsistentBreakpoints;
 extern bool bNoForegroundWindow;
 extern bool bVerboseExceptionLogging;

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -174,7 +174,6 @@ void SettingsDialog::LoadSettings()
     ui->chkSaveDatabaseInProgramDirectory->setChecked(settings.engineSaveDatabaseInProgramDirectory);
     ui->chkDisableDatabaseCompression->setChecked(settings.engineDisableDatabaseCompression);
     ui->chkTraceRecordEnabledDuringTrace->setChecked(settings.engineEnableTraceRecordDuringTrace);
-    ui->chkSkipInt3Stepping->setChecked(settings.engineSkipInt3Stepping);
     ui->chkNoScriptTimeout->setChecked(settings.engineNoScriptTimeout);
     ui->chkIgnoreInconsistentBreakpoints->setChecked(settings.engineIgnoreInconsistentBreakpoints);
     ui->chkHardcoreThreadSwitchWarning->setChecked(settings.engineHardcoreThreadSwitchWarning);

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -33,7 +33,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabEvents">
       <attribute name="title">
@@ -286,13 +286,6 @@
         <widget class="QCheckBox" name="chkTraceRecordEnabledDuringTrace">
          <property name="text">
           <string>Enable Trace Record Recording during a Trace</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="chkSkipInt3Stepping">
-         <property name="text">
-          <string>Skip INT3 stepping</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This relates to my comment on https://github.com/x64dbg/x64dbg/issues/1908 as well as https://github.com/x64dbg/x64dbg/issues/211. The functionality implemented by the patch for 211 makes it so that Step Over/Step Into (swallow exception/pass exception) no longer function as expected. Instead i have removed this option, and made it so that all pass/swallow exception step modes now handle int3 just as any other exception would be in these modes AND normal stepping modes do not automatically swallow int3. This make the features behave as expected while still protecting x64dbg from the int3 anti-debug tricks.