### PR TITLE
Support viewing XMM/YMM registers in infobox and XMM data in disassembly

### DIFF
--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -421,7 +421,9 @@ typedef enum
     size_byte = 1,
     size_word = 2,
     size_dword = 4,
-    size_qword = 8
+    size_qword = 8,
+    size_xmmword = 16,
+    size_ymmword = 32
 } MEMORY_SIZE;
 
 typedef enum

--- a/src/gui/Src/Disassembler/QBeaEngine.cpp
+++ b/src/gui/Src/Disassembler/QBeaEngine.cpp
@@ -223,6 +223,8 @@ Instruction_t QBeaEngine::DisassembleAt(byte_t* data, duint size, duint origBase
     wInst.branchType = branchType;
     wInst.tokens = cap;
     cp.BytesGroup(&wInst.prefixSize, &wInst.opcodeSize, &wInst.group1Size, &wInst.group2Size, &wInst.group3Size);
+    for(uint8_t i = 0; i < _countof(wInst.vectorElementType); ++i)
+        wInst.vectorElementType[i] = cp.getVectorElementType(i);
 
     if(!success)
         return wInst;
@@ -299,6 +301,10 @@ Instruction_t QBeaEngine::DecodeDataAt(byte_t* data, duint size, duint origBase,
     wInst.group1Size = 0;
     wInst.group2Size = 0;
     wInst.group3Size = 0;
+    wInst.vectorElementType[0] = Zydis::VETDefault;
+    wInst.vectorElementType[1] = Zydis::VETDefault;
+    wInst.vectorElementType[2] = Zydis::VETDefault;
+    wInst.vectorElementType[3] = Zydis::VETDefault;
 
     return wInst;
 }

--- a/src/gui/Src/Disassembler/QBeaEngine.h
+++ b/src/gui/Src/Disassembler/QBeaEngine.h
@@ -35,6 +35,7 @@ struct Instruction_t
     BranchType branchType;
     ZydisTokenizer::InstructionToken tokens;
     std::vector<std::pair<const char*, uint8_t>> regsReferenced;
+    uint8_t vectorElementType[4];
 };
 
 class QBeaEngine

--- a/src/gui/Src/Disassembler/ZydisTokenizer.cpp
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.cpp
@@ -12,7 +12,7 @@ ZydisTokenizer::ZydisTokenizer(int maxModuleLength)
     SetConfig(false, false, false, false, false, false, false, false, false);
 }
 
-static ZydisTokenizer::TokenColor colorNamesMap[ZydisTokenizer::TokenType::Last];
+static ZydisTokenizer::TokenColor colorNamesMap[size_t(ZydisTokenizer::TokenType::Last)];
 QHash<QString, int> ZydisTokenizer::stringPoolMap;
 int ZydisTokenizer::poolId = 0;
 
@@ -437,6 +437,8 @@ bool ZydisTokenizer::tokenizeMnemonic()
         _mnemonicType = TokenType::MnemonicNop;
     else if(_cp.IsInt3())
         _mnemonicType = TokenType::MnemonicInt3;
+    else if(_cp.IsUnusual())
+        _mnemonicType = TokenType::MnemonicUnusual;
     else if(_cp.IsBranchType(Zydis::BTCallSem))
         _mnemonicType = TokenType::MnemonicCall;
     else if(_cp.IsBranchType(Zydis::BTCondJmpSem))
@@ -447,8 +449,6 @@ bool ZydisTokenizer::tokenizeMnemonic()
         _mnemonicType = TokenType::MnemonicRet;
     else if(_cp.IsPushPop())
         _mnemonicType = TokenType::MnemonicPushPop;
-    else if(_cp.IsUnusual())
-        _mnemonicType = TokenType::MnemonicUnusual;
 
     return tokenizeMnemonic(_mnemonicType, mnemonic);
 }

--- a/src/gui/Src/Disassembler/ZydisTokenizer.cpp
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.cpp
@@ -175,7 +175,8 @@ void ZydisTokenizer::TokenizeTraceRegister(const char* reg, duint oldValue, duin
     {
         tokens.push_back(SingleToken(TokenType::ArgumentSpace, " ", TokenValue()));
     }
-    tokens.push_back(SingleToken(TokenType::GeneralRegister, QString(reg), TokenValue()));
+    QString regName(reg);
+    tokens.push_back(SingleToken(TokenType::GeneralRegister, ConfigBool("Disassembler", "Uppercase") ? regName.toUpper() : regName, TokenValue()));
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, ": ", TokenValue()));
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(oldValue), TokenValue(8, oldValue)));
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, "-> ", TokenValue()));

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -102,6 +102,7 @@ static QString formatSSEOperand(const QByteArray & data, uint8_t vectorType)
         if(data.size() == 32)
         {
             hex = composeRegTextYMM(data.constData(), 1);
+            isXMMdecoded = true;
         }
         else if(data.size() == 16)
         {

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -92,7 +92,7 @@ void CPUInfoBox::clear()
     setInfoLine(3, "");
 }
 
-static QString formatSSEOperand(const QVector<char> & data, uint8_t vectorType)
+static QString formatSSEOperand(const QByteArray & data, uint8_t vectorType)
 {
     QString hex;
     bool isXMMdecoded = false;
@@ -270,7 +270,7 @@ void CPUInfoBox::disasmSelectionChanged(dsint parVA)
             else
             {
                 //TODO: properly support XMM constants
-                QVector<char> data;
+                QByteArray data;
                 data.resize(basicinfo.memory.size);
                 memset(data.data(), 0, data.size());
                 if(DbgMemRead(arg.value, data.data(), data.size()))
@@ -306,6 +306,81 @@ void CPUInfoBox::disasmSelectionChanged(dsint parVA)
                     !mnemonic.startsWith("ymm") &&
                     !mnemonic.startsWith("st"))
             {
+                setInfoLine(j, mnemonic + "=" + valText);
+                j++;
+            }
+            else if(mnemonic.startsWith("xmm") || mnemonic.startsWith("ymm"))
+            {
+                REGDUMP registers;
+                DbgGetRegDumpEx(&registers, sizeof(registers));
+                if(mnemonic == "xmm0")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[0], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm1")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[1], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm2")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[2], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm3")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[3], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm4")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[4], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm5")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[5], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm6")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[6], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm7")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[7], 16), wInst.vectorElementType[i]);
+#ifdef _WIN64
+                else if(mnemonic == "xmm8")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[8], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm9")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[9], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm10")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[10], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm11")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[11], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm12")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[12], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm13")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[13], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm14")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[14], 16), wInst.vectorElementType[i]);
+                else if(mnemonic == "xmm15")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.XmmRegisters[15], 16), wInst.vectorElementType[i]);
+#endif //_WIN64
+                else if(mnemonic == "ymm0")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[0], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm1")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[1], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm2")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[2], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm3")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[3], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm4")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[4], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm5")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[5], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm6")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[6], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm7")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[7], 32), wInst.vectorElementType[i]);
+#ifdef _WIN64
+                else if(mnemonic == "ymm8")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[8], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm9")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[9], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm10")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[10], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm11")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[11], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm12")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[12], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm13")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[13], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm14")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[14], 32), wInst.vectorElementType[i]);
+                else if(mnemonic == "ymm15")
+                    valText = formatSSEOperand(QByteArray((const char*)&registers.regcontext.YmmRegisters[15], 32), wInst.vectorElementType[i]);
+#endif //_WIN64
                 setInfoLine(j, mnemonic + "=" + valText);
                 j++;
             }

--- a/src/gui/Src/Gui/CPUInfoBox.h
+++ b/src/gui/Src/Gui/CPUInfoBox.h
@@ -5,12 +5,14 @@
 
 class WordEditDialog;
 class XrefBrowseDialog;
+class QBeaEngine;
 
 class CPUInfoBox : public StdTable
 {
     Q_OBJECT
 public:
     explicit CPUInfoBox(StdTable* parent = 0);
+    ~CPUInfoBox();
     int getHeight();
     void addFollowMenuItem(QMenu* menu, QString name, duint value);
     void setupFollowMenu(QMenu* menu, duint wVA);
@@ -43,6 +45,7 @@ private:
     void setupContextMenu();
     void setupShortcuts();
     XrefBrowseDialog* mXrefDlg = nullptr;
+    QBeaEngine* mDisasm;
 
     QAction* mCopyAddressAction;
     QAction* mCopyRvaAction;

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -203,13 +203,12 @@ void RegistersView::InitMappings()
 
     if(mShowFpu)
     {
-
+        REGISTER_NAME tempRegisterName;
         offset++;
 
-        if(mFpuMode)
+        if(mFpuMode == 1)
         {
-            mRegisterRelativePlaces.insert(CS, Register_Relative_Position(DS, SS, ES, x87r0));
-            mRegisterRelativePlaces.insert(SS, Register_Relative_Position(CS, x87r0, DS, x87r0));
+            tempRegisterName = x87r0;
 
             mRegisterMapping.insert(x87r0, "x87r0");
             mRegisterPlaces.insert(x87r0, Register_Position(offset++, 0, 6, 10 * 2));
@@ -237,10 +236,9 @@ void RegistersView::InitMappings()
             mRegisterRelativePlaces.insert(x87r7, Register_Relative_Position(x87r6, x87TagWord));
 
         }
-        else
+        else if(mFpuMode == 0)
         {
-            mRegisterRelativePlaces.insert(CS, Register_Relative_Position(DS, SS, ES, x87st0));
-            mRegisterRelativePlaces.insert(SS, Register_Relative_Position(CS, x87st0, DS, x87st0));
+            tempRegisterName = x87st0;
 
             mRegisterMapping.insert(x87st0, "ST(0)");
             mRegisterPlaces.insert(x87st0, Register_Position(offset++, 0, 6, 10 * 2));
@@ -268,21 +266,56 @@ void RegistersView::InitMappings()
             mRegisterRelativePlaces.insert(x87st7, Register_Relative_Position(x87st6, x87TagWord));
 
         }
+        else if(mFpuMode == 2)
+        {
+            tempRegisterName = MM0;
+
+            mRegisterMapping.insert(MM0, "MM0");
+            mRegisterPlaces.insert(MM0, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM0, Register_Relative_Position(SS, MM1));
+            mRegisterMapping.insert(MM1, "MM1");
+            mRegisterPlaces.insert(MM1, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM1, Register_Relative_Position(MM0, MM2));
+            mRegisterMapping.insert(MM2, "MM2");
+            mRegisterPlaces.insert(MM2, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM2, Register_Relative_Position(MM1, MM3));
+            mRegisterMapping.insert(MM3, "MM3");
+            mRegisterPlaces.insert(MM3, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM3, Register_Relative_Position(MM2, MM4));
+            mRegisterMapping.insert(MM4, "MM4");
+            mRegisterPlaces.insert(MM4, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM4, Register_Relative_Position(MM3, MM5));
+            mRegisterMapping.insert(MM5, "MM5");
+            mRegisterPlaces.insert(MM5, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM5, Register_Relative_Position(MM4, MM6));
+            mRegisterMapping.insert(MM6, "MM6");
+            mRegisterPlaces.insert(MM6, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM6, Register_Relative_Position(MM5, MM7));
+            mRegisterMapping.insert(MM7, "MM7");
+            mRegisterPlaces.insert(MM7, Register_Position(offset++, 0, 4, 8 * 2));
+            mRegisterRelativePlaces.insert(MM7, Register_Relative_Position(MM6, x87TagWord));
+        }
+        mRegisterRelativePlaces.insert(CS, Register_Relative_Position(DS, SS, ES, tempRegisterName));
+        mRegisterRelativePlaces.insert(SS, Register_Relative_Position(CS, tempRegisterName, DS, tempRegisterName));
 
         offset++;
 
         mRegisterMapping.insert(x87TagWord, "x87TagWord");
         mRegisterPlaces.insert(x87TagWord, Register_Position(offset++, 0, 11, sizeof(WORD) * 2));
 
-        if(mFpuMode)
+        switch(mFpuMode)
         {
-            mRegisterRelativePlaces.insert(x87TagWord, Register_Relative_Position(x87r7, x87TW_0));
+        case 0:
+            tempRegisterName = x87st7;
+            break;
+        case 1:
+            tempRegisterName = x87r7;
+            break;
+        case 2:
+            tempRegisterName = MM7;
+            break;
         }
-        else
-        {
-            mRegisterRelativePlaces.insert(x87TagWord, Register_Relative_Position(x87st7, x87TW_0));
-        }
-
+        mRegisterRelativePlaces.insert(x87TagWord, Register_Relative_Position(tempRegisterName, x87TW_0));
 
         //Special treatment of long internationalized string
         int NextColumnPosition = 20;
@@ -463,48 +496,19 @@ void RegistersView::InitMappings()
 
         mRegisterMapping.insert(MxCsr_IE, "MxCsr_IE");
         mRegisterPlaces.insert(MxCsr_IE, Register_Position(offset, 0, 9, 1));
-        mRegisterRelativePlaces.insert(MxCsr_IE, Register_Relative_Position(MxCsr_DE, MxCsr_DM, MxCsr_OE, MM0));
+        mRegisterRelativePlaces.insert(MxCsr_IE, Register_Relative_Position(MxCsr_DE, MxCsr_DM, MxCsr_OE, XMM0));
         mRegisterMapping.insert(MxCsr_DM, "MxCsr_DM");
         mRegisterPlaces.insert(MxCsr_DM, Register_Position(offset, 12, 10, 1));
-        mRegisterRelativePlaces.insert(MxCsr_DM, Register_Relative_Position(MxCsr_IE, MxCsr_RC, MxCsr_ZE, MM0));
+        mRegisterRelativePlaces.insert(MxCsr_DM, Register_Relative_Position(MxCsr_IE, MxCsr_RC, MxCsr_ZE, XMM0));
         mRegisterMapping.insert(MxCsr_RC, "MxCsr_RC");
         mRegisterPlaces.insert(MxCsr_RC, Register_Position(offset++, 25, 10, 19));
-        mRegisterRelativePlaces.insert(MxCsr_RC, Register_Relative_Position(MxCsr_DM, MM0, MxCsr_DE, MM0));
-
-
-        offset++;
-
-        mRegisterMapping.insert(MM0, "MM0");
-        mRegisterPlaces.insert(MM0, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM0, Register_Relative_Position(MxCsr_RC, MM1));
-        mRegisterMapping.insert(MM1, "MM1");
-        mRegisterPlaces.insert(MM1, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM1, Register_Relative_Position(MM0, MM2));
-        mRegisterMapping.insert(MM2, "MM2");
-        mRegisterPlaces.insert(MM2, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM2, Register_Relative_Position(MM1, MM3));
-        mRegisterMapping.insert(MM3, "MM3");
-        mRegisterPlaces.insert(MM3, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM3, Register_Relative_Position(MM2, MM4));
-        mRegisterMapping.insert(MM4, "MM4");
-        mRegisterPlaces.insert(MM4, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM4, Register_Relative_Position(MM3, MM5));
-        mRegisterMapping.insert(MM5, "MM5");
-        mRegisterPlaces.insert(MM5, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM5, Register_Relative_Position(MM4, MM6));
-        mRegisterMapping.insert(MM6, "MM6");
-        mRegisterPlaces.insert(MM6, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM6, Register_Relative_Position(MM5, MM7));
-        mRegisterMapping.insert(MM7, "MM7");
-        mRegisterPlaces.insert(MM7, Register_Position(offset++, 0, 4, 8 * 2));
-        mRegisterRelativePlaces.insert(MM7, Register_Relative_Position(MM6, XMM0));
-
+        mRegisterRelativePlaces.insert(MxCsr_RC, Register_Relative_Position(MxCsr_DM, XMM0, MxCsr_DE, XMM0));
 
         offset++;
 
         mRegisterMapping.insert(XMM0, "XMM0");
         mRegisterPlaces.insert(XMM0, Register_Position(offset++, 0, 6, 16 * 2));
-        mRegisterRelativePlaces.insert(XMM0, Register_Relative_Position(MM7, XMM1));
+        mRegisterRelativePlaces.insert(XMM0, Register_Relative_Position(MxCsr_RC, XMM1));
         mRegisterMapping.insert(XMM1, "XMM1");
         mRegisterPlaces.insert(XMM1, Register_Position(offset++, 0, 6, 16 * 2));
         mRegisterRelativePlaces.insert(XMM1, Register_Relative_Position(XMM0, XMM2));
@@ -723,7 +727,7 @@ RegistersView::RegistersView(CPUWidget* parent) : QScrollArea(parent), mVScrollO
         wSIMDRegDispMode = SIMD_REG_DISP_QWORD_HEX;
         break;
     }
-    mFpuMode = false;
+    mFpuMode = 0;
 
     // precreate ContextMenu Actions
     wCM_Increment = setupAction(DIcon("register_inc.png"), tr("Increment"), this);
@@ -752,8 +756,9 @@ RegistersView::RegistersView(CPUWidget* parent) : QScrollArea(parent), mVScrollO
     wCM_Highlight = setupAction(DIcon("highlight.png"), tr("Highlight"), this);
     mSwitchSIMDDispMode = new QMenu(tr("Change SIMD Register Display Mode"), this);
     mSwitchSIMDDispMode->setIcon(DIcon("simdmode.png"));
-    mSwitchFPUDispMode = new QAction(tr("Display ST(x)"), this);
-    mSwitchFPUDispMode->setCheckable(true);
+    mDisplaySTX = new QAction(tr("Display ST(x)"), this);
+    mDisplayx87rX = new QAction(tr("Display x87rX"), this);
+    mDisplayMMX = new QAction(tr("Display MMX"), this);
     SIMDHex = new QAction(tr("Hexadecimal"), mSwitchSIMDDispMode);
     SIMDFloat = new QAction(tr("Float"), mSwitchSIMDDispMode);
     SIMDDouble = new QAction(tr("Double"), mSwitchSIMDDispMode);
@@ -778,6 +783,9 @@ RegistersView::RegistersView(CPUWidget* parent) : QScrollArea(parent), mVScrollO
     SIMDSQWord->setData(QVariant(SIMD_REG_DISP_QWORD_SIGNED));
     SIMDUQWord->setData(QVariant(SIMD_REG_DISP_QWORD_UNSIGNED));
     SIMDHQWord->setData(QVariant(SIMD_REG_DISP_QWORD_HEX));
+    mDisplaySTX->setData(QVariant(0));
+    mDisplayx87rX->setData(QVariant(1));
+    mDisplayMMX->setData(QVariant(2));
     connect(SIMDHex, SIGNAL(triggered()), this, SLOT(onSIMDMode()));
     connect(SIMDFloat, SIGNAL(triggered()), this, SLOT(onSIMDMode()));
     connect(SIMDDouble, SIGNAL(triggered()), this, SLOT(onSIMDMode()));
@@ -790,7 +798,9 @@ RegistersView::RegistersView(CPUWidget* parent) : QScrollArea(parent), mVScrollO
     connect(SIMDSQWord, SIGNAL(triggered()), this, SLOT(onSIMDMode()));
     connect(SIMDUQWord, SIGNAL(triggered()), this, SLOT(onSIMDMode()));
     connect(SIMDHQWord, SIGNAL(triggered()), this, SLOT(onSIMDMode()));
-    connect(mSwitchFPUDispMode, SIGNAL(triggered()), this, SLOT(onFpuMode()));
+    connect(mDisplaySTX, SIGNAL(triggered()), this, SLOT(onFpuMode()));
+    connect(mDisplayx87rX, SIGNAL(triggered()), this, SLOT(onFpuMode()));
+    connect(mDisplayMMX, SIGNAL(triggered()), this, SLOT(onFpuMode()));
     SIMDHex->setCheckable(true);
     SIMDFloat->setCheckable(true);
     SIMDDouble->setCheckable(true);
@@ -2941,15 +2951,39 @@ void RegistersView::onCopyAllAction()
     appendRegister(text, REGISTER_NAME::SS, "SS : ", "SS : ");
     if(mShowFpu)
     {
-
-        appendRegister(text, REGISTER_NAME::x87r0, "x87r0 : ", "x87r0 : ");
-        appendRegister(text, REGISTER_NAME::x87r1, "x87r1 : ", "x87r1 : ");
-        appendRegister(text, REGISTER_NAME::x87r2, "x87r2 : ", "x87r2 : ");
-        appendRegister(text, REGISTER_NAME::x87r3, "x87r3 : ", "x87r3 : ");
-        appendRegister(text, REGISTER_NAME::x87r4, "x87r4 : ", "x87r4 : ");
-        appendRegister(text, REGISTER_NAME::x87r5, "x87r5 : ", "x87r5 : ");
-        appendRegister(text, REGISTER_NAME::x87r6, "x87r6 : ", "x87r6 : ");
-        appendRegister(text, REGISTER_NAME::x87r7, "x87r7 : ", "x87r7 : ");
+        switch(mFpuMode)
+        {
+        case 0:
+            appendRegister(text, REGISTER_NAME::x87st0, "ST(0) : ", "ST(0) : ");
+            appendRegister(text, REGISTER_NAME::x87st1, "ST(1) : ", "ST(1) : ");
+            appendRegister(text, REGISTER_NAME::x87st2, "ST(2) : ", "ST(2) : ");
+            appendRegister(text, REGISTER_NAME::x87st3, "ST(3) : ", "ST(3) : ");
+            appendRegister(text, REGISTER_NAME::x87st4, "ST(4) : ", "ST(4) : ");
+            appendRegister(text, REGISTER_NAME::x87st5, "ST(5) : ", "ST(5) : ");
+            appendRegister(text, REGISTER_NAME::x87st6, "ST(6) : ", "ST(6) : ");
+            appendRegister(text, REGISTER_NAME::x87st7, "ST(7) : ", "ST(7) : ");
+            break;
+        case 1:
+            appendRegister(text, REGISTER_NAME::x87r0, "x87r0 : ", "x87r0 : ");
+            appendRegister(text, REGISTER_NAME::x87r1, "x87r1 : ", "x87r1 : ");
+            appendRegister(text, REGISTER_NAME::x87r2, "x87r2 : ", "x87r2 : ");
+            appendRegister(text, REGISTER_NAME::x87r3, "x87r3 : ", "x87r3 : ");
+            appendRegister(text, REGISTER_NAME::x87r4, "x87r4 : ", "x87r4 : ");
+            appendRegister(text, REGISTER_NAME::x87r5, "x87r5 : ", "x87r5 : ");
+            appendRegister(text, REGISTER_NAME::x87r6, "x87r6 : ", "x87r6 : ");
+            appendRegister(text, REGISTER_NAME::x87r7, "x87r7 : ", "x87r7 : ");
+            break;
+        case 2:
+            appendRegister(text, REGISTER_NAME::MM0, "MM0 : ", "MM0 : ");
+            appendRegister(text, REGISTER_NAME::MM1, "MM1 : ", "MM1 : ");
+            appendRegister(text, REGISTER_NAME::MM2, "MM2 : ", "MM2 : ");
+            appendRegister(text, REGISTER_NAME::MM3, "MM3 : ", "MM3 : ");
+            appendRegister(text, REGISTER_NAME::MM4, "MM4 : ", "MM4 : ");
+            appendRegister(text, REGISTER_NAME::MM5, "MM5 : ", "MM5 : ");
+            appendRegister(text, REGISTER_NAME::MM6, "MM6 : ", "MM6 : ");
+            appendRegister(text, REGISTER_NAME::MM7, "MM7 : ", "MM7 : ");
+            break;
+        }
         appendRegister(text, REGISTER_NAME::x87TagWord, "x87TagWord : ", "x87TagWord : ");
         appendRegister(text, REGISTER_NAME::x87ControlWord, "x87ControlWord : ", "x87ControlWord : ");
         appendRegister(text, REGISTER_NAME::x87StatusWord, "x87StatusWord : ", "x87StatusWord : ");
@@ -3000,14 +3034,6 @@ void RegistersView::onCopyAllAction()
         appendRegister(text, REGISTER_NAME::MxCsr_DE, "MxCsr_DE : ", "MxCsr_DE : ");
         appendRegister(text, REGISTER_NAME::MxCsr_IE, "MxCsr_IE : ", "MxCsr_IE : ");
         appendRegister(text, REGISTER_NAME::MxCsr_RC, "MxCsr_RC : ", "MxCsr_RC : ");
-        appendRegister(text, REGISTER_NAME::MM0, "MM0 : ", "MM0 : ");
-        appendRegister(text, REGISTER_NAME::MM1, "MM1 : ", "MM1 : ");
-        appendRegister(text, REGISTER_NAME::MM2, "MM2 : ", "MM2 : ");
-        appendRegister(text, REGISTER_NAME::MM3, "MM3 : ", "MM3 : ");
-        appendRegister(text, REGISTER_NAME::MM4, "MM4 : ", "MM4 : ");
-        appendRegister(text, REGISTER_NAME::MM5, "MM5 : ", "MM5 : ");
-        appendRegister(text, REGISTER_NAME::MM6, "MM6 : ", "MM6 : ");
-        appendRegister(text, REGISTER_NAME::MM7, "MM7 : ", "MM7 : ");
         appendRegister(text, REGISTER_NAME::XMM0, "XMM0  : ", "XMM0  : ");
         appendRegister(text, REGISTER_NAME::XMM1, "XMM1  : ", "XMM1  : ");
         appendRegister(text, REGISTER_NAME::XMM2, "XMM2  : ", "XMM2  : ");
@@ -3175,11 +3201,6 @@ void RegistersView::displayCustomContextMenuSlot(QPoint pos)
     SIMDSQWord->setChecked(SIMDSQWord == selectedAction);
     SIMDUQWord->setChecked(SIMDUQWord == selectedAction);
     SIMDHQWord->setChecked(SIMDHQWord == selectedAction);
-    if(mFpuMode)
-        mSwitchFPUDispMode->setText(tr("Display ST(x)"));
-    else
-        mSwitchFPUDispMode->setText(tr("Display x87rX"));
-    mSwitchFPUDispMode->setChecked(mFpuMode);
 
     if(mSelected != UNKNOWN)
     {
@@ -3276,7 +3297,16 @@ void RegistersView::displayCustomContextMenuSlot(QPoint pos)
         {
             wMenu.addMenu(mSwitchSIMDDispMode);
         }
-        wMenu.addAction(mSwitchFPUDispMode);
+
+        if(mFPUMMX.contains(mSelected) || mFPUx87_80BITSDISPLAY.contains(mSelected))
+        {
+            if(mFpuMode != 0)
+                wMenu.addAction(mDisplaySTX);
+            if(mFpuMode != 1)
+                wMenu.addAction(mDisplayx87rX);
+            if(mFpuMode != 2)
+                wMenu.addAction(mDisplayMMX);
+        }
 
         wMenu.exec(this->mapToGlobal(pos));
     }
@@ -3286,7 +3316,12 @@ void RegistersView::displayCustomContextMenuSlot(QPoint pos)
         wMenu.addAction(wCM_ChangeFPUView);
         wMenu.addAction(wCM_CopyAll);
         wMenu.addMenu(mSwitchSIMDDispMode);
-        wMenu.addAction(mSwitchFPUDispMode);
+        if(mFpuMode != 0)
+            wMenu.addAction(mDisplaySTX);
+        if(mFpuMode != 1)
+            wMenu.addAction(mDisplayx87rX);
+        if(mFpuMode != 2)
+            wMenu.addAction(mDisplayMMX);
         wMenu.addSeparator();
         QAction* wHwbpCsp = wMenu.addAction(DIcon("breakpoint.png"), tr("Set Hardware Breakpoint on %1").arg(ArchValue("ESP", "RSP")));
         QAction* wAction = wMenu.exec(this->mapToGlobal(pos));
@@ -3750,7 +3785,7 @@ void RegistersView::onSIMDMode()
 
 void RegistersView::onFpuMode()
 {
-    mFpuMode = !mFpuMode;
+    mFpuMode = (char)(dynamic_cast<QAction*>(sender())->data().toInt());
     InitMappings();
     emit refresh();
 }

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -686,47 +686,6 @@ RegistersView::RegistersView(CPUWidget* parent) : QScrollArea(parent), mVScrollO
 {
     setWindowTitle("Registers");
     mChangeViewButton = NULL;
-    connect(Bridge::getBridge(), SIGNAL(close()), this, SLOT(onClose()));
-    switch(ConfigUint("Gui", "SIMDRegistersDisplayMode"))
-    {
-    default:
-    case 0:
-        wSIMDRegDispMode = SIMD_REG_DISP_HEX;
-        break;
-    case 1:
-        wSIMDRegDispMode = SIMD_REG_DISP_FLOAT;
-        break;
-    case 2:
-        wSIMDRegDispMode = SIMD_REG_DISP_DOUBLE;
-        break;
-    case 3:
-        wSIMDRegDispMode = SIMD_REG_DISP_WORD_SIGNED;
-        break;
-    case 4:
-        wSIMDRegDispMode = SIMD_REG_DISP_DWORD_SIGNED;
-        break;
-    case 5:
-        wSIMDRegDispMode = SIMD_REG_DISP_QWORD_SIGNED;
-        break;
-    case 6:
-        wSIMDRegDispMode = SIMD_REG_DISP_WORD_UNSIGNED;
-        break;
-    case 7:
-        wSIMDRegDispMode = SIMD_REG_DISP_DWORD_UNSIGNED;
-        break;
-    case 8:
-        wSIMDRegDispMode = SIMD_REG_DISP_QWORD_UNSIGNED;
-        break;
-    case 9:
-        wSIMDRegDispMode = SIMD_REG_DISP_WORD_HEX;
-        break;
-    case 10:
-        wSIMDRegDispMode = SIMD_REG_DISP_DWORD_HEX;
-        break;
-    case 11:
-        wSIMDRegDispMode = SIMD_REG_DISP_QWORD_HEX;
-        break;
-    }
     mFpuMode = 0;
 
     // precreate ContextMenu Actions
@@ -771,18 +730,18 @@ RegistersView::RegistersView(CPUWidget* parent) : QScrollArea(parent), mVScrollO
     SIMDHWord = new QAction(tr("Hexadecimal Word"), mSwitchSIMDDispMode);
     SIMDHDWord = new QAction(tr("Hexadecimal DWord"), mSwitchSIMDDispMode);
     SIMDHQWord = new QAction(tr("Hexadecimal QWord"), mSwitchSIMDDispMode);
-    SIMDHex->setData(QVariant(SIMD_REG_DISP_HEX));
-    SIMDFloat->setData(QVariant(SIMD_REG_DISP_FLOAT));
-    SIMDDouble->setData(QVariant(SIMD_REG_DISP_DOUBLE));
-    SIMDSWord->setData(QVariant(SIMD_REG_DISP_WORD_SIGNED));
-    SIMDUWord->setData(QVariant(SIMD_REG_DISP_WORD_UNSIGNED));
-    SIMDHWord->setData(QVariant(SIMD_REG_DISP_WORD_HEX));
-    SIMDSDWord->setData(QVariant(SIMD_REG_DISP_DWORD_SIGNED));
-    SIMDUDWord->setData(QVariant(SIMD_REG_DISP_DWORD_UNSIGNED));
-    SIMDHDWord->setData(QVariant(SIMD_REG_DISP_DWORD_HEX));
-    SIMDSQWord->setData(QVariant(SIMD_REG_DISP_QWORD_SIGNED));
-    SIMDUQWord->setData(QVariant(SIMD_REG_DISP_QWORD_UNSIGNED));
-    SIMDHQWord->setData(QVariant(SIMD_REG_DISP_QWORD_HEX));
+    SIMDHex->setData(QVariant(0));
+    SIMDFloat->setData(QVariant(1));
+    SIMDDouble->setData(QVariant(2));
+    SIMDSWord->setData(QVariant(3));
+    SIMDUWord->setData(QVariant(6));
+    SIMDHWord->setData(QVariant(9));
+    SIMDSDWord->setData(QVariant(4));
+    SIMDUDWord->setData(QVariant(7));
+    SIMDHDWord->setData(QVariant(10));
+    SIMDSQWord->setData(QVariant(5));
+    SIMDUQWord->setData(QVariant(8));
+    SIMDHQWord->setData(QVariant(11));
     mDisplaySTX->setData(QVariant(0));
     mDisplayx87rX->setData(QVariant(1));
     mDisplayMMX->setData(QVariant(2));
@@ -1371,51 +1330,6 @@ RegistersView::~RegistersView()
 {
 }
 
-void RegistersView::onClose()
-{
-    duint cfg = 0;
-    switch(wSIMDRegDispMode)
-    {
-    case SIMD_REG_DISP_HEX:
-        cfg = 0;
-        break;
-    case SIMD_REG_DISP_FLOAT:
-        cfg = 1;
-        break;
-    case SIMD_REG_DISP_DOUBLE:
-        cfg = 2;
-        break;
-    case SIMD_REG_DISP_WORD_SIGNED:
-        cfg = 3;
-        break;
-    case SIMD_REG_DISP_DWORD_SIGNED:
-        cfg = 4;
-        break;
-    case SIMD_REG_DISP_QWORD_SIGNED:
-        cfg = 5;
-        break;
-    case SIMD_REG_DISP_WORD_UNSIGNED:
-        cfg = 6;
-        break;
-    case SIMD_REG_DISP_DWORD_UNSIGNED:
-        cfg = 7;
-        break;
-    case SIMD_REG_DISP_QWORD_UNSIGNED:
-        cfg = 8;
-        break;
-    case SIMD_REG_DISP_WORD_HEX:
-        cfg = 9;
-        break;
-    case SIMD_REG_DISP_DWORD_HEX:
-        cfg = 10;
-        break;
-    case SIMD_REG_DISP_QWORD_HEX:
-        cfg = 11;
-        break;
-    }
-    Config()->setUint("Gui", "SIMDRegistersDisplayMode", cfg);
-}
-
 void RegistersView::fontsUpdatedSlot()
 {
     auto font = ConfigFont("Registers");
@@ -1885,133 +1799,6 @@ QString RegistersView::getRegisterLabel(REGISTER_NAME register_selected)
     return std::move(newText);
 }
 
-static QString fillValue(const char* value, int valsize = 2, bool bFpuRegistersLittleEndian = false)
-{
-    if(bFpuRegistersLittleEndian)
-        return QString(QByteArray(value, valsize).toHex()).toUpper();
-    else // Big Endian
-        return QString(ByteReverse(QByteArray(value, valsize)).toHex()).toUpper();
-}
-
-static QString composeRegTextXMM(const char* value, RegistersView::SIMD_REG_DISP_MODE wSIMDRegDispMode, bool bFpuRegistersLittleEndian)
-{
-    QString valueText;
-    switch(wSIMDRegDispMode)
-    {
-    default:
-    case RegistersView::SIMD_REG_DISP_HEX:
-    {
-        valueText = fillValue(value, 16, bFpuRegistersLittleEndian);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_DOUBLE:
-    {
-        const double* dbl_values = reinterpret_cast<const double*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = ToDoubleString(&dbl_values[0]) + ' ' + ToDoubleString(&dbl_values[1]);
-        else // Big Endian
-            valueText = ToDoubleString(&dbl_values[1]) + ' ' + ToDoubleString(&dbl_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_FLOAT:
-    {
-        const float* flt_values = reinterpret_cast<const float*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = ToFloatString(&flt_values[0]) + ' ' + ToFloatString(&flt_values[1]) + ' '
-                        + ToFloatString(&flt_values[2]) + ' ' + ToFloatString(&flt_values[3]);
-        else // Big Endian
-            valueText = ToFloatString(&flt_values[3]) + ' ' + ToFloatString(&flt_values[2]) + ' '
-                        + ToFloatString(&flt_values[1]) + ' ' + ToFloatString(&flt_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_WORD_HEX:
-    {
-        if(bFpuRegistersLittleEndian)
-            valueText = fillValue(value) + ' ' + fillValue(value + 1 * 2) + ' ' + fillValue(value + 2 * 2) + ' ' + fillValue(value + 3 * 2)
-                        + ' ' + fillValue(value + 4 * 2) + ' ' + fillValue(value + 5 * 2) + ' ' + fillValue(value + 6 * 2) + ' ' + fillValue(value + 7 * 2);
-        else // Big Endian
-            valueText = fillValue(value + 7 * 2) + ' ' + fillValue(value + 6 * 2) + ' ' + fillValue(value + 5 * 2) + ' ' + fillValue(value + 4 * 2)
-                        + ' ' + fillValue(value + 3 * 2) + ' ' + fillValue(value + 2 * 2) + ' ' + fillValue(value + 1 * 2) + ' ' + fillValue(value);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_WORD_SIGNED:
-    {
-        const short* sword_values = reinterpret_cast<const short*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = QString::number(sword_values[0]) + ' ' + QString::number(sword_values[1]) + ' ' + QString::number(sword_values[2]) + ' ' + QString::number(sword_values[3])
-                        + ' ' + QString::number(sword_values[4]) + ' ' + QString::number(sword_values[5]) + ' ' + QString::number(sword_values[6]) + ' ' + QString::number(sword_values[7]);
-        else // Big Endian
-            valueText = QString::number(sword_values[7]) + ' ' + QString::number(sword_values[6]) + ' ' + QString::number(sword_values[5]) + ' ' + QString::number(sword_values[4])
-                        + ' ' + QString::number(sword_values[3]) + ' ' + QString::number(sword_values[2]) + ' ' + QString::number(sword_values[1]) + ' ' + QString::number(sword_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_WORD_UNSIGNED:
-    {
-        const unsigned short* uword_values = reinterpret_cast<const unsigned short*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = QString::number(uword_values[0]) + ' ' + QString::number(uword_values[1]) + ' ' + QString::number(uword_values[2]) + ' ' + QString::number(uword_values[3])
-                        + ' ' + QString::number(uword_values[4]) + ' ' + QString::number(uword_values[5]) + ' ' + QString::number(uword_values[6]) + ' ' + QString::number(uword_values[7]);
-        else // Big Endian
-            valueText = QString::number(uword_values[7]) + ' ' + QString::number(uword_values[6]) + ' ' + QString::number(uword_values[5]) + ' ' + QString::number(uword_values[4])
-                        + ' ' + QString::number(uword_values[3]) + ' ' + QString::number(uword_values[2]) + ' ' + QString::number(uword_values[1]) + ' ' + QString::number(uword_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_DWORD_HEX:
-    {
-        if(bFpuRegistersLittleEndian)
-            valueText = fillValue(value, 4) + ' ' +  fillValue(value + 1 * 4, 4) + ' ' +  fillValue(value + 2 * 4, 4) + ' ' +  fillValue(value + 3 * 4, 4);
-        else // Big Endian
-            valueText = fillValue(value + 3 * 4, 4) + ' ' +  fillValue(value + 2 * 4, 4) + ' ' +  fillValue(value + 1 * 4, 4) + ' ' +  fillValue(value, 4);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_DWORD_SIGNED:
-    {
-        const int* sdword_values = reinterpret_cast<const int*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = QString::number(sdword_values[0]) + ' ' + QString::number(sdword_values[1]) + ' ' + QString::number(sdword_values[2]) + ' ' + QString::number(sdword_values[3]);
-        else // Big Endian
-            valueText = QString::number(sdword_values[3]) + ' ' + QString::number(sdword_values[2]) + ' ' + QString::number(sdword_values[1]) + ' ' + QString::number(sdword_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_DWORD_UNSIGNED:
-    {
-        const unsigned int* udword_values = reinterpret_cast<const unsigned int*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = QString::number(udword_values[0]) + ' ' + QString::number(udword_values[1]) + ' ' + QString::number(udword_values[2]) + ' ' + QString::number(udword_values[3]);
-        else // Big Endian
-            valueText = QString::number(udword_values[3]) + ' ' + QString::number(udword_values[2]) + ' ' + QString::number(udword_values[1]) + ' ' + QString::number(udword_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_QWORD_HEX:
-    {
-        if(bFpuRegistersLittleEndian)
-            valueText = fillValue(value, 8) + ' ' + fillValue(value + 8, 8);
-        else // Big Endian
-            valueText = fillValue(value + 8, 8) + ' ' + fillValue(value, 8);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_QWORD_SIGNED:
-    {
-        const long long* sqword_values = reinterpret_cast<const long long*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = QString::number(sqword_values[0]) + ' ' + QString::number(sqword_values[1]);
-        else // Big Endian
-            valueText = QString::number(sqword_values[1]) + ' ' + QString::number(sqword_values[0]);
-    }
-    break;
-    case RegistersView::SIMD_REG_DISP_QWORD_UNSIGNED:
-    {
-        const unsigned long long* uqword_values = reinterpret_cast<const unsigned long long*>(value);
-        if(bFpuRegistersLittleEndian)
-            valueText = QString::number(uqword_values[0]) + ' ' + QString::number(uqword_values[1]);
-        else // Big Endian
-            valueText = QString::number(uqword_values[1]) + ' ' + QString::number(uqword_values[0]);
-    }
-    break;
-    }
-    return std::move(valueText);
-}
-
 /**
  * @brief RegistersView::GetRegStringValueFromValue Get the textual representation of the register value.
  * @param reg The name of the register
@@ -2095,16 +1882,9 @@ QString RegistersView::GetRegStringValueFromValue(REGISTER_NAME reg, const char*
         if(size != 0)
         {
             if(mFPUXMM.contains(reg))
-                valueText = composeRegTextXMM(value, wSIMDRegDispMode, bFpuRegistersLittleEndian);
+                valueText = GetDataTypeString(value, size, enc_xmmword);
             else if(mFPUYMM.contains(reg))
-            {
-                if(wSIMDRegDispMode == SIMD_REG_DISP_HEX)
-                    valueText = fillValue(value, size, bFpuRegistersLittleEndian);
-                else if(bFpuRegistersLittleEndian)
-                    valueText = composeRegTextXMM(value, wSIMDRegDispMode, bFpuRegistersLittleEndian) + ' ' + composeRegTextXMM(value + 16, wSIMDRegDispMode, bFpuRegistersLittleEndian);
-                else
-                    valueText = composeRegTextXMM(value + 16, wSIMDRegDispMode, bFpuRegistersLittleEndian) + ' ' + composeRegTextXMM(value, wSIMDRegDispMode, bFpuRegistersLittleEndian);
-            }
+                valueText = GetDataTypeString(value, size, enc_ymmword);
             else
                 valueText = fillValue(value, size, bFpuRegistersLittleEndian);
         }
@@ -3150,42 +2930,42 @@ void RegistersView::displayCustomContextMenuSlot(QPoint pos)
     QMenu wMenu(this);
     QMenu* followInDumpNMenu = nullptr;
     const QAction* selectedAction = nullptr;
-    switch(wSIMDRegDispMode)
+    switch(ConfigUint("Gui", "SIMDRegistersDisplayMode"))
     {
-    case SIMD_REG_DISP_HEX:
+    case 0:
         selectedAction = SIMDHex;
         break;
-    case SIMD_REG_DISP_FLOAT:
+    case 1:
         selectedAction = SIMDFloat;
         break;
-    case SIMD_REG_DISP_DOUBLE:
+    case 2:
         selectedAction = SIMDDouble;
         break;
-    case SIMD_REG_DISP_WORD_SIGNED:
+    case 3:
         selectedAction = SIMDSWord;
         break;
-    case SIMD_REG_DISP_WORD_UNSIGNED:
+    case 6:
         selectedAction = SIMDUWord;
         break;
-    case SIMD_REG_DISP_WORD_HEX:
+    case 9:
         selectedAction = SIMDHWord;
         break;
-    case SIMD_REG_DISP_DWORD_SIGNED:
+    case 4:
         selectedAction = SIMDSDWord;
         break;
-    case SIMD_REG_DISP_DWORD_UNSIGNED:
+    case 7:
         selectedAction = SIMDUDWord;
         break;
-    case SIMD_REG_DISP_DWORD_HEX:
+    case 10:
         selectedAction = SIMDHDWord;
         break;
-    case SIMD_REG_DISP_QWORD_SIGNED:
+    case 5:
         selectedAction = SIMDSQWord;
         break;
-    case SIMD_REG_DISP_QWORD_UNSIGNED:
+    case 8:
         selectedAction = SIMDUQWord;
         break;
-    case SIMD_REG_DISP_QWORD_HEX:
+    case 11:
         selectedAction = SIMDHQWord;
         break;
     }
@@ -3779,7 +3559,7 @@ void RegistersView::setRegisters(REGDUMP* reg)
 
 void RegistersView::onSIMDMode()
 {
-    wSIMDRegDispMode = (SIMD_REG_DISP_MODE)(dynamic_cast<QAction*>(sender())->data().toInt());
+    Config()->setUint("Gui", "SIMDRegistersDisplayMode", dynamic_cast<QAction*>(sender())->data().toInt());
     emit refresh();
 }
 

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -284,10 +284,12 @@ private:
     unsigned int mRowHeight, mCharWidth;
     // SIMD registers display mode
     SIMD_REG_DISP_MODE wSIMDRegDispMode;
-    bool mFpuMode; //false = order by ST(X), true = order by x87rX
+    char mFpuMode; //0 = order by ST(X), 1 = order by x87rX, 2 = MMX registers
     // context menu actions
     QMenu* mSwitchSIMDDispMode;
-    QAction* mSwitchFPUDispMode;
+    QAction* mDisplaySTX;
+    QAction* mDisplayx87rX;
+    QAction* mDisplayMMX;
     QAction* mFollowInDump;
     QAction* wCM_Increment;
     QAction* wCM_Decrement;

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -72,22 +72,6 @@ public:
         UNKNOWN
     };
 
-    enum SIMD_REG_DISP_MODE : int
-    {
-        SIMD_REG_DISP_HEX,
-        SIMD_REG_DISP_FLOAT,
-        SIMD_REG_DISP_DOUBLE,
-        SIMD_REG_DISP_WORD_SIGNED,
-        SIMD_REG_DISP_DWORD_SIGNED,
-        SIMD_REG_DISP_QWORD_SIGNED,
-        SIMD_REG_DISP_WORD_UNSIGNED,
-        SIMD_REG_DISP_DWORD_UNSIGNED,
-        SIMD_REG_DISP_QWORD_UNSIGNED,
-        SIMD_REG_DISP_WORD_HEX,
-        SIMD_REG_DISP_DWORD_HEX,
-        SIMD_REG_DISP_QWORD_HEX
-    };
-
     // contains viewport position of register
     struct Register_Position
     {
@@ -214,7 +198,6 @@ protected slots:
     // switch SIMD display modes
     void onSIMDMode();
     void onFpuMode();
-    void onClose();
     QString getRegisterLabel(REGISTER_NAME);
     int CompareRegisters(const REGISTER_NAME reg_name, REGDUMP* regdump1, REGDUMP* regdump2);
     SIZE_T GetSizeRegister(const REGISTER_NAME reg_name);
@@ -283,7 +266,6 @@ private:
     // font measures (TODO: create a class that calculates all thos values)
     unsigned int mRowHeight, mCharWidth;
     // SIMD registers display mode
-    SIMD_REG_DISP_MODE wSIMDRegDispMode;
     char mFpuMode; //0 = order by ST(X), 1 = order by x87rX, 2 = MMX registers
     // context menu actions
     QMenu* mSwitchSIMDDispMode;

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -746,10 +746,6 @@ void TraceBrowser::mousePressEvent(QMouseEvent* event)
                     mHighlightToken = ZydisTokenizer::SingleToken();
                 }
             }
-            else if(!mPermanentHighlightingMode)
-            {
-                mHighlightToken = ZydisTokenizer::SingleToken();
-            }
             if(mHighlightingMode) //disable highlighting mode after clicked
             {
                 mHighlightingMode = false;

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -167,7 +167,7 @@ QString TraceBrowser::paintContent(QPainter* painter, dsint rowBase, int rowOffs
         painter->drawRect(rect);
     }
 
-    int index = rowBase + rowOffset;
+    duint index = rowBase + rowOffset;
     duint cur_addr;
     cur_addr = mTraceFile->Registers(index).regcontext.cip;
     bool wIsSelected = (index >= mSelection.fromIndex && index <= mSelection.toIndex);
@@ -382,7 +382,7 @@ NotDebuggingLabel:
         if(mHighlightToken.text.length())
             ZydisTokenizer::TokenToRichText(fakeInstruction, richText, &mHighlightToken);
         else
-            ZydisTokenizer::TokenToRichText(fakeInstruction, richText, 0);
+            ZydisTokenizer::TokenToRichText(fakeInstruction, richText, nullptr);
         RichTextPainter::paintRichText(painter, x + 0, y, getColumnWidth(col) - 0, getRowHeight(), 4, richText, mFontMetrics);
 
         return "";
@@ -440,7 +440,7 @@ NotDebuggingLabel:
     }
 }
 
-ZydisTokenizer::InstructionToken TraceBrowser::memoryTokens(int atIndex)
+ZydisTokenizer::InstructionToken TraceBrowser::memoryTokens(unsigned long long atIndex)
 {
     duint MemoryAddress[MAX_MEMORY_OPERANDS];
     duint MemoryOldContent[MAX_MEMORY_OPERANDS];
@@ -466,7 +466,7 @@ ZydisTokenizer::InstructionToken TraceBrowser::memoryTokens(int atIndex)
     return  fakeInstruction;
 }
 
-ZydisTokenizer::InstructionToken TraceBrowser::registersTokens(int atIndex)
+ZydisTokenizer::InstructionToken TraceBrowser::registersTokens(unsigned long long atIndex)
 {
     ZydisTokenizer::InstructionToken fakeInstruction = ZydisTokenizer::InstructionToken();
     REGDUMP now = mTraceFile->Registers(atIndex);
@@ -843,8 +843,8 @@ void TraceBrowser::mouseMoveEvent(QMouseEvent* event)
 void TraceBrowser::keyPressEvent(QKeyEvent* event)
 {
     int key = event->key();
-    int curindex = getInitialSelection();
-    int visibleindex = curindex;
+    auto curindex = getInitialSelection();
+    auto visibleindex = curindex;
     if((key == Qt::Key_Up || key == Qt::Key_Down) && mTraceFile && mTraceFile->Progress() == 100)
     {
         if(key == Qt::Key_Up)

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -341,7 +341,7 @@ NotDebuggingLabel:
         unsigned char opcodes[16];
         int opcodeSize = 0;
         mTraceFile->OpCode(index, opcodes, &opcodeSize);
-        Instruction_t inst = mDisasm->DisassembleAt(opcodes, opcodeSize, 0, mTraceFile->Registers(index).regcontext.cip, false);
+        Instruction_t inst = mDisasm->DisassembleAt(opcodes, opcodeSize, 0, cur_addr, false);
         RichTextPainter::paintRichText(painter, x, y, getColumnWidth(col), getRowHeight(), 4, getRichBytes(inst), mFontMetrics);
         return "";
     }
@@ -353,7 +353,7 @@ NotDebuggingLabel:
         int opcodeSize = 0;
         mTraceFile->OpCode(index, opcodes, &opcodeSize);
 
-        Instruction_t inst = mDisasm->DisassembleAt(opcodes, opcodeSize, 0, mTraceFile->Registers(index).regcontext.cip, false);
+        Instruction_t inst = mDisasm->DisassembleAt(opcodes, opcodeSize, 0, cur_addr, false);
 
         if(mHighlightToken.text.length())
             ZydisTokenizer::TokenToRichText(inst.tokens, richText, &mHighlightToken);
@@ -1117,7 +1117,7 @@ void TraceBrowser::gotoSlot()
     if(gotoDlg.exec() == QDialog::Accepted)
     {
         auto val = DbgValFromString(gotoDlg.expressionText.toUtf8().constData());
-        if(val > 0 && val < mTraceFile->Length())
+        if(val >= 0 && val < mTraceFile->Length())
         {
             setSingleSelection(val);
             makeVisible(val);

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -50,6 +50,7 @@ TraceBrowser::TraceBrowser(QWidget* parent) : AbstractTableView(parent)
 
     connect(Bridge::getBridge(), SIGNAL(updateTraceBrowser()), this, SLOT(updateSlot()));
     connect(Bridge::getBridge(), SIGNAL(openTraceFile(const QString &)), this, SLOT(openSlot(const QString &)));
+    connect(Config(), SIGNAL(tokenizerConfigUpdated()), this, SLOT(tokenizerConfigUpdatedSlot()));
 }
 
 TraceBrowser::~TraceBrowser()

--- a/src/gui/Src/Tracer/TraceBrowser.h
+++ b/src/gui/Src/Tracer/TraceBrowser.h
@@ -54,8 +54,8 @@ private:
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
 
-    ZydisTokenizer::InstructionToken memoryTokens(int atIndex);
-    ZydisTokenizer::InstructionToken registersTokens(int atIndex);
+    ZydisTokenizer::InstructionToken memoryTokens(unsigned long long atIndex);
+    ZydisTokenizer::InstructionToken registersTokens(unsigned long long atIndex);
     VaHistory mHistory;
     MenuBuilder* mMenuBuilder;
     bool mRvaDisplayEnabled;

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -145,6 +145,7 @@ void TraceFileReader::OpCode(unsigned long long index, unsigned char* buffer, in
     if(page == nullptr)
     {
         memset(buffer, 0, 16);
+        *opcodeSize = 0;
         return;
     }
     else

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -92,31 +92,37 @@ void TraceFileReader::parseFinishedSlot()
     //GuiAddLogMessage(QString("%1;%2;%3\r\n").arg(i.first).arg(i.second.first).arg(i.second.second).toUtf8().constData());
 }
 
+// Return if the file read was error
 bool TraceFileReader::isError() const
 {
     return error;
 }
 
+// Return 100 when loading is completed
 int TraceFileReader::Progress() const
 {
     return progress.load();
 }
 
+// Return the count of instructions
 unsigned long long TraceFileReader::Length() const
 {
     return length;
 }
 
+// Return the hash value of executable to be matched against current executable
 duint TraceFileReader::HashValue() const
 {
     return hashValue;
 }
 
+// Return the executable name of executable
 QString TraceFileReader::ExePath() const
 {
     return EXEPath;
 }
 
+// Return the registers context at a given index
 REGDUMP TraceFileReader::Registers(unsigned long long index)
 {
     unsigned long long base;
@@ -131,6 +137,7 @@ REGDUMP TraceFileReader::Registers(unsigned long long index)
         return page->Registers(index - base);
 }
 
+// Return the opcode at a given index. buffer must be 16 bytes long.
 void TraceFileReader::OpCode(unsigned long long index, unsigned char* buffer, int* opcodeSize)
 {
     unsigned long long base;
@@ -144,6 +151,7 @@ void TraceFileReader::OpCode(unsigned long long index, unsigned char* buffer, in
         page->OpCode(index - base, buffer, opcodeSize);
 }
 
+// Return the thread id at a given index
 DWORD TraceFileReader::ThreadId(unsigned long long index)
 {
     unsigned long long base;
@@ -154,6 +162,7 @@ DWORD TraceFileReader::ThreadId(unsigned long long index)
         return page->ThreadId(index - base);
 }
 
+// Return the number of recorded memory accesses at a given index
 int TraceFileReader::MemoryAccessCount(unsigned long long index)
 {
     unsigned long long base;
@@ -164,6 +173,7 @@ int TraceFileReader::MemoryAccessCount(unsigned long long index)
         return page->MemoryAccessCount(index - base);
 }
 
+// Return the memory access info at a given index
 void TraceFileReader::MemoryAccessInfo(unsigned long long index, duint* address, duint* oldMemory, duint* newMemory, bool* isValid)
 {
     unsigned long long base;
@@ -174,8 +184,10 @@ void TraceFileReader::MemoryAccessInfo(unsigned long long index, duint* address,
         return page->MemoryAccessInfo(index - base, address, oldMemory, newMemory, isValid);
 }
 
+// Used internally to get the page for the given index and read from disk if necessary
 TraceFilePage* TraceFileReader::getPage(unsigned long long index, unsigned long long* base)
 {
+    // Try to access the most recent used page
     if(lastAccessedPage)
     {
         if(index >= lastAccessedIndexOffset && index < lastAccessedIndexOffset + lastAccessedPage->Length())
@@ -184,6 +196,7 @@ TraceFilePage* TraceFileReader::getPage(unsigned long long index, unsigned long 
             return lastAccessedPage;
         }
     }
+    // Try to access pages in memory
     const auto cache = pages.find(Range(index, index));
     if(cache != pages.cend())
     {
@@ -200,7 +213,7 @@ TraceFilePage* TraceFileReader::getPage(unsigned long long index, unsigned long 
     }
     else if(index >= Length()) //Out of bound
         return nullptr;
-    //page in
+    // Remove an oldest page from system memory to make room for a new one.
     if(pages.size() >= 2048) //TODO: trim resident pages based on system memory usage, instead of a hard limit.
     {
         FILETIME pageOutTime = pages.begin()->second.lastAccessed;
@@ -241,7 +254,7 @@ TraceFilePage* TraceFileReader::getPage(unsigned long long index, unsigned long 
             start = middle;
         middle = (start + end) / 2;
     }
-
+    // Read the requested page from disk and return
     if(fileOffset->second.second + fileOffset->first >= index && fileOffset->first <= index)
     {
         pages.insert(std::make_pair(Range(fileOffset->first, fileOffset->first + fileOffset->second.second - 1), TraceFilePage(this, fileOffset->second.first, fileOffset->second.second)));
@@ -428,6 +441,7 @@ void TraceFileParser::run()
     that->traceFile.moveToThread(that->thread());
 }
 
+// Remove last page from memory and read from disk again to show updates
 void TraceFileReader::purgeLastPage()
 {
     unsigned long long index = 0;

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -3,6 +3,7 @@
 #include "StringUtil.h"
 #include "MiscUtil.h"
 #include "ldconvert.h"
+#include "Configuration.h"
 
 QString ToLongDoubleString(const void* buffer)
 {
@@ -40,6 +41,145 @@ QString EscapeCh(QChar ch)
     }
 }
 
+QString fillValue(const char* value, int valsize, bool bFpuRegistersLittleEndian)
+{
+    if(bFpuRegistersLittleEndian)
+        return QString(QByteArray(value, valsize).toHex()).toUpper();
+    else // Big Endian
+        return QString(ByteReverse(QByteArray(value, valsize)).toHex()).toUpper();
+}
+
+QString composeRegTextXMM(const char* value, int mode)
+{
+    bool bFpuRegistersLittleEndian = ConfigBool("Gui", "FpuRegistersLittleEndian");
+    QString valueText;
+    switch(mode)
+    {
+    default:
+    case 0:
+    {
+        valueText = fillValue(value, 16, bFpuRegistersLittleEndian);
+    }
+    break;
+    case 2:
+    {
+        const double* dbl_values = reinterpret_cast<const double*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = ToDoubleString(&dbl_values[0]) + ' ' + ToDoubleString(&dbl_values[1]);
+        else // Big Endian
+            valueText = ToDoubleString(&dbl_values[1]) + ' ' + ToDoubleString(&dbl_values[0]);
+    }
+    break;
+    case 1:
+    {
+        const float* flt_values = reinterpret_cast<const float*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = ToFloatString(&flt_values[0]) + ' ' + ToFloatString(&flt_values[1]) + ' '
+                        + ToFloatString(&flt_values[2]) + ' ' + ToFloatString(&flt_values[3]);
+        else // Big Endian
+            valueText = ToFloatString(&flt_values[3]) + ' ' + ToFloatString(&flt_values[2]) + ' '
+                        + ToFloatString(&flt_values[1]) + ' ' + ToFloatString(&flt_values[0]);
+    }
+    break;
+    case 9:
+    {
+        if(bFpuRegistersLittleEndian)
+            valueText = fillValue(value) + ' ' + fillValue(value + 1 * 2) + ' ' + fillValue(value + 2 * 2) + ' ' + fillValue(value + 3 * 2)
+                        + ' ' + fillValue(value + 4 * 2) + ' ' + fillValue(value + 5 * 2) + ' ' + fillValue(value + 6 * 2) + ' ' + fillValue(value + 7 * 2);
+        else // Big Endian
+            valueText = fillValue(value + 7 * 2) + ' ' + fillValue(value + 6 * 2) + ' ' + fillValue(value + 5 * 2) + ' ' + fillValue(value + 4 * 2)
+                        + ' ' + fillValue(value + 3 * 2) + ' ' + fillValue(value + 2 * 2) + ' ' + fillValue(value + 1 * 2) + ' ' + fillValue(value);
+    }
+    break;
+    case 3:
+    {
+        const short* sword_values = reinterpret_cast<const short*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = QString::number(sword_values[0]) + ' ' + QString::number(sword_values[1]) + ' ' + QString::number(sword_values[2]) + ' ' + QString::number(sword_values[3])
+                        + ' ' + QString::number(sword_values[4]) + ' ' + QString::number(sword_values[5]) + ' ' + QString::number(sword_values[6]) + ' ' + QString::number(sword_values[7]);
+        else // Big Endian
+            valueText = QString::number(sword_values[7]) + ' ' + QString::number(sword_values[6]) + ' ' + QString::number(sword_values[5]) + ' ' + QString::number(sword_values[4])
+                        + ' ' + QString::number(sword_values[3]) + ' ' + QString::number(sword_values[2]) + ' ' + QString::number(sword_values[1]) + ' ' + QString::number(sword_values[0]);
+    }
+    break;
+    case 6:
+    {
+        const unsigned short* uword_values = reinterpret_cast<const unsigned short*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = QString::number(uword_values[0]) + ' ' + QString::number(uword_values[1]) + ' ' + QString::number(uword_values[2]) + ' ' + QString::number(uword_values[3])
+                        + ' ' + QString::number(uword_values[4]) + ' ' + QString::number(uword_values[5]) + ' ' + QString::number(uword_values[6]) + ' ' + QString::number(uword_values[7]);
+        else // Big Endian
+            valueText = QString::number(uword_values[7]) + ' ' + QString::number(uword_values[6]) + ' ' + QString::number(uword_values[5]) + ' ' + QString::number(uword_values[4])
+                        + ' ' + QString::number(uword_values[3]) + ' ' + QString::number(uword_values[2]) + ' ' + QString::number(uword_values[1]) + ' ' + QString::number(uword_values[0]);
+    }
+    break;
+    case 10:
+    {
+        if(bFpuRegistersLittleEndian)
+            valueText = fillValue(value, 4) + ' ' +  fillValue(value + 1 * 4, 4) + ' ' +  fillValue(value + 2 * 4, 4) + ' ' +  fillValue(value + 3 * 4, 4);
+        else // Big Endian
+            valueText = fillValue(value + 3 * 4, 4) + ' ' +  fillValue(value + 2 * 4, 4) + ' ' +  fillValue(value + 1 * 4, 4) + ' ' +  fillValue(value, 4);
+    }
+    break;
+    case 4:
+    {
+        const int* sdword_values = reinterpret_cast<const int*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = QString::number(sdword_values[0]) + ' ' + QString::number(sdword_values[1]) + ' ' + QString::number(sdword_values[2]) + ' ' + QString::number(sdword_values[3]);
+        else // Big Endian
+            valueText = QString::number(sdword_values[3]) + ' ' + QString::number(sdword_values[2]) + ' ' + QString::number(sdword_values[1]) + ' ' + QString::number(sdword_values[0]);
+    }
+    break;
+    case 7:
+    {
+        const unsigned int* udword_values = reinterpret_cast<const unsigned int*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = QString::number(udword_values[0]) + ' ' + QString::number(udword_values[1]) + ' ' + QString::number(udword_values[2]) + ' ' + QString::number(udword_values[3]);
+        else // Big Endian
+            valueText = QString::number(udword_values[3]) + ' ' + QString::number(udword_values[2]) + ' ' + QString::number(udword_values[1]) + ' ' + QString::number(udword_values[0]);
+    }
+    break;
+    case 11:
+    {
+        if(bFpuRegistersLittleEndian)
+            valueText = fillValue(value, 8) + ' ' + fillValue(value + 8, 8);
+        else // Big Endian
+            valueText = fillValue(value + 8, 8) + ' ' + fillValue(value, 8);
+    }
+    break;
+    case 5:
+    {
+        const long long* sqword_values = reinterpret_cast<const long long*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = QString::number(sqword_values[0]) + ' ' + QString::number(sqword_values[1]);
+        else // Big Endian
+            valueText = QString::number(sqword_values[1]) + ' ' + QString::number(sqword_values[0]);
+    }
+    break;
+    case 8:
+    {
+        const unsigned long long* uqword_values = reinterpret_cast<const unsigned long long*>(value);
+        if(bFpuRegistersLittleEndian)
+            valueText = QString::number(uqword_values[0]) + ' ' + QString::number(uqword_values[1]);
+        else // Big Endian
+            valueText = QString::number(uqword_values[1]) + ' ' + QString::number(uqword_values[0]);
+    }
+    break;
+    }
+    return valueText;
+}
+
+QString composeRegTextYMM(const char* value, int mode)
+{
+    bool bFpuRegistersLittleEndian = ConfigBool("Gui", "FpuRegistersLittleEndian");
+    if(ConfigUint("Gui", "SIMDRegistersDisplayMode") == 0)
+        return fillValue(value, 32, bFpuRegistersLittleEndian);
+    else if(bFpuRegistersLittleEndian)
+        return composeRegTextXMM(value, mode) + ' ' + composeRegTextXMM(value + 16, mode);
+    else
+        return composeRegTextXMM(value + 16, mode) + ' ' + composeRegTextXMM(value, mode);
+}
+
 QString GetDataTypeString(const void* buffer, duint size, ENCODETYPE type)
 {
     switch(type)
@@ -59,9 +199,11 @@ QString GetDataTypeString(const void* buffer, duint size, ENCODETYPE type)
     case enc_oword:
         return QString(ByteReverse(QByteArray((const char*)buffer, 16)).toHex());
     case enc_mmword:
-    case enc_xmmword:
-    case enc_ymmword:
         return QString(QByteArray((const char*)buffer, size).toHex());
+    case enc_xmmword:
+        return composeRegTextXMM((const char*)buffer, ConfigUint("Gui", "SIMDRegistersDisplayMode"));
+    case enc_ymmword:
+        return composeRegTextYMM((const char*)buffer, ConfigUint("Gui", "SIMDRegistersDisplayMode"));
     case enc_real4:
         return ToFloatString(buffer);
     case enc_real8:

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -172,7 +172,7 @@ QString composeRegTextXMM(const char* value, int mode)
 QString composeRegTextYMM(const char* value, int mode)
 {
     bool bFpuRegistersLittleEndian = ConfigBool("Gui", "FpuRegistersLittleEndian");
-    if(ConfigUint("Gui", "SIMDRegistersDisplayMode") == 0)
+    if(mode == 0)
         return fillValue(value, 32, bFpuRegistersLittleEndian);
     else if(bFpuRegistersLittleEndian)
         return composeRegTextXMM(value, mode) + ' ' + composeRegTextXMM(value + 16, mode);

--- a/src/gui/Src/Utils/StringUtil.h
+++ b/src/gui/Src/Utils/StringUtil.h
@@ -100,6 +100,10 @@ QString ToLongDoubleString(const void* buffer);
 
 QString ToDateString(const QDate & date);
 
+QString fillValue(const char* value, int valsize = 2, bool bFpuRegistersLittleEndian = false);
+QString composeRegTextXMM(const char* value, int mode);
+QString composeRegTextYMM(const char* value, int mode);
+
 QString GetDataTypeString(const void* buffer, duint size, ENCODETYPE type);
 
 inline QDate GetCompileDate()

--- a/src/zydis_wrapper/zydis_wrapper.cpp
+++ b/src/zydis_wrapper/zydis_wrapper.cpp
@@ -695,6 +695,8 @@ Zydis::VectorElementType Zydis::getVectorElementType(int opindex) const
 {
     if(!Success())
         return Zydis::VETDefault;
+    if(opindex >= mInstr.operandCount)
+        return Zydis::VETDefault;
     const auto & op = mInstr.operands[opindex];
     switch(op.elementType)
     {

--- a/src/zydis_wrapper/zydis_wrapper.cpp
+++ b/src/zydis_wrapper/zydis_wrapper.cpp
@@ -691,6 +691,22 @@ size_t Zydis::ResolveOpValue(int opindex, const std::function<size_t(ZydisRegist
     return dest;
 }
 
+Zydis::VectorElementType Zydis::getVectorElementType(int opindex) const
+{
+    if(!Success())
+        return Zydis::VETDefault;
+    const auto & op = mInstr.operands[opindex];
+    switch(op.elementType)
+    {
+    case ZYDIS_ELEMENT_TYPE_FLOAT32:
+        return Zydis::VETFloat32;
+    case ZYDIS_ELEMENT_TYPE_FLOAT64:
+        return Zydis::VETFloat64;
+    default:
+        return Zydis::VETDefault;
+    }
+}
+
 bool Zydis::IsBranchGoingToExecute(size_t cflags, size_t ccx) const
 {
     if(!Success())

--- a/src/zydis_wrapper/zydis_wrapper.h
+++ b/src/zydis_wrapper/zydis_wrapper.h
@@ -91,7 +91,7 @@ public:
 
     bool IsBranchType(std::underlying_type_t<BranchType> bt) const;
 
-    enum VectorElementType
+    enum VectorElementType : uint8_t
     {
         VETDefault,
         VETFloat32,

--- a/src/zydis_wrapper/zydis_wrapper.h
+++ b/src/zydis_wrapper/zydis_wrapper.h
@@ -91,6 +91,16 @@ public:
 
     bool IsBranchType(std::underlying_type_t<BranchType> bt) const;
 
+    enum VectorElementType
+    {
+        VETDefault,
+        VETFloat32,
+        VETFloat64,
+        VETInt32,
+        VETInt64
+    };
+    VectorElementType getVectorElementType(int opindex) const;
+
     // Shortcuts.
     bool IsRet() const { return IsBranchType(BTRet); }
     bool IsCall() const { return IsBranchType(BTCall); }


### PR DESCRIPTION
Support viewing XMM/YMM registers in infobox and XMM data in disassembly
The user now has to select to display ST(X), x87rX or MMX.
![screenshot](https://user-images.githubusercontent.com/15761310/82819266-a42ac600-9e8f-11ea-82e8-1a76e4834e62.png)
