### PR TITLE
Fix hardware breakpoint replacement slot display

### DIFF
--- a/src/gui/Src/Gui/BreakpointMenu.cpp
+++ b/src/gui/Src/Gui/BreakpointMenu.cpp
@@ -20,10 +20,11 @@ void BreakpointMenu::build(MenuBuilder* builder)
     QAction* removeHwBreakpointAction = makeShortcutAction(DIcon("breakpoint_remove.png"), tr("Remove Hardware"), std::bind(&BreakpointMenu::toggleHwBpActionSlot, this), "ActionRemoveHwBp");
 
     QMenu* replaceSlotMenu = makeMenu(DIcon("breakpoint_execute.png"), tr("Set Hardware on Execution"));
-    QAction* replaceSlot0Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot1.png"), tr("Replace Slot 0 (Free)"), std::bind(&BreakpointMenu::setHwBpOnSlot0ActionSlot, this));
-    QAction* replaceSlot1Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot2.png"), tr("Replace Slot 1 (Free)"), std::bind(&BreakpointMenu::setHwBpOnSlot1ActionSlot, this));
-    QAction* replaceSlot2Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot3.png"), tr("Replace Slot 2 (Free)"), std::bind(&BreakpointMenu::setHwBpOnSlot2ActionSlot, this));
-    QAction* replaceSlot3Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot4.png"), tr("Replace Slot 3 (Free)"), std::bind(&BreakpointMenu::setHwBpOnSlot3ActionSlot, this));
+    // Replacement slot menu are only used when the breakpoints are full, so using "Unknown" as the placeholder. Might want to change this in case we display the menu when there are still free slots.
+    QAction* replaceSlot0Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot1.png"), tr("Replace Slot 0 (Unknown)"), std::bind(&BreakpointMenu::setHwBpOnSlot0ActionSlot, this));
+    QAction* replaceSlot1Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot2.png"), tr("Replace Slot 1 (Unknown)"), std::bind(&BreakpointMenu::setHwBpOnSlot1ActionSlot, this));
+    QAction* replaceSlot2Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot3.png"), tr("Replace Slot 2 (Unknown)"), std::bind(&BreakpointMenu::setHwBpOnSlot2ActionSlot, this));
+    QAction* replaceSlot3Action = makeMenuAction(replaceSlotMenu, DIcon("breakpoint_execute_slot4.png"), tr("Replace Slot 3 (Unknown)"), std::bind(&BreakpointMenu::setHwBpOnSlot3ActionSlot, this));
 
     builder->addMenu(makeMenu(DIcon("breakpoint.png"), tr("Breakpoint")), [ = ](QMenu * menu)
     {
@@ -60,24 +61,27 @@ void BreakpointMenu::build(MenuBuilder* builder)
             }
             else
             {
-                for(int i = 0; i < 4; i++)
+                for(int i = 0; i < bpList.count; i++)
                 {
-                    switch(bpList.bp[i].slot)
+                    if(bpList.bp[i].enabled)
                     {
-                    case 0:
-                        replaceSlot0Action->setText(tr("Replace Slot %1 (0x%2)").arg(1).arg(ToPtrString(bpList.bp[i].addr)));
-                        break;
-                    case 1:
-                        replaceSlot1Action->setText(tr("Replace Slot %1 (0x%2)").arg(2).arg(ToPtrString(bpList.bp[i].addr)));
-                        break;
-                    case 2:
-                        replaceSlot2Action->setText(tr("Replace Slot %1 (0x%2)").arg(3).arg(ToPtrString(bpList.bp[i].addr)));
-                        break;
-                    case 3:
-                        replaceSlot3Action->setText(tr("Replace Slot %1 (0x%2)").arg(4).arg(ToPtrString(bpList.bp[i].addr)));
-                        break;
-                    default:
-                        break;
+                        switch(bpList.bp[i].slot)
+                        {
+                        case 0:
+                            replaceSlot0Action->setText(tr("Replace Slot %1 (0x%2)").arg(1).arg(ToPtrString(bpList.bp[i].addr)));
+                            break;
+                        case 1:
+                            replaceSlot1Action->setText(tr("Replace Slot %1 (0x%2)").arg(2).arg(ToPtrString(bpList.bp[i].addr)));
+                            break;
+                        case 2:
+                            replaceSlot2Action->setText(tr("Replace Slot %1 (0x%2)").arg(3).arg(ToPtrString(bpList.bp[i].addr)));
+                            break;
+                        case 3:
+                            replaceSlot3Action->setText(tr("Replace Slot %1 (0x%2)").arg(4).arg(ToPtrString(bpList.bp[i].addr)));
+                            break;
+                        default:
+                            break;
+                        }
                     }
                 }
                 menu->addMenu(replaceSlotMenu);


### PR DESCRIPTION
Replacement candidates used to show "Slot X (Free)" before sometimes when there are disabled hardware breakpoints. Fix it and change the placeholder to "Unknown" since it's logically invalid to display the menu when there's a free slot.