### PR TITLE
Follow source operand

### DIFF
--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -906,7 +906,7 @@ void Disassembly::keyPressEvent(QKeyEvent* event)
         // Follow memory operand in dump
         DISASM_INSTR instr;
         DbgDisasmAt(rvaToVa(getInitialSelection()), &instr);
-        for(int op = 0; op < instr.argcount; op++)
+        for(int op = instr.argcount - 1; op >= 0; op--)
         {
             if(instr.arg[op].type == arg_memory)
             {
@@ -922,7 +922,7 @@ void Disassembly::keyPressEvent(QKeyEvent* event)
             }
         }
         // Follow constant in dump
-        for(int op = 0; op < instr.argcount; op++)
+        for(int op = instr.argcount - 1; op >= 0; op--)
         {
             if(instr.arg[op].type == arg_normal)
             {


### PR DESCRIPTION
When I used x64dbg I found this incorrect, it should follow source operand. Most often destination operand doesn't have anything meaningful.