### PR TITLE
Improved call stack tab, displaying multiple threads 

### DIFF
--- a/src/dbg/_dbgfunctions.cpp
+++ b/src/dbg/_dbgfunctions.cpp
@@ -107,6 +107,12 @@ static void _getcallstack(DBGCALLSTACK* callstack)
         stackgetcallstack(GetContextDataEx(hActiveThread, UE_CSP), (CALLSTACK*)callstack);
 }
 
+static void _getcallstackbythread(HANDLE thread, DBGCALLSTACK* callstack)
+{
+    if(thread)
+        stackgetcallstackbythread(thread, (CALLSTACK*)callstack);
+}
+
 static void _getsehchain(DBGSEHCHAIN* sehchain)
 {
     std::vector<duint> SEHList;
@@ -532,4 +538,5 @@ void dbgfunctionsinit()
     _dbgfunctions.RefreshModuleList = _refreshmodulelist;
     _dbgfunctions.GetAddrFromLineEx = _getaddrfromlineex;
     _dbgfunctions.ModSymbolStatus = _modsymbolstatus;
+    _dbgfunctions.GetCallStackByThread = _getcallstackbythread;
 }

--- a/src/dbg/_dbgfunctions.h
+++ b/src/dbg/_dbgfunctions.h
@@ -207,6 +207,7 @@ typedef int(*SYMAUTOCOMPLETE)(const char* Search, char** Buffer, int MaxSymbols)
 typedef void(*REFRESHMODULELIST)();
 typedef duint(*GETADDRFROMLINEEX)(duint mod, const char* szSourceFile, int line);
 typedef MODULESYMBOLSTATUS(*MODSYMBOLSTATUS)(duint mod);
+typedef void(*GETCALLSTACKBYTHREAD)(HANDLE thread, DBGCALLSTACK* callstack);
 
 //The list of all the DbgFunctions() return value.
 //WARNING: This list is append only. Do not insert things in the middle or plugins would break.
@@ -285,6 +286,7 @@ typedef struct DBGFUNCTIONS_
     REFRESHMODULELIST RefreshModuleList;
     GETADDRFROMLINEEX GetAddrFromLineEx;
     MODSYMBOLSTATUS ModSymbolStatus;
+    GETCALLSTACKBYTHREAD GetCallStackByThread;
 } DBGFUNCTIONS;
 
 #ifdef BUILD_DBG

--- a/src/dbg/stackinfo.cpp
+++ b/src/dbg/stackinfo.cpp
@@ -360,6 +360,103 @@ void stackgetcallstack(duint csp, std::vector<CALLSTACKENTRY> & callstackVector,
     CallstackCache[csp] = callstackVector;
 }
 
+void stackgetcallstackbythread(HANDLE thread, CALLSTACK* callstack)
+{
+    std::vector<CALLSTACKENTRY> callstackVector;
+    duint csp = GetContextDataEx(thread, UE_CSP);
+    // Gather context data
+    CONTEXT context;
+    memset(&context, 0, sizeof(CONTEXT));
+
+    context.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+
+    if(SuspendThread(thread) == -1)
+        return;
+
+    if(!GetThreadContext(thread, &context))
+        return;
+
+    if(ResumeThread(thread) == -1)
+        return;
+
+    if(ShowSuspectedCallStack)
+    {
+        stackgetsuspectedcallstack(csp, callstackVector);
+    }
+    else
+    {
+        // Set up all frame data
+        STACKFRAME64 frame;
+        ZeroMemory(&frame, sizeof(STACKFRAME64));
+
+#ifdef _M_IX86
+        DWORD machineType = IMAGE_FILE_MACHINE_I386;
+        frame.AddrPC.Offset = context.Eip;
+        frame.AddrPC.Mode = AddrModeFlat;
+        frame.AddrFrame.Offset = context.Ebp;
+        frame.AddrFrame.Mode = AddrModeFlat;
+        frame.AddrStack.Offset = csp;
+        frame.AddrStack.Mode = AddrModeFlat;
+#elif _M_X64
+        DWORD machineType = IMAGE_FILE_MACHINE_AMD64;
+        frame.AddrPC.Offset = context.Rip;
+        frame.AddrPC.Mode = AddrModeFlat;
+        frame.AddrFrame.Offset = context.Rsp;
+        frame.AddrFrame.Mode = AddrModeFlat;
+        frame.AddrStack.Offset = csp;
+        frame.AddrStack.Mode = AddrModeFlat;
+#endif
+
+        const int MaxWalks = 50;
+        // Container for each callstack entry (50 pre-allocated entries)
+        callstackVector.clear();
+        callstackVector.reserve(MaxWalks);
+
+        for(auto i = 0; i < MaxWalks; i++)
+        {
+            if(!SafeStackWalk64(
+                        machineType,
+                        fdProcessInfo->hProcess,
+                        thread,
+                        &frame,
+                        &context,
+                        StackReadProcessMemoryProc64,
+                        StackSymFunctionTableAccess64,
+                        StackGetModuleBaseProc64,
+                        StackTranslateAddressProc64))
+            {
+                // Maybe it failed, maybe we have finished walking the stack
+                break;
+            }
+
+            if(frame.AddrPC.Offset != 0)
+            {
+                // Valid frame
+                CALLSTACKENTRY entry;
+                memset(&entry, 0, sizeof(CALLSTACKENTRY));
+
+                StackEntryFromFrame(&entry, (duint)frame.AddrFrame.Offset + sizeof(duint), (duint)frame.AddrPC.Offset, (duint)frame.AddrReturn.Offset);
+                callstackVector.push_back(entry);
+            }
+            else
+            {
+                // Base reached
+                break;
+            }
+        }
+    }
+
+    callstack->total = (int)callstackVector.size();
+
+    if(callstack->total > 0)
+    {
+        callstack->entries = (CALLSTACKENTRY*)BridgeAlloc(callstack->total * sizeof(CALLSTACKENTRY));
+
+        // Copy data directly from the vector
+        memcpy(callstack->entries, callstackVector.data(), callstack->total * sizeof(CALLSTACKENTRY));
+    }
+}
+
 void stackgetcallstack(duint csp, CALLSTACK* callstack)
 {
     std::vector<CALLSTACKENTRY> callstackVector;

--- a/src/dbg/stackinfo.cpp
+++ b/src/dbg/stackinfo.cpp
@@ -401,7 +401,7 @@ void stackgetcallstackbythread(HANDLE thread, CALLSTACK* callstack)
         DWORD machineType = IMAGE_FILE_MACHINE_AMD64;
         frame.AddrPC.Offset = context.Rip;
         frame.AddrPC.Mode = AddrModeFlat;
-        frame.AddrFrame.Offset = context.Rsp;
+        frame.AddrFrame.Offset = context.Rbp;
         frame.AddrFrame.Mode = AddrModeFlat;
         frame.AddrStack.Offset = csp;
         frame.AddrStack.Mode = AddrModeFlat;

--- a/src/dbg/stackinfo.h
+++ b/src/dbg/stackinfo.h
@@ -22,6 +22,7 @@ bool stackcommentget(duint addr, STACK_COMMENT* comment);
 void stackupdatecallstack(duint csp);
 void stackgetcallstack(duint csp, CALLSTACK* callstack);
 void stackgetcallstack(duint csp, std::vector<CALLSTACKENTRY> & callstack, bool cache);
+void stackgetcallstackbythread(HANDLE thread, CALLSTACK* callstack);
 void stackupdatesettings();
 
 #endif //_STACKINFO_H

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -5,7 +5,7 @@ CallStackView::CallStackView(StdTable* parent) : StdTable(parent)
 {
     int charwidth = getCharWidth();
 
-    addColumnAt(8 * charwidth, tr("Thread Number"), true);
+    addColumnAt(8 * charwidth, tr("Thread ID"), true);
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("Address"), true); //address in the stack
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("To"), false); //return to
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("From"), false); //return from
@@ -97,10 +97,7 @@ void CallStackView::updateCallStack()
         memset(&callstack, 0, sizeof(DBGCALLSTACK));
         DbgFunctions()->GetCallStackByThread(threadList.list[j].BasicInfo.Handle, &callstack);
         setRowCount(currentRow + callstack.total + 1);
-        if(!threadList.list[j].BasicInfo.ThreadNumber)
-            setCellContent(currentRow, ColThread, tr("Main"));
-        else
-            setCellContent(currentRow, ColThread, ToDecString(threadList.list[j].BasicInfo.ThreadNumber));
+        setCellContent(currentRow, ColThread, ToDecString(threadList.list[j].BasicInfo.ThreadId));
 
         currentRow++;
 

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -90,14 +90,22 @@ void CallStackView::updateCallStack()
     DbgGetThreadList(&threadList);
 
     int currentRow = 0;
+    int currentIndexToDraw = 0;
     setRowCount(0);
     for(int j = 0; j < threadList.count; j++)
     {
+        if(!j)
+            currentIndexToDraw = threadList.CurrentThread; // Draw the current thread first
+        else if(j == threadList.CurrentThread)
+            currentIndexToDraw = 0; // Draw the previously skipped thread
+        else
+            currentIndexToDraw = j;
+
         DBGCALLSTACK callstack;
         memset(&callstack, 0, sizeof(DBGCALLSTACK));
-        DbgFunctions()->GetCallStackByThread(threadList.list[j].BasicInfo.Handle, &callstack);
+        DbgFunctions()->GetCallStackByThread(threadList.list[currentIndexToDraw].BasicInfo.Handle, &callstack);
         setRowCount(currentRow + callstack.total + 1);
-        setCellContent(currentRow, ColThread, ToDecString(threadList.list[j].BasicInfo.ThreadId));
+        setCellContent(currentRow, ColThread, ToDecString(threadList.list[currentIndexToDraw].BasicInfo.ThreadId));
 
         currentRow++;
 

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -58,6 +58,22 @@ void CallStackView::setupContextMenu()
     mMenuBuilder->loadFromConfig();
 }
 
+QString CallStackView::paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h)
+{
+    if(isSelected(rowBase, rowOffset))
+        painter->fillRect(QRect(x, y, w, h), QBrush(mSelectionColor));
+
+    bool isSpaceRow = !getCellContent(rowBase + rowOffset, ColThread).isEmpty();
+
+    if(col > ColThread && isSpaceRow)
+    {
+        auto mid = h / 2.0;
+        painter->drawLine(QPointF(x, y + mid), QPointF(x + w, y + mid));
+    }
+
+    return getCellContent(rowBase + rowOffset, col);
+}
+
 void CallStackView::updateCallStack()
 {
     if(!DbgFunctions()->GetCallStackByThread)

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -28,11 +28,17 @@ void CallStackView::setupContextMenu()
         return DbgIsDebugging();
     });
     QIcon icon = DIcon(ArchValue("processor32.png", "processor64.png"));
-    mMenuBuilder->addAction(makeAction(icon, tr("Follow &Address"), SLOT(followAddress())));
-    mMenuBuilder->addAction(makeAction(icon, tr("Follow &To"), SLOT(followTo())));
+    mMenuBuilder->addAction(makeAction(icon, tr("Follow &Address"), SLOT(followAddress())), [this](QMenu*)
+    {
+        return isSelectionValid();
+    });
+    mMenuBuilder->addAction(makeAction(icon, tr("Follow &To"), SLOT(followTo())), [this](QMenu*)
+    {
+        return isSelectionValid();
+    });
     QAction* mFollowFrom = mMenuBuilder->addAction(makeAction(icon, tr("Follow &From"), SLOT(followFrom())), [this](QMenu*)
     {
-        return !getCellContent(getInitialSelection(), ColFrom).isEmpty();
+        return !getCellContent(getInitialSelection(), ColFrom).isEmpty() && isSelectionValid();
     });
     mFollowFrom->setShortcutContext(Qt::WidgetShortcut);
     mFollowFrom->setShortcut(QKeySequence("enter"));
@@ -175,4 +181,9 @@ void CallStackView::showSuspectedCallStack()
     DbgSettingsUpdated();
     updateCallStack();
     emit Bridge::getBridge()->updateDump();
+}
+
+bool CallStackView::isSelectionValid()
+{
+    return getCellContent(getInitialSelection(), ColThread).isEmpty();
 }

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -31,7 +31,7 @@ void CallStackView::setupContextMenu()
     mMenuBuilder->addAction(makeAction(icon, tr("Follow &To"), SLOT(followTo())));
     QAction* mFollowFrom = mMenuBuilder->addAction(makeAction(icon, tr("Follow &From"), SLOT(followFrom())), [this](QMenu*)
     {
-        return !getCellContent(getInitialSelection(), 2).isEmpty();
+        return !getCellContent(getInitialSelection(), ColFrom).isEmpty();
     });
     mFollowFrom->setShortcutContext(Qt::WidgetShortcut);
     mFollowFrom->setShortcut(QKeySequence("enter"));
@@ -68,30 +68,30 @@ void CallStackView::updateCallStack()
     for(int i = 0; i < callstack.total; i++)
     {
         QString addrText = ToPtrString(callstack.entries[i].addr);
-        setCellContent(i, 0, addrText);
+        setCellContent(i, ColAddress, addrText);
         addrText = ToPtrString(callstack.entries[i].to);
-        setCellContent(i, 1, addrText);
+        setCellContent(i, ColTo, addrText);
         if(callstack.entries[i].from)
         {
             addrText = ToPtrString(callstack.entries[i].from);
-            setCellContent(i, 2, addrText);
+            setCellContent(i, ColFrom, addrText);
         }
         if(i != callstack.total - 1)
-            setCellContent(i, 3, ToHexString(callstack.entries[i + 1].addr - callstack.entries[i].addr));
+            setCellContent(i, ColSize, ToHexString(callstack.entries[i + 1].addr - callstack.entries[i].addr));
         else
-            setCellContent(i, 3, "");
-        setCellContent(i, 4, callstack.entries[i].comment);
+            setCellContent(i, ColSize, "");
+        setCellContent(i, ColComment, callstack.entries[i].comment);
         int party = DbgFunctions()->ModGetParty(callstack.entries[i].to);
         switch(party)
         {
         case mod_user:
-            setCellContent(i, 5, tr("User"));
+            setCellContent(i, ColParty, tr("User"));
             break;
         case mod_system:
-            setCellContent(i, 5, tr("System"));
+            setCellContent(i, ColParty, tr("System"));
             break;
         default:
-            setCellContent(i, 5, QString::number(party));
+            setCellContent(i, ColParty, QString::number(party));
             break;
         }
     }
@@ -110,19 +110,19 @@ void CallStackView::contextMenuSlot(const QPoint pos)
 
 void CallStackView::followAddress()
 {
-    QString addrText = getCellContent(getInitialSelection(), 0);
+    QString addrText = getCellContent(getInitialSelection(), ColAddress);
     DbgCmdExecDirect(QString("sdump " + addrText));
 }
 
 void CallStackView::followTo()
 {
-    QString addrText = getCellContent(getInitialSelection(), 1);
+    QString addrText = getCellContent(getInitialSelection(), ColTo);
     DbgCmdExecDirect(QString("disasm " + addrText));
 }
 
 void CallStackView::followFrom()
 {
-    QString addrText = getCellContent(getInitialSelection(), 2);
+    QString addrText = getCellContent(getInitialSelection(), ColFrom);
     DbgCmdExecDirect(QString("disasm " + addrText));
 }
 

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -66,18 +66,28 @@ void CallStackView::setupContextMenu()
 
 QString CallStackView::paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h)
 {
+    QString ret = getCellContent(rowBase + rowOffset, col);
+
     if(isSelected(rowBase, rowOffset))
         painter->fillRect(QRect(x, y, w, h), QBrush(mSelectionColor));
 
     bool isSpaceRow = !getCellContent(rowBase + rowOffset, ColThread).isEmpty();
 
-    if(col > ColThread && isSpaceRow)
+    if(!col && !(rowBase + rowOffset) && !ret.isEmpty())
+    {
+        painter->fillRect(QRect(x, y, w, h), QBrush(ConfigColor("ThreadCurrentBackgroundColor")));
+        painter->setPen(QPen(ConfigColor("ThreadCurrentColor")));
+        painter->drawText(QRect(x + 4, y, w - 4, h), Qt::AlignVCenter | Qt::AlignLeft, ret);
+        ret = "";
+    }
+
+    else if(col > ColThread && isSpaceRow)
     {
         auto mid = h / 2.0;
         painter->drawLine(QPointF(x, y + mid), QPointF(x + w, y + mid));
     }
 
-    return getCellContent(rowBase + rowOffset, col);
+    return ret;
 }
 
 void CallStackView::updateCallStack()

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -21,7 +21,8 @@ protected slots:
 private:
     enum
     {
-        ColAddress = 0,
+        ColThread = 0,
+        ColAddress,
         ColTo,
         ColFrom,
         ColSize,

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -10,6 +10,9 @@ public:
     explicit CallStackView(StdTable* parent = 0);
     void setupContextMenu();
 
+protected:
+    QString paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h) override;
+
 protected slots:
     void updateCallStack();
     void contextMenuSlot(const QPoint pos);

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -34,6 +34,7 @@ private:
     };
 
     MenuBuilder* mMenuBuilder;
+    bool isSelectionValid();
 };
 
 #endif // CALLSTACKVIEW_H

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -19,6 +19,16 @@ protected slots:
     void showSuspectedCallStack();
 
 private:
+    enum
+    {
+        ColAddress = 0,
+        ColTo,
+        ColFrom,
+        ColSize,
+        ColComment,
+        ColParty
+    };
+
     MenuBuilder* mMenuBuilder;
 };
 

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -311,7 +311,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Watch1", 6);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "BreakpointsView", 7);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "MemoryMap", 8);
-    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CallStack", 6);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CallStack", 7);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "SEH", 4);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Script", 3);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "Thread", 14);


### PR DESCRIPTION
-Added new function (GetCallStackByThread)
-Change the call stack view, it displays call stacks from multiple threads now

Hope it looks better now. Not sure if the internals of that function looks good for you.

Before: 
![x32dbg_2020-10-23_17-10-33](https://user-images.githubusercontent.com/11231925/97021243-e3e6fe00-1552-11eb-81de-f0320d7bcfed.png)

After:
![x32dbg_2020-10-23_15-39-43](https://user-images.githubusercontent.com/11231925/97021274-eb0e0c00-1552-11eb-8849-7816ba862f3c.png)

