### PR TITLE
Fixed some bugs with Alt+G and Alt+T

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -40,7 +40,6 @@ CPUDisassembly::CPUDisassembly(QWidget* parent, bool isMain) : Disassembly(paren
         connect(Bridge::getBridge(), SIGNAL(selectionDisasmGet(SELECTIONDATA*)), this, SLOT(selectionGetSlot(SELECTIONDATA*)));
         connect(Bridge::getBridge(), SIGNAL(selectionDisasmSet(const SELECTIONDATA*)), this, SLOT(selectionSetSlot(const SELECTIONDATA*)));
         connect(Bridge::getBridge(), SIGNAL(displayWarning(QString, QString)), this, SLOT(displayWarningSlot(QString, QString)));
-        connect(Bridge::getBridge(), SIGNAL(focusDisasm()), this, SLOT(setFocus()));
     }
 
     // Connect some internal signals
@@ -1989,7 +1988,7 @@ void CPUDisassembly::setEncodeTypeSlot()
 void CPUDisassembly::graphSlot()
 {
     if(DbgCmdExecDirect(QString("graph %1").arg(ToPtrString(rvaToVa(getSelectionStart()))).toUtf8().constData()))
-        emit displayGraphWidget();
+        GuiFocusView(GUI_GRAPH);
 }
 
 void CPUDisassembly::analyzeModuleSlot()

--- a/src/gui/Src/Gui/CPUDisassembly.h
+++ b/src/gui/Src/Gui/CPUDisassembly.h
@@ -34,7 +34,6 @@ signals:
     void displaySourceManagerWidget();
     void showPatches();
     void displayLogWidget();
-    void displayGraphWidget();
     void displaySymbolsWidget();
 
 public slots:

--- a/src/gui/Src/Gui/CPUWidget.cpp
+++ b/src/gui/Src/Gui/CPUWidget.cpp
@@ -34,6 +34,8 @@ CPUWidget::CPUWidget(QWidget* parent) : QWidget(parent), ui(new Ui::CPUWidget)
     connect(Bridge::getBridge(), SIGNAL(dbgStateChanged(DBGSTATE)), mSideBar, SLOT(debugStateChangedSlot(DBGSTATE)));
     connect(Bridge::getBridge(), SIGNAL(updateSideBar()), mSideBar, SLOT(reload()));
     connect(Bridge::getBridge(), SIGNAL(updateArgumentView()), mArgumentWidget, SLOT(refreshData()));
+    connect(Bridge::getBridge(), SIGNAL(focusDisasm()), this, SLOT(setDisasmFocus()));
+    connect(Bridge::getBridge(), SIGNAL(focusGraph()), this, SLOT(setGraphFocus()));
 
     mDisas->setCodeFoldingManager(mSideBar->getCodeFoldingManager());
 

--- a/src/gui/Src/Gui/CPUWidget.h
+++ b/src/gui/Src/Gui/CPUWidget.h
@@ -30,8 +30,6 @@ public:
 
     // Misc
     void setDefaultDisposition();
-    void setDisasmFocus();
-    void setGraphFocus();
 
     void saveWindowSettings();
     void loadWindowSettings();
@@ -44,6 +42,10 @@ public:
     CPUMultiDump* getDumpWidget();
     CPUStack* getStackWidget();
     CPUInfoBox* getInfoBoxWidget();
+
+public slots:
+    void setDisasmFocus();
+    void setGraphFocus();
 
 protected:
     CPUSideBar* mSideBar;

--- a/src/gui/Src/Gui/DisassemblerGraphView.cpp
+++ b/src/gui/Src/Gui/DisassemblerGraphView.cpp
@@ -74,7 +74,6 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget* parent)
     connect(Bridge::getBridge(), SIGNAL(updateGraph()), this, SLOT(updateGraphSlot()));
     connect(Bridge::getBridge(), SIGNAL(selectionGraphGet(SELECTIONDATA*)), this, SLOT(selectionGetSlot(SELECTIONDATA*)));
     connect(Bridge::getBridge(), SIGNAL(disassembleAt(dsint, dsint)), this, SLOT(disassembleAtSlot(dsint, dsint)));
-    connect(Bridge::getBridge(), SIGNAL(focusGraph()), this, SLOT(setFocus()));
     connect(Bridge::getBridge(), SIGNAL(getCurrentGraph(BridgeCFGraphList*)), this, SLOT(getCurrentGraphSlot(BridgeCFGraphList*)));
     connect(Bridge::getBridge(), SIGNAL(dbgStateChanged(DBGSTATE)), this, SLOT(dbgStateChangedSlot(DBGSTATE)));
 
@@ -1129,6 +1128,9 @@ void DisassemblerGraphView::mouseMoveEvent(QMouseEvent* event)
 
 void DisassemblerGraphView::mouseReleaseEvent(QMouseEvent* event)
 {
+    // Bring the user back to disassembly if the user is stuck in an empty graph view (Alt+G)
+    if((!this->ready || !DbgIsDebugging()) && event->button() == Qt::LeftButton)
+        GuiFocusView(GUI_DISASSEMBLY);
     this->viewport()->update();
 
     if(event->button() == Qt::ForwardButton)

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -333,7 +333,6 @@ MainWindow::MainWindow(QWidget* parent)
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displayReferencesWidget()), this, SLOT(displayReferencesWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displaySourceManagerWidget()), this, SLOT(displaySourceViewWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displayLogWidget()), this, SLOT(displayLogWidget()));
-    connect(mCpuWidget->getDisasmWidget(), SIGNAL(displayGraphWidget()), this, SLOT(displayGraphWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displaySymbolsWidget()), this, SLOT(displaySymbolWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(showPatches()), this, SLOT(patchWindow()));
 

--- a/src/gui/Src/Gui/MainWindow.ui
+++ b/src/gui/Src/Gui/MainWindow.ui
@@ -180,7 +180,7 @@
    </widget>
    <widget class="QMenu" name="menu_Trace">
     <property name="title">
-     <string>&amp;Trace</string>
+     <string>Traci&amp;ng</string>
     </property>
     <widget class="QMenu" name="menuTrace_record">
      <property name="title">


### PR DESCRIPTION
If the user pressed Alt+G (not G), the user would be stuck in an empty graph. GuiFocusView was broken. Alt+T (#2397) is restored. I checked Ollydbg, the Alt+T hotkey opens the thread view, and the menu "&Trace" doesn't have a working hotkey. "&View", "&Windows", "&Help" don't either (Alt+V=Watches, Alt+W=Windows, Alt+H=Hardware breakpoints)