### PR TITLE
Updated string searching algorithm to support string in any language

### DIFF
--- a/src/dbg/disasm_helper.cpp
+++ b/src/dbg/disasm_helper.cpp
@@ -280,10 +280,36 @@ void disasmget(duint addr, DISASM_INSTR* instr, bool getregs)
         memset(instr, 0, sizeof(DISASM_INSTR)); // Buffer overflow
 }
 
+bool isunicodestring(const WString & data)
+{
+    if(data.size() < 2)
+        return false;
+    for(auto & i : data)
+    {
+        // No specials
+        if(i >= 0xFFF0)
+            return false;
+        // No ANSI control chars
+        if(i < 0x80 && !isprint(i) && !isspace(i))
+            return false;
+        // No C1 control chars
+        if(i >= 0x80 && i < 0xA0)
+            return false;
+        // No 0xFF char
+        if(i == 0xFF)
+            return false;
+        // No surrogates and private use chars
+        if(i >= 0xD800 && i <= 0xF8FF)
+            return false;
+    }
+    return true;
+}
+
+// These functions are exported so that plugins can use this to detect a string, or replace with a plugin-developed string dection algorithm through hooking
 extern "C" __declspec(dllexport) bool isasciistring(const unsigned char* data, int maxlen)
 {
     int len = 0;
-    for(char* p = (char*)data; *p; len++, p++)
+    for(const char* p = (const char*)data; *p; len++, p++)
     {
         if(len >= maxlen)
             break;
@@ -291,16 +317,29 @@ extern "C" __declspec(dllexport) bool isasciistring(const unsigned char* data, i
 
     if(len < 2 || len + 1 >= maxlen)
         return false;
-    for(int i = 0; i < len; i++)
-        if(!isprint(data[i]) && !isspace(data[i]))
-            return false;
+
+    String data2;
+    WString wdata2;
+    // Convert to and from Unicode
+    wdata2 = StringUtils::LocalCpToUtf16((const char*)data);
+    if(wdata2.size() < 2)
+        return false;
+    data2 = StringUtils::Utf16ToLocalCp(wdata2);
+    if(data2.size() > maxlen || data2.size() < 2)
+        return false;
+    // Is the data exactly representable in both ANSI and Unicode?
+    if(memcmp(data2.c_str(), data, data2.size()) != 0)
+        return false;
+    // Filter out bad chars
+    if(!isunicodestring(wdata2))
+        return false;
     return true;
 }
 
 extern "C" __declspec(dllexport) bool isunicodestring(const unsigned char* data, int maxlen)
 {
     int len = 0;
-    for(wchar_t* p = (wchar_t*)data; *p; len++, p++)
+    for(const wchar_t* p = (const wchar_t*)data; *p; len++, p++)
     {
         if(len >= maxlen)
             break;
@@ -309,32 +348,38 @@ extern "C" __declspec(dllexport) bool isunicodestring(const unsigned char* data,
     if(len < 2 || len + 1 >= maxlen)
         return false;
 
-    for(int i = 0; i < len * 2; i += 2)
-    {
-        if(data[i + 1]) //Extended ASCII only
-            return false;
-        if(!isprint(data[i]) && !isspace(data[i]))
-            return false;
-    }
+    String data2;
+    WString wdata2;
+    // Convert to and from ANSI
+    data2 = StringUtils::Utf16ToLocalCp((const wchar_t*)data);
+    if(data2.size() > maxlen || data2.size() < 2)
+        return false;
+    wdata2 = StringUtils::LocalCpToUtf16(data2);
+    if(wdata2.size() > maxlen || wdata2.size() < 2)
+        return false;
+    // Is the data exactly representable in both ANSI and Unicode?
+    if(memcmp(wdata2.c_str(), data, wdata2.size() * sizeof(wchar_t)) != 0)
+        return false;
+    // Filter out bad chars
+    if(!isunicodestring(wdata2))
+        return false;
     return true;
 }
 
 bool disasmispossiblestring(duint addr, STRING_TYPE* type)
 {
-    unsigned char data[11];
+    unsigned char data[60];
     memset(data, 0, sizeof(data));
     duint bytesRead = 0;
     if(!MemReadUnsafe(addr, data, sizeof(data) - 3, &bytesRead) && bytesRead < 2)
         return false;
-    duint test = 0;
-    memcpy(&test, data, sizeof(duint));
     if(isasciistring(data, sizeof(data)))
     {
         if(type)
             *type = str_ascii;
         return true;
     }
-    if(isunicodestring(data, _countof(data)))
+    if(isunicodestring(data, sizeof(data) / 2))
     {
         if(type)
             *type = str_unicode;
@@ -362,6 +407,10 @@ bool disasmgetstringat(duint addr, STRING_TYPE* type, char* ascii, char* unicode
     {
         if(type)
             *type = str_ascii;
+
+        // Convert ANSI string to UTF-8
+        std::string asciiData2 = StringUtils::LocalCpToUtf8((const char*)data());
+        memcpy(asciiData, asciiData2.c_str(), min((size_t(maxlen) + 1) * 2, asciiData2.size() + 1));
 
         // Escape the string
         String escaped = StringUtils::Escape(asciiData);

--- a/src/dbg/stringutils.cpp
+++ b/src/dbg/stringutils.cpp
@@ -377,6 +377,21 @@ WString StringUtils::LocalCpToUtf16(const char* str)
     return convertedString;
 }
 
+String StringUtils::Utf16ToLocalCp(const WString & str)
+{
+    String convertedString;
+    if(str.size() == 0)
+        return convertedString;
+    int requiredSize = WideCharToMultiByte(CP_ACP, 0, str.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if(requiredSize > 0)
+    {
+        convertedString.resize(requiredSize - 1);
+        if(!WideCharToMultiByte(CP_ACP, 0, str.c_str(), -1, (char*)convertedString.c_str(), requiredSize, nullptr, nullptr))
+            convertedString.clear();
+    }
+    return convertedString;
+}
+
 //Taken from: https://stackoverflow.com/a/24315631
 void StringUtils::ReplaceAll(String & s, const String & from, const String & to)
 {

--- a/src/dbg/stringutils.h
+++ b/src/dbg/stringutils.h
@@ -25,6 +25,7 @@ public:
     static String PadLeft(const String & s, size_t minLength, char ch);
     static String Utf16ToUtf8(const WString & wstr);
     static String Utf16ToUtf8(const wchar_t* wstr);
+    static String Utf16ToLocalCp(const WString & wstr);
     static WString Utf8ToUtf16(const String & str);
     static WString Utf8ToUtf16(const char* str);
     static String LocalCpToUtf8(const String & str);


### PR DESCRIPTION
String searching is always a headache for most x64dbg users. Most users need to find a plugin or special version for their language, and almost none of them are free and open source. I try to fix that by improving the algorithm to work with all people at the cost of some more useless strings being found, which is acceptable for me.
The algorithm used here is very simple: it converts to and from Unicode, and checks whether the original string is recovered after round-trip conversion without errors. It works for me, and users in other languages are encouraged to test it.