### PR TITLE
Added in Log windows values for addresses of functions after module w…

### DIFF
--- a/src/dbg/analysis/controlflowanalysis.cpp
+++ b/src/dbg/analysis/controlflowanalysis.cpp
@@ -294,19 +294,18 @@ void ControlFlowAnalysis::Functions()
         if(!function)
         {
             continue;
-            // dprintf("unresolved block %s\n", blockToString(block).c_str());
-            // if(parents)
-            // {
-            //     dprintf("parents:\n");
-            //     for(auto parent : *parents)
-            //         dprintf("  %s\n", blockToString(findBlock(parent)).c_str());
-            // }
-            // else
-            //     dprintf("parents: null");
-            // dprintf("left: %s\n", blockToString(findBlock(block->left)).c_str());
-            // dprintf("right: %s\n", blockToString(findBlock(block->right)).c_str());
-            //return;
-            //continue;
+            /*dprintf("unresolved block %s\n", blockToString(block).c_str());
+             if(parents)
+             {
+                 dprintf("parents:\n");
+                 for(auto parent : *parents)
+                     dprintf("  %s\n", blockToString(findBlock(parent)).c_str());
+             }
+             else
+                 dprintf("parents: null");
+             dprintf("left: %s\n", blockToString(findBlock(block->left)).c_str());
+             dprintf("right: %s\n", blockToString(findBlock(block->right)).c_str());
+            return;*/
         }
         block->function = function;
         resolved++;

--- a/src/dbg/analysis/controlflowanalysis.cpp
+++ b/src/dbg/analysis/controlflowanalysis.cpp
@@ -295,16 +295,16 @@ void ControlFlowAnalysis::Functions()
         {
             continue;
             /*dprintf("unresolved block %s\n", blockToString(block).c_str());
-             if(parents)
-             {
-                 dprintf("parents:\n");
-                 for(auto parent : *parents)
-                     dprintf("  %s\n", blockToString(findBlock(parent)).c_str());
-             }
-             else
-                 dprintf("parents: null");
-             dprintf("left: %s\n", blockToString(findBlock(block->left)).c_str());
-             dprintf("right: %s\n", blockToString(findBlock(block->right)).c_str());
+            if(parents)
+            {
+                dprintf("parents:\n");
+                for(auto parent : *parents)
+                    dprintf("  %s\n", blockToString(findBlock(parent)).c_str());
+            }
+            else
+                dprintf("parents: null");
+            dprintf("left: %s\n", blockToString(findBlock(block->left)).c_str());
+            dprintf("right: %s\n", blockToString(findBlock(block->right)).c_str());
             return;*/
         }
         block->function = function;

--- a/src/dbg/analysis/controlflowanalysis.cpp
+++ b/src/dbg/analysis/controlflowanalysis.cpp
@@ -294,18 +294,19 @@ void ControlFlowAnalysis::Functions()
         if(!function)
         {
             continue;
-            /*dprintf("unresolved block %s\n", blockToString(block).c_str());
-            if(parents)
-            {
-                dprintf("parents:\n");
-                for(auto parent : *parents)
-                    dprintf("  %s\n", blockToString(findBlock(parent)).c_str());
-            }
-            else
-                dprintf("parents: null");
-            dprintf("left: %s\n", blockToString(findBlock(block->left)).c_str());
-            dprintf("right: %s\n", blockToString(findBlock(block->right)).c_str());
-            return;*/
+            // dprintf("unresolved block %s\n", blockToString(block).c_str());
+            // if(parents)
+            // {
+            //     dprintf("parents:\n");
+            //     for(auto parent : *parents)
+            //         dprintf("  %s\n", blockToString(findBlock(parent)).c_str());
+            // }
+            // else
+            //     dprintf("parents: null");
+            // dprintf("left: %s\n", blockToString(findBlock(block->left)).c_str());
+            // dprintf("right: %s\n", blockToString(findBlock(block->right)).c_str());
+            //return;
+            //continue;
         }
         block->function = function;
         resolved++;
@@ -324,6 +325,12 @@ void ControlFlowAnalysis::Functions()
     }
     dprintf("%d/%u unreferenced blocks\n", unreferencedCount, DWORD(mBlocks.size()));
     dprintf("%u functions found!\n", DWORD(mFunctions.size()));
+
+    for (const auto& function: mFunctions)
+    {
+       dprintf("%p function\n",
+           reinterpret_cast<decltype(function.first)*>(function.first));
+    }
 }
 
 void ControlFlowAnalysis::FunctionRanges()

--- a/src/dbg/analysis/controlflowanalysis.cpp
+++ b/src/dbg/analysis/controlflowanalysis.cpp
@@ -325,10 +325,10 @@ void ControlFlowAnalysis::Functions()
     dprintf("%d/%u unreferenced blocks\n", unreferencedCount, DWORD(mBlocks.size()));
     dprintf("%u functions found!\n", DWORD(mFunctions.size()));
 
-    for (const auto& function: mFunctions)
+    for(const auto & function : mFunctions)
     {
-       dprintf("%p function\n",
-           reinterpret_cast<decltype(function.first)*>(function.first));
+        dprintf("%p function\n",
+                reinterpret_cast<decltype(function.first)*>(function.first));
     }
 }
 


### PR DESCRIPTION
**List of function found during analysis of debugging module**

After user pressed Ctrl-A combination, in the Log it's possible to see not only the statistics but functions' addresses. It's possible to click on that address for fast moving to that area and analyse functions that were found.