### PR TITLE
DBG: Fixed variables entries contains invalid garbage names.

### DIFF
--- a/src/dbg/variable.cpp
+++ b/src/dbg/variable.cpp
@@ -386,10 +386,9 @@ bool varenum(VAR* List, size_t* Size)
     }
 
     // Fill out all list entries
-    for(auto & itr : variables)
+    for(const auto &entryIter : variables)
     {
-        *List = itr.second;
-        List++;
+        *(List++) = VAR(entryIter.second);
     }
 
     return true;


### PR DESCRIPTION
[FutureProofFix]: Force copy of variables from the variables list. Sometimes auto copy used in the for loop results in reference to the local stack (i guess and there may be some more like this, noticeable in latest compiler builds). Occured in build, compiled with msvc 19.16 (VS2017) not the official (VS2013) builds.

![{D3A54040-4BE4-42E7-8D9B-69E4AFE41627}](https://user-images.githubusercontent.com/60508489/84648197-4afc0280-af22-11ea-9664-600ff375bc1d.png)