### PR TITLE
fix "Trace already active" after "ticnd ())"

### DIFF
--- a/src/dbg/debugger_tracing.h
+++ b/src/dbg/debugger_tracing.h
@@ -45,7 +45,13 @@ struct TraceState
     {
         delete traceCondition;
         traceCondition = new TraceCondition(expression, maxSteps);
-        return traceCondition->condition.IsValidExpression();
+        bool temp = traceCondition->condition.IsValidExpression();
+        if(!temp)
+        {
+            delete traceCondition;
+            traceCondition = nullptr;
+        }
+        return temp;
     }
 
     bool InitLogFile()

--- a/src/dbg/expressionparser.cpp
+++ b/src/dbg/expressionparser.cpp
@@ -191,6 +191,8 @@ void ExpressionParser::tokenize()
         {
             if(stateMemory)
                 stateMemory--;
+            else
+                mIsValidExpression = false;
             mCurToken.push_back(ch);
         }
         break;


### PR DESCRIPTION
fix "Trace already active" when start tracing after "ticnd ())"
"ticnd []]" is now invalid