### PR TITLE
Fixed compilation error for VS2015

### DIFF
--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -112,7 +112,7 @@ void TraceWidget::updateInfobox(unsigned long long selection, TraceFileReader* t
     mInfo->setCellContent(1, 0, QString());
     mInfo->setCellContent(2, 0, QString());
     mInfo->setCellContent(3, 0, QString());
-    auto resolveRegValue = [registers](ZydisRegister regname)
+    auto resolveRegValue = [&registers](ZydisRegister regname)
     {
         switch(regname)
         {


### PR DESCRIPTION
After the recent addition of TraceWidget.cpp the project doesn't compile using VS2015 compiler with following error:

```functional:497: error: C2719: '_Func': formal parameter with requested alignment of 16 won't be aligned```

`x64dbg\src\gui\Src\Tracer\TraceWidget.cpp:268: see reference to function template instantiation "std::function<size_t (ZydisRegister)>::function<TraceWidget::updateInfobox::<lambda_15bf0c2c58dce742746d406f455e8824>,unsigned long,void>(_Fx)" being compiled
with
[
    _Fx=TraceWidget::updateInfobox::<lambda_15bf0c2c58dce742746d406f455e8824>
]
`

I know that the main target for the project is VS2013, however I think the commit doesn't change anything in the program behavior and now it builds using VS2015 without errors.