### PR TITLE
Programatic way to show "References" tab

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1737,6 +1737,11 @@ BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList)
     _gui_sendmessage(GUI_GET_CURRENT_GRAPH, graphList, nullptr);
 }
 
+BRIDGE_IMPEXP void GuiShowReferences()
+{
+    _gui_sendmessage(GUI_SHOW_REF, 0, 0);
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInst = hinstDLL;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1181,6 +1181,7 @@ typedef enum
     GUI_UPDATE_TRACE_BROWSER,       // param1=unused,               param2=unused
     GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
     GUI_GET_CURRENT_GRAPH,          // param1=BridgeCFGraphList*,   param2=unused
+    GUI_SHOW_REF,                   // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1361,6 +1362,7 @@ BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);
 BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
 BRIDGE_IMPEXP void GuiExecuteOnGuiThreadEx(GUICALLBACKEX cbGuiThread, void* userdata);
 BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList);
+BRIDGE_IMPEXP void GuiShowReferences();
 
 #ifdef __cplusplus
 }

--- a/src/dbg/commands/cmd-gui.cpp
+++ b/src/dbg/commands/cmd-gui.cpp
@@ -297,3 +297,9 @@ bool cbDebugUpdateTitle(int argc, char* argv[])
     DebugUpdateTitleAsync(addr, false);
     return true;
 }
+
+bool cbShowReferences(int argc, char* argv[])
+{
+    GuiShowReferences();
+    return true;
+}

--- a/src/dbg/commands/cmd-gui.h
+++ b/src/dbg/commands/cmd-gui.h
@@ -20,3 +20,4 @@ bool cbInstrAddFavCmd(int argc, char* argv[]);
 bool cbInstrSetFavToolShortcut(int argc, char* argv[]);
 bool cbInstrFoldDisassembly(int argc, char* argv[]);
 bool cbDebugUpdateTitle(int argc, char* argv[]);
+bool cbShowReferences(int argc, char* argv[]);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -403,6 +403,7 @@ static void registercommands()
     dbgcmdnew("AddFavouriteToolShortcut,SetFavouriteToolShortcut", cbInstrSetFavToolShortcut, false); //set favourite tool shortcut
     dbgcmdnew("FoldDisassembly", cbInstrFoldDisassembly, true); //fold disassembly segment
     dbgcmdnew("guiupdatetitle", cbDebugUpdateTitle, true); // set relevant disassembly title
+    dbgcmdnew("showref", cbShowReferences, false); // show references window
 
     //misc
     dbgcmdnew("chd", cbInstrChd, false); //Change directory

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -875,6 +875,10 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         result.Wait();
     }
     break;
+
+    case GUI_SHOW_REF:
+        emit showReferences();
+        break;
     }
 
     return nullptr;

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -162,6 +162,7 @@ signals:
     void updateTraceBrowser();
     void symbolSelectModule(duint base);
     void getCurrentGraph(BridgeCFGraphList* graphList);
+    void showReferences();
 
 private:
     CRITICAL_SECTION csBridge;

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -84,6 +84,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(Bridge::getBridge(), SIGNAL(setNameMenuEntry(int, QString)), this, SLOT(setNameMenuEntry(int, QString)));
     connect(Bridge::getBridge(), SIGNAL(setNameMenu(int, QString)), this, SLOT(setNameMenu(int, QString)));
     connect(Bridge::getBridge(), SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
+    connect(Bridge::getBridge(), SIGNAL(showReferences()), this, SLOT(displayReferencesWidget()));
     connect(Bridge::getBridge(), SIGNAL(addQWidgetTab(QWidget*)), this, SLOT(addQWidgetTab(QWidget*)));
     connect(Bridge::getBridge(), SIGNAL(showQWidgetTab(QWidget*)), this, SLOT(showQWidgetTab(QWidget*)));
     connect(Bridge::getBridge(), SIGNAL(closeQWidgetTab(QWidget*)), this, SLOT(closeQWidgetTab(QWidget*)));


### PR DESCRIPTION
These changes allow to show the "References" tab either via plugin or using new command `showref`