### PR TITLE
GUI: Possibility to change watch type using GUI (context menu)

### DIFF
--- a/src/dbg/commands/cmd-watch-control.cpp
+++ b/src/dbg/commands/cmd-watch-control.cpp
@@ -87,6 +87,40 @@ bool cbSetWatchdog(int argc, char* argv[])
     return true;
 }
 
+bool cbSetWatchType(int argc, char* argv[])
+{
+    if(argc < 3)
+    {
+        dputs(QT_TRANSLATE_NOOP("DBG", "No enough arguments for SetWatchType\n"));
+        return false;
+    }
+    duint id;
+    bool ok = valfromstring(argv[1], &id);
+    if(!ok)
+    {
+        dputs(QT_TRANSLATE_NOOP("DBG", "Error expression in argument 1.\n"));
+        return false;
+    }
+    WATCHVARTYPE newtype;
+    if(_stricmp(argv[2], "uint") == 0)
+        newtype = WATCHVARTYPE::TYPE_UINT;
+    else if(_stricmp(argv[2], "int") == 0)
+        newtype = WATCHVARTYPE::TYPE_INT;
+    else if(_stricmp(argv[2], "float") == 0)
+        newtype = WATCHVARTYPE::TYPE_FLOAT;
+    else if(_stricmp(argv[2], "ascii") == 0)
+        newtype = WATCHVARTYPE::TYPE_ASCII;
+    else if(_stricmp(argv[2], "unicode") == 0)
+        newtype = WATCHVARTYPE::TYPE_UNICODE;
+    else
+    {
+        dputs(QT_TRANSLATE_NOOP("DBG", "Unknown watch type.\n"));
+        return false;
+    }
+    WatchSetType((unsigned int)id, newtype);
+    return true;
+}
+
 bool cbSetWatchExpression(int argc, char* argv[])
 {
     if(argc < 3)

--- a/src/dbg/commands/cmd-watch-control.h
+++ b/src/dbg/commands/cmd-watch-control.h
@@ -7,4 +7,5 @@ bool cbDelWatch(int argc, char* argv[]);
 bool cbSetWatchdog(int argc, char* argv[]);
 bool cbSetWatchExpression(int argc, char* argv[]);
 bool cbSetWatchName(int argc, char* argv[]);
+bool cbSetWatchType(int argc, char* argv[]);
 bool cbCheckWatchdog(int argc, char* argv[]);

--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -241,6 +241,21 @@ WATCHVARTYPE WatchGetType(unsigned int id)
         return WATCHVARTYPE::TYPE_INVALID;
 }
 
+void WatchSetTypeUnlocked(unsigned int id, WATCHVARTYPE type)
+{
+    auto obj = watchexpr.find(id);
+    if(obj != watchexpr.end())
+        obj->second->setType(type);
+}
+
+void WatchSetType(unsigned int id, WATCHVARTYPE type)
+{
+    EXCLUSIVE_ACQUIRE(LockWatch);
+    WatchSetTypeUnlocked(id, type);
+    EXCLUSIVE_RELEASE();
+    GuiUpdateWatchViewAsync();
+}
+
 unsigned int WatchGetWindow(unsigned int id)
 {
     SHARED_ACQUIRE(LockWatch);

--- a/src/dbg/watch.h
+++ b/src/dbg/watch.h
@@ -48,10 +48,14 @@ public:
     inline const String & getExpr()
     {
         return expr.GetExpression();
-    }
+    };
     inline const bool HaveCurrentValue()
     {
         return haveCurrValue;
+    };
+    inline void setType(WATCHVARTYPE type)
+    {
+        varType = type;
     };
 };
 
@@ -69,6 +73,7 @@ WATCHDOGMODE WatchGetWatchdogMode(unsigned int id);
 WATCHDOGMODE WatchGetWatchdogEnabled(unsigned int id);
 duint WatchGetUnsignedValue(unsigned int id);
 WATCHVARTYPE WatchGetType(unsigned int id);
+void WatchSetType(unsigned int id, WATCHVARTYPE type);
 std::vector<WATCHINFO> WatchGetList();
 
 void WatchCacheSave(JSON root); // Save watch data to database

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -258,7 +258,9 @@ static void registercommands()
     dbgcmdnew("SetWatchdog", cbSetWatchdog, true); // Setup watchdog
     dbgcmdnew("SetWatchExpression", cbSetWatchExpression, true); // Set watch expression
     dbgcmdnew("SetWatchName", cbSetWatchName, true); // Set watch name
+    dbgcmdnew("SetWatchType", cbSetWatchType, true); // Set watch type
     dbgcmdnew("CheckWatchdog", cbCheckWatchdog, true); // Watchdog
+
 
     //variables
     dbgcmdnew("varnew,var", cbInstrVar, false); //make a variable arg1:name,[arg2:value]

--- a/src/gui/Src/Gui/WatchView.cpp
+++ b/src/gui/Src/Gui/WatchView.cpp
@@ -161,6 +161,14 @@ void WatchView::setupContextMenu()
     watchdogBuilder->addAction(makeAction(DIcon("treat_selection_as_tbyte.png"), tr("Is true"), SLOT(watchdogIsTrueSlot()))); // TODO: better icon
     watchdogBuilder->addAction(makeAction(DIcon("treat_selection_as_fword.png"), tr("Is false"), SLOT(watchdogIsFalseSlot())));
     mMenu->addMenu(watchdogMenu, watchdogBuilder);
+    MenuBuilder* typeBuilder = new MenuBuilder(this, nonEmptyFunc);
+    QMenu* typeMenu = new QMenu(tr("Type"), this);
+    typeBuilder->addAction(makeAction(DIcon("integer.png"), tr("Uint"), SLOT(setTypeUintSlot())));
+    typeBuilder->addAction(makeAction(DIcon("integer.png"), tr("Int"), SLOT(setTypeIntSlot())));
+    typeBuilder->addAction(makeAction(DIcon("float.png"), tr("Float"), SLOT(setTypeFloatSlot())));
+    typeBuilder->addAction(makeAction(DIcon("ascii.png"), tr("Ascii"), SLOT(setTypeAsciiSlot())));
+    typeBuilder->addAction(makeAction(DIcon("ascii-extended.png"), tr("Unicode"), SLOT(setTypeUnicodeSlot())));
+    mMenu->addMenu(typeMenu, typeBuilder);
     mMenu->addSeparator();
     MenuBuilder* copyMenu = new MenuBuilder(this);
     setupCopyMenu(copyMenu);

--- a/src/gui/Src/Gui/WatchView.cpp
+++ b/src/gui/Src/Gui/WatchView.cpp
@@ -274,3 +274,33 @@ void WatchView::watchdogIsFalseSlot()
     DbgCmdExecDirect(QString("SetWatchdog %1, \"isfalse\"").arg(getSelectedId()));
     updateWatch();
 }
+
+void WatchView::setTypeUintSlot()
+{
+    DbgCmdExecDirect(QString("SetWatchType %1, \"uint\"").arg(getSelectedId()));
+    updateWatch();
+}
+
+void WatchView::setTypeIntSlot()
+{
+    DbgCmdExecDirect(QString("SetWatchType %1, \"int\"").arg(getSelectedId()));
+    updateWatch();
+}
+
+void WatchView::setTypeFloatSlot()
+{
+    DbgCmdExecDirect(QString("SetWatchType %1, \"float\"").arg(getSelectedId()));
+    updateWatch();
+}
+
+void WatchView::setTypeAsciiSlot()
+{
+    DbgCmdExecDirect(QString("SetWatchType %1, \"ascii\"").arg(getSelectedId()));
+    updateWatch();
+}
+
+void WatchView::setTypeUnicodeSlot()
+{
+    DbgCmdExecDirect(QString("SetWatchType %1, \"unicode\"").arg(getSelectedId()));
+    updateWatch();
+}

--- a/src/gui/Src/Gui/WatchView.h
+++ b/src/gui/Src/Gui/WatchView.h
@@ -26,6 +26,11 @@ public slots:
     void watchdogUnchangedSlot();
     void watchdogIsTrueSlot();
     void watchdogIsFalseSlot();
+    void setTypeUintSlot();
+    void setTypeIntSlot();
+    void setTypeFloatSlot();
+    void setTypeAsciiSlot();
+    void setTypeUnicodeSlot();
 
 protected:
     void setupContextMenu();


### PR DESCRIPTION
-Added new command `SetWatchType`, not sure if it is necessary but I think it's more clean this way
-Added possibility to change watch type from context menu (lack of possibility to change the watch type from gui was reported in #2309)

![x32dbg_2020-10-22_01-56-49](https://user-images.githubusercontent.com/11231925/96802340-f1dd3780-1409-11eb-8733-90f5ebe827bb.png)
