### PR TITLE
Don't override user font when using dark theme (#2422 #2426)

### DIFF
--- a/bin/themes/Dark/style.ini
+++ b/bin/themes/Dark/style.ini
@@ -233,13 +233,3 @@ ThreadCurrentBackgroundColor=#C24000
 ThreadCurrentColor=#FFFFFF
 WatchTriggeredBackgroundColor=#XXXXXX
 WatchTriggeredColor=#EF5350
-
-[Fonts]
-AbstractTableView=Lucida Console,8,-1,5,50,0,0,0,0,0
-Application=MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0
-Disassembly=Lucida Console,8,-1,5,50,0,0,0,0,0
-HexDump=Lucida Console,8,-1,5,50,0,0,0,0,0
-HexEdit=Lucida Console,8,-1,5,50,0,0,0,0,0
-Log=Courier New,8,-1,5,50,0,0,0,0,0
-Registers=Lucida Console,8,-1,5,50,0,0,0,0,0
-Stack=Lucida Console,8,-1,5,50,0,0,0,0,0

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -2267,8 +2267,8 @@ void MainWindow::on_actionDefaultTheme_triggered()
     Config()->Colors = Config()->defaultColors;
     Config()->writeColors();
     // Reset [Fonts] to default
-    Config()->Fonts = Config()->defaultFonts;
-    Config()->writeFonts();
+    //Config()->Fonts = Config()->defaultFonts;
+    //Config()->writeFonts();
     // Remove custom colors
     BridgeSettingSet("Colors", "CustomColorCount", nullptr);
 }


### PR DESCRIPTION
It doesn't need to set font when switching to dark theme, and the font used in dark theme shouldn't override the user setting.