### PR TITLE
Fix flag setting when flag is already set

### DIFF
--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -623,11 +623,11 @@ bool setflag(const char* string, bool set)
         flag = 0x100000;
     else if(scmp(string, "id"))
         flag = 0x200000;
-    if(eflags & flag && !set)
-        xorval = flag;
-    else if(!(eflags & flag) && set)
-        xorval = flag;
-    return SetContextDataEx(hActiveThread, UE_CFLAGS, eflags ^ xorval);
+    if(set)
+        eflags |= flag;
+    else
+        eflags &= ~flag;
+    return SetContextDataEx(hActiveThread, UE_CFLAGS, eflags);
 }
 
 /**

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -625,7 +625,7 @@ bool setflag(const char* string, bool set)
         flag = 0x200000;
     if(eflags & flag && !set)
         xorval = flag;
-    else if(set)
+    else if(!(eflags & flag) && set)
         xorval = flag;
     return SetContextDataEx(hActiveThread, UE_CFLAGS, eflags ^ xorval);
 }


### PR DESCRIPTION
This fixes commands such as `_ZF=1` where ZF is already set to 1 by checking whether the bit is already set.