### PR TITLE
Fetch mCmdHistory on an empty mCmdLineEdit and able to disable it

### DIFF
--- a/src/gui/Src/BasicView/HistoryLineEdit.cpp
+++ b/src/gui/Src/BasicView/HistoryLineEdit.cpp
@@ -46,6 +46,14 @@ void HistoryLineEdit::addLineToHistory(QString parLine)
     mCmdIndex = -1;
 }
 
+QString HistoryLineEdit::getLineFromHistory()
+{
+    if(mCmdHistory.empty())
+        return "";
+    else
+        return mCmdHistory.first();
+}
+
 QString HistoryLineEdit::addHistoryClear()
 {
     auto str = text();

--- a/src/gui/Src/BasicView/HistoryLineEdit.h
+++ b/src/gui/Src/BasicView/HistoryLineEdit.h
@@ -11,6 +11,7 @@ public:
     explicit HistoryLineEdit(QWidget* parent = 0);
     void keyPressEvent(QKeyEvent* event);
     void addLineToHistory(QString parLine);
+    QString getLineFromHistory();
     QString addHistoryClear();
     void setFocus();
     void loadSettings(QString sectionPrefix);

--- a/src/gui/Src/Gui/CommandLineEdit.cpp
+++ b/src/gui/Src/Gui/CommandLineEdit.cpp
@@ -113,10 +113,13 @@ void CommandLineEdit::execute()
     if(mCurrentScriptIndex == -1)
         return;
     GUISCRIPTEXECUTE exec = mScriptInfo[mCurrentScriptIndex].execute;
-    const QString & cmd = text();
+    QString & cmd = text();
 
     if(exec)
     {
+        if(cmd.trimmed().isEmpty())
+            cmd = getLineFromHistory();
+
         // Send this string directly to the user
         exec(cmd.toUtf8().constData());
     }

--- a/src/gui/Src/Gui/CommandLineEdit.cpp
+++ b/src/gui/Src/Gui/CommandLineEdit.cpp
@@ -113,13 +113,13 @@ void CommandLineEdit::execute()
     if(mCurrentScriptIndex == -1)
         return;
     GUISCRIPTEXECUTE exec = mScriptInfo[mCurrentScriptIndex].execute;
-    QString & cmd = text();
+    QString cmd = text();
 
     if(exec)
     {
         if(cmd.trimmed().isEmpty())
-            cmd = getLineFromHistory();
-
+            if(Config()->getBool("Gui", "AutoRepeatOnEnter"))
+                cmd = getLineFromHistory();
         // Send this string directly to the user
         exec(cmd.toUtf8().constData());
     }

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -281,6 +281,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     guiBool.insert("ShowExitConfirmation", true);
     guiBool.insert("DisableAutoComplete", false);
     guiBool.insert("CaseSensitiveAutoComplete", false);
+    guiBool.insert("AutoRepeatOnEnter", false);
     //Named menu settings
     insertMenuBuilderBools(&guiBool, "CPUDisassembly", 50); //CPUDisassembly
     insertMenuBuilderBools(&guiBool, "CPUDump", 50); //CPUDump


### PR DESCRIPTION
This improves #2184 by adding a setting to disable the behaviour