### PR TITLE
Change NtTerminateProcess breakpoint to a generic 'exit breakpoint'

### DIFF
--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -56,7 +56,7 @@ void SettingsDialog::LoadSettings()
     settings.eventSystemBreakpoint = true;
     settings.eventTlsCallbacks = true;
     settings.eventEntryBreakpoint = true;
-    settings.eventNtTerminateProcess = false;
+    settings.eventExitBreakpoint = false;
     settings.engineType = DebugEngineTitanEngine;
     settings.engineCalcType = calc_unsigned;
     settings.engineBreakpointType = break_int3short;
@@ -90,7 +90,7 @@ void SettingsDialog::LoadSettings()
 
     //Events tab
     GetSettingBool("Events", "SystemBreakpoint", &settings.eventSystemBreakpoint);
-    GetSettingBool("Events", "NtTerminateProcess", &settings.eventNtTerminateProcess);
+    GetSettingBool("Events", "NtTerminateProcess", &settings.eventExitBreakpoint);
     GetSettingBool("Events", "TlsCallbacks", &settings.eventTlsCallbacks);
     GetSettingBool("Events", "TlsCallbacksSystem", &settings.eventTlsCallbacksSystem);
     GetSettingBool("Events", "EntryBreakpoint", &settings.eventEntryBreakpoint);
@@ -105,7 +105,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Events", "ThreadEnd", &settings.eventThreadEnd);
     GetSettingBool("Events", "DebugStrings", &settings.eventDebugStrings);
     ui->chkSystemBreakpoint->setCheckState(bool2check(settings.eventSystemBreakpoint));
-    ui->chkNtTerminateProcess->setCheckState(bool2check(settings.eventNtTerminateProcess));
+    ui->chkExitBreakpoint->setCheckState(bool2check(settings.eventExitBreakpoint));
     ui->chkTlsCallbacks->setCheckState(bool2check(settings.eventTlsCallbacks));
     ui->chkTlsCallbacksSystem->setCheckState(bool2check(settings.eventTlsCallbacksSystem));
     ui->chkEntryBreakpoint->setCheckState(bool2check(settings.eventEntryBreakpoint));
@@ -389,7 +389,7 @@ void SettingsDialog::SaveSettings()
 {
     //Events tab
     BridgeSettingSetUint("Events", "SystemBreakpoint", settings.eventSystemBreakpoint);
-    BridgeSettingSetUint("Events", "NtTerminateProcess", settings.eventNtTerminateProcess);
+    BridgeSettingSetUint("Events", "NtTerminateProcess", settings.eventExitBreakpoint);
     BridgeSettingSetUint("Events", "TlsCallbacks", settings.eventTlsCallbacks);
     BridgeSettingSetUint("Events", "TlsCallbacksSystem", settings.eventTlsCallbacksSystem);
     BridgeSettingSetUint("Events", "EntryBreakpoint", settings.eventEntryBreakpoint);
@@ -660,9 +660,9 @@ void SettingsDialog::on_chkSystemBreakpoint_stateChanged(int arg1)
     settings.eventSystemBreakpoint = arg1 != Qt::Unchecked;
 }
 
-void SettingsDialog::on_chkNtTerminateProcess_stateChanged(int arg1)
+void SettingsDialog::on_chkExitBreakpoint_stateChanged(int arg1)
 {
-    settings.eventNtTerminateProcess = arg1 != Qt::Unchecked;
+    settings.eventExitBreakpoint = arg1 != Qt::Unchecked;
 }
 
 void SettingsDialog::on_chkTlsCallbacks_stateChanged(int arg1)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -30,7 +30,7 @@ private slots:
     void on_btnSave_clicked();
     //Event tab
     void on_chkSystemBreakpoint_stateChanged(int arg1);
-    void on_chkNtTerminateProcess_stateChanged(int arg1);
+    void on_chkExitBreakpoint_stateChanged(int arg1);
     void on_chkTlsCallbacks_stateChanged(int arg1);
     void on_chkTlsCallbacksSystem_stateChanged(int arg1);
     void on_chkEntryBreakpoint_stateChanged(int arg1);
@@ -172,7 +172,7 @@ private:
     {
         //Event Tab
         bool eventSystemBreakpoint;
-        bool eventNtTerminateProcess;
+        bool eventExitBreakpoint;
         bool eventTlsCallbacks;
         bool eventTlsCallbacksSystem;
         bool eventEntryBreakpoint;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -40,7 +40,7 @@
        <string>Events</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QCheckBox" name="chkEntryBreakpoint">
          <property name="text">
           <string>Entry Breakpoint*</string>
@@ -91,10 +91,10 @@
          </property>
         </spacer>
        </item>
-       <item row="2" column="0">
-        <widget class="QCheckBox" name="chkNtTerminateProcess">
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="chkExitBreakpoint">
          <property name="text">
-          <string>NtTerminateProcess*</string>
+          <string>Exit Breakpoint*</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
I like the `NtTerminateProcess` breakpoint that can be enabled in the settings, but it has some issues compared to what I'm used to from WinDbg. Consider the following program:
```C++
int main()
{
    return TerminateThread(GetCurrentThread(), 0);
}
```
This will bypass the `NtTerminateProcess` breakpoint, since terminating the last thread of a process will also terminate the process (but without invoking `NtTerminateProcess` directly.) A probably more useful example is some other process (task manager or maybe something more malicious) terminating the debuggee process. In cases such as this it is currently not possible to do a proper post mortem to see what caused the debuggee to exit, because the entire GUI state is wiped.

This PR renames the `NtTerminateProcess` breakpoint to simply 'Exit Breakpoint', and moves the implementation to the exit process callback. This means the process state (current EIP/RIP, call stack etc.) can still be inspected regardless of how the process was terminated.