### PR TITLE
Clear history before exit breakpoint

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1500,17 +1500,17 @@ static void cbExitProcess(EXIT_PROCESS_DEBUG_INFO* ExitProcess)
     PLUG_CB_EXITPROCESS callbackInfo;
     callbackInfo.ExitProcess = ExitProcess;
     plugincbcall(CB_EXITPROCESS, &callbackInfo);
+    _dbg_animatestop(); // Stop animating
+    //history
+    dbgcleartracestate();
+    dbgClearRtuBreakpoints();
+    HistoryClear();
     if(breakHere)
     {
         dbgsetforeground();
         dbgsetskipexceptions(false);
         wait(WAITID_RUN);
     }
-    _dbg_animatestop(); // Stop animating
-    //history
-    dbgcleartracestate();
-    dbgClearRtuBreakpoints();
-    HistoryClear();
 }
 
 static void cbCreateThread(CREATE_THREAD_DEBUG_INFO* CreateThread)


### PR DESCRIPTION
As requested by @torusrxxx in #2592 (which was already merged when he left the comment).