### PR TITLE
In some cases, the call stack information for a 64-bit process cannot be obtained correctly.

### DIFF
--- a/src/dbg/stackinfo.cpp
+++ b/src/dbg/stackinfo.cpp
@@ -309,7 +309,7 @@ void stackgetcallstack(duint csp, std::vector<CALLSTACKENTRY> & callstackVector,
         DWORD machineType = IMAGE_FILE_MACHINE_AMD64;
         frame.AddrPC.Offset = context.Rip;
         frame.AddrPC.Mode = AddrModeFlat;
-        frame.AddrFrame.Offset = context.Rsp;
+        frame.AddrFrame.Offset = context.Rbp;
         frame.AddrFrame.Mode = AddrModeFlat;
         frame.AddrStack.Offset = csp;
         frame.AddrStack.Mode = AddrModeFlat;


### PR DESCRIPTION
In some cases, the call stack information for a 64-bit process cannot be obtained correctly.
reference: https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-stackframe

AddrFrame

An ADDRESS64 structure that specifies the frame pointer.

x86:  The frame pointer is EBP.

Intel Itanium:  There is no frame pointer, but AddrBStore is used.

x64:  The frame pointer is RBP or RDI. This value is not always used.