### PR TITLE
enhance the FPU support for trace info box and trace registers view

### DIFF
--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -110,7 +110,7 @@ QString CPUInfoBox::formatSSEOperand(const QByteArray & data, uint8_t vectorType
         }
         else if(data.size() == 4)
         {
-            hex = QString::number(((const float*)data.constData())[0]);
+            hex = ToFloatString(data.constData());
             isXMMdecoded = true;
         }
         break;
@@ -127,7 +127,7 @@ QString CPUInfoBox::formatSSEOperand(const QByteArray & data, uint8_t vectorType
         }
         else if(data.size() == 8)
         {
-            hex = QString::number(((const double*)data.constData())[0]);
+            hex = ToDoubleString(data.constData());
             isXMMdecoded = true;
         }
         break;

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -91,7 +91,7 @@ void CPUInfoBox::clear()
     setInfoLine(3, "");
 }
 
-QString CPUInfoBox::formatSSEOperand(const QByteArray & data, uint8_t vectorType)
+QString CPUInfoBox::formatSSEOperand(const QByteArray & data, unsigned char vectorType)
 {
     QString hex;
     bool isXMMdecoded = false;

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -91,7 +91,7 @@ void CPUInfoBox::clear()
     setInfoLine(3, "");
 }
 
-static QString formatSSEOperand(const QByteArray & data, uint8_t vectorType)
+QString CPUInfoBox::formatSSEOperand(const QByteArray & data, uint8_t vectorType)
 {
     QString hex;
     bool isXMMdecoded = false;

--- a/src/gui/Src/Gui/CPUInfoBox.h
+++ b/src/gui/Src/Gui/CPUInfoBox.h
@@ -22,6 +22,8 @@ public:
     void setupWatchMenu(QMenu* menu, duint wVA);
     int followInDump(dsint wVA);
 
+    static QString formatSSEOperand(const QByteArray & data, uint8_t vectorType);
+
 public slots:
     void disasmSelectionChanged(dsint parVA);
     void dbgStateChanged(DBGSTATE state);

--- a/src/gui/Src/Gui/CPUInfoBox.h
+++ b/src/gui/Src/Gui/CPUInfoBox.h
@@ -1,6 +1,7 @@
 #ifndef INFOBOX_H
 #define INFOBOX_H
 
+#include "Imports.h"
 #include "StdTable.h"
 
 class WordEditDialog;

--- a/src/gui/Src/Gui/CPUInfoBox.h
+++ b/src/gui/Src/Gui/CPUInfoBox.h
@@ -1,7 +1,6 @@
 #ifndef INFOBOX_H
 #define INFOBOX_H
 
-#include "Imports.h"
 #include "StdTable.h"
 
 class WordEditDialog;
@@ -23,7 +22,7 @@ public:
     void setupWatchMenu(QMenu* menu, duint wVA);
     int followInDump(dsint wVA);
 
-    static QString formatSSEOperand(const QByteArray & data, uint8_t vectorType);
+    static QString formatSSEOperand(const QByteArray & data, unsigned char vectorType);
 
 public slots:
     void disasmSelectionChanged(dsint parVA);

--- a/src/gui/Src/Gui/CPURegistersView.cpp
+++ b/src/gui/Src/Gui/CPURegistersView.cpp
@@ -222,6 +222,17 @@ extern STRING_VALUE_TABLE_t TagWordValueStringTable[4];
 
 #define MODIFY_FIELDS_DISPLAY(prefix, title, table) ModifyFields(prefix + QChar(' ') + QString(title), (STRING_VALUE_TABLE_t *) & table, SIZE_TABLE(table) )
 
+static void editSIMDRegister(CPURegistersView* parent, int bits, const QString & title, char* data, RegistersView::REGISTER_NAME mSelected)
+{
+    EditFloatRegister mEditFloat(bits, parent);
+    mEditFloat.setWindowTitle(title);
+    mEditFloat.loadData(data);
+    mEditFloat.show();
+    mEditFloat.selectAllText();
+    if(mEditFloat.exec() == QDialog::Accepted)
+        parent->setRegister(mSelected, (duint)mEditFloat.getData());
+}
+
 /**
  * @brief   This function displays the appropriate edit dialog according to selected register
  * @return  Nothing.
@@ -246,35 +257,11 @@ void CPURegistersView::displayEditDialog()
             updateRegistersSlot();
         }
         else if(mFPUYMM.contains(mSelected))
-        {
-            EditFloatRegister mEditFloat(256, this);
-            mEditFloat.setWindowTitle(tr("Edit YMM register"));
-            mEditFloat.loadData(registerValue(&wRegDumpStruct, mSelected));
-            mEditFloat.show();
-            mEditFloat.selectAllText();
-            if(mEditFloat.exec() == QDialog::Accepted)
-                setRegister(mSelected, (duint)mEditFloat.getData());
-        }
+            editSIMDRegister(this, 256, tr("Edit YMM register"), registerValue(&wRegDumpStruct, mSelected), mSelected);
         else if(mFPUXMM.contains(mSelected))
-        {
-            EditFloatRegister mEditFloat(128, this);
-            mEditFloat.setWindowTitle(tr("Edit XMM register"));
-            mEditFloat.loadData(registerValue(&wRegDumpStruct, mSelected));
-            mEditFloat.show();
-            mEditFloat.selectAllText();
-            if(mEditFloat.exec() == QDialog::Accepted)
-                setRegister(mSelected, (duint)mEditFloat.getData());
-        }
+            editSIMDRegister(this, 128, tr("Edit XMM register"), registerValue(&wRegDumpStruct, mSelected), mSelected);
         else if(mFPUMMX.contains(mSelected))
-        {
-            EditFloatRegister mEditFloat(64, this);
-            mEditFloat.setWindowTitle(tr("Edit MMX register"));
-            mEditFloat.loadData(registerValue(&wRegDumpStruct, mSelected));
-            mEditFloat.show();
-            mEditFloat.selectAllText();
-            if(mEditFloat.exec() == QDialog::Accepted)
-                setRegister(mSelected, (duint)mEditFloat.getData());
-        }
+            editSIMDRegister(this, 64, tr("Edit MMX register"), registerValue(&wRegDumpStruct, mSelected), mSelected);
         else
         {
             bool errorinput = false;

--- a/src/gui/Src/Gui/EditFloatRegister.cpp
+++ b/src/gui/Src/Gui/EditFloatRegister.cpp
@@ -223,7 +223,7 @@ void EditFloatRegister::hideNonMMXPart()
  * @param[in] RegisterData   the data to be loaded. It must be at lease the same size as the size specified in RegisterSize
  * @return    Nothing.
  */
-void EditFloatRegister::loadData(char* RegisterData)
+void EditFloatRegister::loadData(const char* RegisterData)
 {
     memcpy(Data, RegisterData, RegSize / 8);
     reloadDataLow();
@@ -234,7 +234,7 @@ void EditFloatRegister::loadData(char* RegisterData)
  * @brief    Get the register data from the dialog
  * @return   The output buffer.
  */
-const char* EditFloatRegister::getData()
+const char* EditFloatRegister::getData() const
 {
     return Data;
 }

--- a/src/gui/Src/Gui/EditFloatRegister.h
+++ b/src/gui/Src/Gui/EditFloatRegister.h
@@ -18,8 +18,8 @@ class EditFloatRegister : public QDialog
 
 public:
     explicit EditFloatRegister(int RegisterSize, QWidget* parent = 0);
-    void loadData(char* RegisterData);
-    const char* getData();
+    void loadData(const char* RegisterData);
+    const char* getData() const;
     void selectAllText();
 
     ~EditFloatRegister();

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -917,10 +917,10 @@ void TraceBrowser::setupRightClickContextMenu()
                 menu->addAction(QString("%1: %2 -> %3").arg(getAddrText(MemoryAddress[i], nolabel, false)).arg(ToPtrString(MemoryOldContent[i])).arg(ToPtrString(MemoryNewContent[i])));
             }
             mRvaDisplayEnabled = RvaDisplayEnabled;
-            menu->addSeparator();
+            return true;
         }
-        menu->addAction(QString("ThreadID: %1").arg(mTraceFile->ThreadId(index)));
-        return true;
+        else
+            return false; //The information menu now only contains memory access info
     });
     mMenuBuilder->addMenu(makeMenu(tr("Information")), infoMenu);
 

--- a/src/gui/Src/Tracer/TraceRegisters.h
+++ b/src/gui/Src/Tracer/TraceRegisters.h
@@ -15,6 +15,9 @@ public slots:
     virtual void displayCustomContextMenuSlot(QPoint pos);
     void onCopySIMDRegister();
 
+protected:
+    virtual void mouseDoubleClickEvent(QMouseEvent* event);
+
 private:
     QAction* wCM_CopySIMDRegister;
 };


### PR DESCRIPTION
- The content of FPU registers now show in the trace info box as numbers, easing the reverse engineering of floating point code.
- Double click on EIP in trace registers will follow in disassembly, double click on XMM register in trace registers will open the View XMM registers dialog.
- FPU operands in memory will now display in the trace info box.
- Moved Thread ID from "Information" menu to trace info box
- Increase output precision for FPU register in info box
- Hide scrollbars in trace info box