### PR TITLE
Changes connected to LOOPxx instructions

### DIFF
--- a/src/gui/Src/Disassembler/QBeaEngine.cpp
+++ b/src/gui/Src/Disassembler/QBeaEngine.cpp
@@ -207,7 +207,7 @@ Instruction_t QBeaEngine::DisassembleAt(const byte_t* data, duint size, duint or
             branchType = Instruction_t::Unconditional;
         else if(cp.IsBranchType(Zydis::BTCall))
             branchType = Instruction_t::Call;
-        else if(cp.IsBranchType(Zydis::BTCondJmp))
+        else if(cp.IsBranchType(Zydis::BTCondJmp) || cp.IsBranchType(Zydis::BTLoop))
             branchType = Instruction_t::Conditional;
     }
     else

--- a/src/zydis_wrapper/zydis_wrapper.cpp
+++ b/src/zydis_wrapper/zydis_wrapper.cpp
@@ -768,11 +768,11 @@ bool Zydis::IsBranchGoingToExecute(ZydisMnemonic id, size_t cflags, size_t ccx)
     case ZYDIS_MNEMONIC_JS: //jump short if sign
         return bSF;
     case ZYDIS_MNEMONIC_LOOP: //decrement count; jump short if ecx!=0
-        return ccx != 0;
+        return ccx != 1;
     case ZYDIS_MNEMONIC_LOOPE: //decrement count; jump short if ecx!=0 and zf=1
-        return ccx != 0 && bZF;
+        return ccx != 1 && bZF;
     case ZYDIS_MNEMONIC_LOOPNE: //decrement count; jump short if ecx!=0 and zf=0
-        return ccx != 0 && !bZF;
+        return ccx != 1 && !bZF;
     default:
         return false;
     }


### PR DESCRIPTION
Firstly, the indicators in CPUSideBar aren't shown for LOOPxx instructions.

Also, back in the days when you selected LOOPxx instruction, you could spot the hint like "Jump is taken" or "Jump is not taken" in the CPUInfoBox. I believe this was deleted by this commit https://github.com/x64dbg/x64dbg/commit/6348cb5728f53f51c96c272423153dd3476bc21e after changes in `CPUInfoBox::disasmSelectionChanged` because it is still present in my April snapshot. However, it was working incorrectly. This is, because the LOOP instruction **firstly decrements** the ECX, then checks if it's != 0. I will try to explain it using images.

ECX = 0, "Jump is not taken" in the info box
![Part1](https://i.imgur.com/B377zP8.png)

However... the jump is in fact taken, ECX = 0xFFFFFFFF
![Part2](https://i.imgur.com/tkl6qne.png)

Now when the ECX = 1, "Jump is taken" in the info box
![Part3](https://i.imgur.com/wBwgTh1.png)

However... the jump is not taken, ECX = 0
![Part4](https://i.imgur.com/jn8dxUF.png)

x64dbg needs to check whether the ECX = 1 to check if the branch is going to execute, that is because both decrementation and comparison is done inside the CPU LOOP instruction handler