### PR TITLE
Flashing background instead of border when following reference in dump

### DIFF
--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -13,6 +13,7 @@
 #include "WordEditDialog.h"
 #include "CodepageSelectionDialog.h"
 #include "MiscUtil.h"
+#include "BackgroundFlickerThread.h"
 
 CPUDump::CPUDump(CPUDisassembly* disas, CPUMultiDump* multiDump, QWidget* parent) : HexDump(parent)
 {
@@ -282,6 +283,12 @@ void CPUDump::setupContextMenu()
 
     mMenuBuilder->loadFromConfig();
     updateShortcuts();
+}
+
+void CPUDump::getAttention()
+{
+    BackgroundFlickerThread* thread = new BackgroundFlickerThread(this, mBackgroundColor, this);
+    thread->start();
 }
 
 void CPUDump::getColumnRichText(int col, dsint rva, RichTextPainter::List & richText)

--- a/src/gui/Src/Gui/CPUDump.h
+++ b/src/gui/Src/Gui/CPUDump.h
@@ -16,6 +16,7 @@ public:
     void getColumnRichText(int col, dsint rva, RichTextPainter::List & richText) override;
     QString paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h);
     void setupContextMenu();
+    void getAttention();
     void contextMenuEvent(QContextMenuEvent* event);
     void mouseDoubleClickEvent(QMouseEvent* event);
     void mouseMoveEvent(QMouseEvent* event);

--- a/src/gui/Src/Gui/CPUMultiDump.cpp
+++ b/src/gui/Src/Gui/CPUMultiDump.cpp
@@ -7,7 +7,6 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QTabBar>
-#include "FlickerThread.h"
 
 CPUMultiDump::CPUMultiDump(CPUDisassembly* disas, int nbCpuDumpTabs, QWidget* parent)
     : MHTabWidget(parent, true)
@@ -226,8 +225,5 @@ void CPUMultiDump::focusCurrentDumpSlot()
 
 void CPUMultiDump::getDumpAttention()
 {
-    FlickerThread* thread = new FlickerThread(mCurrentCPUDump, this);
-    thread->setProperties(3, 1);
-    connect(thread, SIGNAL(setStyleSheet(QString)), mCurrentCPUDump, SLOT(setStyleSheet(QString)));
-    thread->start();
+    mCurrentCPUDump->getAttention();
 }

--- a/src/gui/Src/Utils/BackgroundFlickerThread.cpp
+++ b/src/gui/Src/Utils/BackgroundFlickerThread.cpp
@@ -1,7 +1,7 @@
 #include "BackgroundFlickerThread.h"
 #include <Windows.h>
 
-BackgroundFlickerThread::BackgroundFlickerThread(QWidget* widget, QColor& background, QObject* parent) : QThread(parent), background(background)
+BackgroundFlickerThread::BackgroundFlickerThread(QWidget* widget, QColor & background, QObject* parent) : QThread(parent), background(background)
 {
     mWidget = widget;
     setProperties();

--- a/src/gui/Src/Utils/BackgroundFlickerThread.cpp
+++ b/src/gui/Src/Utils/BackgroundFlickerThread.cpp
@@ -1,0 +1,29 @@
+#include "BackgroundFlickerThread.h"
+#include <Windows.h>
+
+BackgroundFlickerThread::BackgroundFlickerThread(QWidget* widget, QColor& background, QObject* parent) : QThread(parent), background(background)
+{
+    mWidget = widget;
+    setProperties();
+}
+
+void BackgroundFlickerThread::setProperties(int count, int delay)
+{
+    this->count = count;
+    this->delay = delay;
+}
+
+void BackgroundFlickerThread::run()
+{
+    QColor oldColor = background;
+    for(int i = 0; i < count; i++)
+    {
+        background = QColor(Qt::red);
+        mWidget->update();
+        Sleep(delay);
+
+        background = oldColor;
+        mWidget->update();
+        Sleep(delay);
+    }
+}

--- a/src/gui/Src/Utils/BackgroundFlickerThread.h
+++ b/src/gui/Src/Utils/BackgroundFlickerThread.h
@@ -9,13 +9,13 @@ class BackgroundFlickerThread : public QThread
 {
     Q_OBJECT
 public:
-    explicit BackgroundFlickerThread(QWidget* widget, QColor& background, QObject* parent = 0);
+    explicit BackgroundFlickerThread(QWidget* widget, QColor & background, QObject* parent = 0);
     void setProperties(int count = 3, int delay = 300);
 
 private:
     void run();
     QWidget* mWidget;
-    QColor& background;
+    QColor & background;
     int count;
     int delay;
 };

--- a/src/gui/Src/Utils/BackgroundFlickerThread.h
+++ b/src/gui/Src/Utils/BackgroundFlickerThread.h
@@ -1,0 +1,23 @@
+#ifndef BACKGROUNDFLICKERTHREAD_H
+#define BACKGROUNDFLICKERTHREAD_H
+
+#include <QThread>
+#include <QWidget>
+#include <QColor>
+
+class BackgroundFlickerThread : public QThread
+{
+    Q_OBJECT
+public:
+    explicit BackgroundFlickerThread(QWidget* widget, QColor& background, QObject* parent = 0);
+    void setProperties(int count = 3, int delay = 300);
+
+private:
+    void run();
+    QWidget* mWidget;
+    QColor& background;
+    int count;
+    int delay;
+};
+
+#endif // BACKGROUNDFLICKERTHREAD_H

--- a/src/gui/x64dbg.pro
+++ b/src/gui/x64dbg.pro
@@ -183,7 +183,8 @@ SOURCES += \
     Src/BasicView/AbstractStdTable.cpp \
     Src/Gui/ZehSymbolTable.cpp \
     Src/BasicView/StdSearchListView.cpp \
-    Src/BasicView/StdTableSearchList.cpp
+    Src/BasicView/StdTableSearchList.cpp \
+    Src/Utils/BackgroundFlickerThread.cpp
 
 
 HEADERS += \
@@ -305,7 +306,8 @@ HEADERS += \
     Src/BasicView/StdSearchListView.h \
     Src/Gui/FileLines.h \
     Src/BasicView/StdTableSearchList.h \
-    Src/Utils/MethodInvoker.h
+    Src/Utils/MethodInvoker.h \
+    Src/Utils/BackgroundFlickerThread.h
     
 
 FORMS += \


### PR DESCRIPTION
This pull request implements idea covered in #1794 issue. Now it is easier (at least in my opinion) to focus on the dump widget, instead of the disassembly widget which doesn't change when following some addresses

![2020-07-01_21-45-50](https://user-images.githubusercontent.com/11231925/86946506-c0867780-c14a-11ea-88ec-6dccff0ac24b.gif)
