### PR TITLE
Changes related to WatchView

### DIFF
--- a/src/dbg/watch.cpp
+++ b/src/dbg/watch.cpp
@@ -90,7 +90,7 @@ bool WatchExpr::modifyExpr(const char* expression, WATCHVARTYPE type)
     {
         expr = b;
         varType = type;
-        currValue = 0;
+        this->getIntValue();
         haveCurrValue = false;
         return true;
     }

--- a/src/gui/Src/Gui/WatchView.cpp
+++ b/src/gui/Src/Gui/WatchView.cpp
@@ -249,8 +249,9 @@ void WatchView::editWatchSlot()
 {
     QString expr;
     QString originalExpr = getCellContent(getInitialSelection(), ColExpr);
+    QString currentType = getCellContent(getInitialSelection(), ColType);
     if(SimpleInputBox(this, tr("Enter the expression to watch"), originalExpr, expr, tr("Example: [EAX]")))
-        DbgCmdExecDirect(QString("SetWatchExpression ").append(getSelectedId()).append(",").append(expr));
+        DbgCmdExecDirect(QString("SetWatchExpression ").append(getSelectedId()).append(",").append(expr).append(",").append(currentType));
     updateWatch();
 }
 

--- a/src/gui/Src/Gui/WatchView.cpp
+++ b/src/gui/Src/Gui/WatchView.cpp
@@ -37,24 +37,24 @@ void WatchView::updateWatch()
         setSingleSelection(WatchList.Count() - 1);
     for(int i = 0; i < WatchList.Count(); i++)
     {
-        setCellContent(i, 0, QString(WatchList[i].WatchName));
-        setCellContent(i, 1, QString(WatchList[i].Expression));
+        setCellContent(i, ColName, QString(WatchList[i].WatchName));
+        setCellContent(i, ColExpr, QString(WatchList[i].Expression));
         switch(WatchList[i].varType)
         {
         case WATCHVARTYPE::TYPE_UINT:
-            setCellContent(i, 3, "UINT");
-            setCellContent(i, 2, ToPtrString(WatchList[i].value));
+            setCellContent(i, ColType, "UINT");
+            setCellContent(i, ColValue, ToPtrString(WatchList[i].value));
             break;
         case WATCHVARTYPE::TYPE_INT:
-            setCellContent(i, 3, "INT");
-            setCellContent(i, 2, QString::number((dsint)WatchList[i].value));
+            setCellContent(i, ColType, "INT");
+            setCellContent(i, ColValue, QString::number((dsint)WatchList[i].value));
             break;
         case WATCHVARTYPE::TYPE_FLOAT:
-            setCellContent(i, 3, "FLOAT");
-            setCellContent(i, 2, ToFloatString(&WatchList[i].value));
+            setCellContent(i, ColType, "FLOAT");
+            setCellContent(i, ColValue, ToFloatString(&WatchList[i].value));
             break;
         case WATCHVARTYPE::TYPE_ASCII:
-            setCellContent(i, 3, "ASCII");
+            setCellContent(i, ColType, "ASCII");
             {
                 char buffer[128];
                 // zero the buffer
@@ -68,14 +68,14 @@ void WatchView::updateWatch()
                     // remove CRLF
                     text.replace(QChar('\x13'), "\\r");
                     text.replace(QChar('\x10'), "\\n");
-                    setCellContent(i, 2, text);
+                    setCellContent(i, ColValue, text);
                 }
                 else
-                    setCellContent(i, 2, tr("%1 is not readable.").arg(ToPtrString(WatchList[i].value)));
+                    setCellContent(i, ColValue, tr("%1 is not readable.").arg(ToPtrString(WatchList[i].value)));
             }
             break;
         case WATCHVARTYPE::TYPE_UNICODE:
-            setCellContent(i, 3, "UNICODE");
+            setCellContent(i, ColType, "UNICODE");
             {
                 unsigned short buffer[128];
                 // zero the buffer
@@ -93,38 +93,38 @@ void WatchView::updateWatch()
                     // remove CRLF
                     text.replace(QChar('\x13'), "\\r");
                     text.replace(QChar('\x10'), "\\n");
-                    setCellContent(i, 2, text);
+                    setCellContent(i, ColValue, text);
                 }
                 else
-                    setCellContent(i, 2, tr("%1 is not readable.").arg(ToPtrString(WatchList[i].value)));
+                    setCellContent(i, ColValue, tr("%1 is not readable.").arg(ToPtrString(WatchList[i].value)));
             }
             break;
         case WATCHVARTYPE::TYPE_INVALID:
         default:
-            setCellContent(i, 3, "INVALID");
-            setCellContent(i, 2, "");
+            setCellContent(i, ColType, "INVALID");
+            setCellContent(i, ColValue, "");
             break;
         }
         switch(WatchList[i].watchdogMode)
         {
         case WATCHDOGMODE::MODE_DISABLED:
         default:
-            setCellContent(i, 4, tr("Disabled"));
+            setCellContent(i, ColWatchdog, tr("Disabled"));
             break;
         case WATCHDOGMODE::MODE_CHANGED:
-            setCellContent(i, 4, tr("Changed"));
+            setCellContent(i, ColWatchdog, tr("Changed"));
             break;
         case WATCHDOGMODE::MODE_ISTRUE:
-            setCellContent(i, 4, tr("Is true"));
+            setCellContent(i, ColWatchdog, tr("Is true"));
             break;
         case WATCHDOGMODE::MODE_ISFALSE:
-            setCellContent(i, 4, tr("Is false"));
+            setCellContent(i, ColWatchdog, tr("Is false"));
             break;
         case WATCHDOGMODE::MODE_UNCHANGED:
-            setCellContent(i, 4, tr("Not changed"));
+            setCellContent(i, ColWatchdog, tr("Not changed"));
             break;
         }
-        setCellContent(i, 5, QString::number(WatchList[i].id));
+        setCellContent(i, ColId, QString::number(WatchList[i].id));
     }
     reloadData();
 }
@@ -178,14 +178,14 @@ void WatchView::setupContextMenu()
 
 QString WatchView::getSelectedId()
 {
-    return QChar('.') + getCellContent(getInitialSelection(), 5);
+    return QChar('.') + getCellContent(getInitialSelection(), ColId);
 }
 
 QString WatchView::paintContent(QPainter* painter, dsint rowBase, int rowOffset, int col, int x, int y, int w, int h)
 {
     QString ret = StdTable::paintContent(painter, rowBase, rowOffset, col, x, y, w, h);
     const dsint row = rowBase + rowOffset;
-    if(row != getInitialSelection() && DbgFunctions()->WatchIsWatchdogTriggered(getCellContent(row, 5).toUInt()))
+    if(row != getInitialSelection() && DbgFunctions()->WatchIsWatchdogTriggered(getCellContent(row, ColId).toUInt()))
     {
         painter->fillRect(QRect(x, y, w, h), mWatchTriggeredBackgroundColor);
         painter->setPen(mWatchTriggeredColor); //white text
@@ -222,7 +222,7 @@ void WatchView::delWatchSlot()
 void WatchView::renameWatchSlot()
 {
     QString name;
-    QString originalName = getCellContent(getInitialSelection(), 0);
+    QString originalName = getCellContent(getInitialSelection(), ColName);
     if(SimpleInputBox(this, tr("Enter the name of the watch variable"), originalName, name, originalName))
         DbgCmdExecDirect(QString("SetWatchName ").append(getSelectedId() + "," + name));
     updateWatch();
@@ -248,7 +248,7 @@ void WatchView::modifyWatchSlot()
 void WatchView::editWatchSlot()
 {
     QString expr;
-    QString originalExpr = getCellContent(getInitialSelection(), 1);
+    QString originalExpr = getCellContent(getInitialSelection(), ColExpr);
     if(SimpleInputBox(this, tr("Enter the expression to watch"), originalExpr, expr, tr("Example: [EAX]")))
         DbgCmdExecDirect(QString("SetWatchExpression ").append(getSelectedId()).append(",").append(expr));
     updateWatch();

--- a/src/gui/Src/Gui/WatchView.h
+++ b/src/gui/Src/Gui/WatchView.h
@@ -40,6 +40,17 @@ protected:
     MenuBuilder* mMenu;
     QPen mWatchTriggeredColor;
     QBrush mWatchTriggeredBackgroundColor;
+
+private:
+    enum
+    {
+        ColName = 0,
+        ColExpr,
+        ColValue,
+        ColType,
+        ColWatchdog,
+        ColId
+    };
 };
 
 #endif // WATCHVIEW_H


### PR DESCRIPTION
-Added column enum to WatchView
-Added current type to `SetWatchExpression` executed from `editWatchSlot`, this is because otherwise if no type is specified this resets the watch type back to `uint`
-Added "force refresh" feature. Without this change, after you edit watch expression, the value of this particular watch is always "0" until you refresh it by for example stepping to next instruction.