### PR TITLE
GUI: Sanitizing input expression before assemble.

### DIFF
--- a/src/gui/Src/Gui/AssembleDialog.cpp
+++ b/src/gui/Src/Gui/AssembleDialog.cpp
@@ -79,7 +79,10 @@ void AssembleDialog::setOkButtonEnabled(bool enabled)
 
 void AssembleDialog::validateInstruction(QString expression)
 {
-    if(!ui->lineEdit->text().length())
+    //sanitize the expression (just simplifying it by removing excess whitespaces)
+    expression = expression.simplified();
+
+    if(!expression.length())
     {
         emit mValidateThread->emitInstructionChanged(0, tr("empty instruction"));
         return;
@@ -97,7 +100,7 @@ void AssembleDialog::validateInstruction(QString expression)
     selectedInstructionSize = basicInstrInfo.size;
 
     // Get typed in instruction size
-    if(!DbgFunctions()->Assemble(mSelectedInstrVa, NULL, &typedInstructionSize, ui->lineEdit->text().toUtf8().constData(), error.data())  || selectedInstructionSize == 0)
+    if(!DbgFunctions()->Assemble(mSelectedInstrVa, NULL, &typedInstructionSize, expression.toUtf8().constData(), error.data())  || selectedInstructionSize == 0)
     {
         emit mValidateThread->emitInstructionChanged(0, QString(error));
         return;

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -934,18 +934,21 @@ void CPUDisassembly::assembleSlot()
             if(exec != QDialog::Accepted)
                 return;
 
+            //sanitize the expression (just simplifying it by removing excess whitespaces)
+            auto expression = assembleDialog.editText.simplified();
+
             //if the instruction its unknown or is the old instruction or empty (easy way to skip from GUI) skipping
-            if(assembleDialog.editText == QString("???") || assembleDialog.editText.toLower() == instr.instStr.toLower() || assembleDialog.editText == QString(""))
+            if(expression == QString("???") || expression.toLower() == instr.instStr.toLower() || expression == QString(""))
                 break;
 
-            if(!DbgFunctions()->AssembleAtEx(wVA, assembleDialog.editText.toUtf8().constData(), error, assembleDialog.bFillWithNopsChecked))
+            if(!DbgFunctions()->AssembleAtEx(wVA, expression.toUtf8().constData(), error, assembleDialog.bFillWithNopsChecked))
             {
-                QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Failed to assemble instruction \" %1 \" (%2)").arg(assembleDialog.editText).arg(error));
+                QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Failed to assemble instruction \" %1 \" (%2)").arg(expression).arg(error));
                 msg.setWindowIcon(DIcon("compile-error.png"));
                 msg.setParent(this, Qt::Dialog);
                 msg.setWindowFlags(msg.windowFlags() & (~Qt::WindowContextHelpButtonHint));
                 msg.exec();
-                actual_inst = assembleDialog.editText;
+                actual_inst = expression;
                 assembly_error = true;
             }
         }


### PR DESCRIPTION
BUG: When assembling an instruction, if we copy and paste an instruction from somewhere with whitspaces [ \r\n] it results in invalid parsing in asmjit engine selected and throws an error as "Error writing to memory".

SCENARIO: Copy and pacste an instruction from a text editor with a newline prefix to the assemble dialog and try to assemble.
If there is newline in the prefix the validation don't even care about the expression after the newline prefix.