### PR TITLE
Fixed memory leak; properly clean QThread after it finishes

### DIFF
--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -393,5 +393,6 @@ void SearchListView::searchSlot()
 {
     FlickerThread* thread = new FlickerThread(mSearchBox, this);
     connect(thread, SIGNAL(setStyleSheet(QString)), mSearchBox, SLOT(setStyleSheet(QString)));
+    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
     thread->start();
 }

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -288,6 +288,7 @@ void CPUDump::setupContextMenu()
 void CPUDump::getAttention()
 {
     BackgroundFlickerThread* thread = new BackgroundFlickerThread(this, mBackgroundColor, this);
+    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
     thread->start();
 }
 


### PR DESCRIPTION
It seems that at the moment the FlickerThread and BackgroundFlickerThread objects are never deleted (despite fact that they are allocated on the heap using "new" operator)