### PR TITLE
GUI: Disabled possibilty to sort content in call stack tab, fixed #2637

### DIFF
--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -6,8 +6,8 @@ CallStackView::CallStackView(StdTable* parent) : StdTable(parent)
 {
     int charwidth = getCharWidth();
 
-    addColumnAt(8 * charwidth, tr("Thread ID"), true);
-    addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("Address"), true); //address in the stack
+    addColumnAt(8 * charwidth, tr("Thread ID"), false);
+    addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("Address"), false); //address in the stack
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("To"), false); //return to
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("From"), false); //return from
     addColumnAt(8 + charwidth * sizeof(dsint) * 2, tr("Size"), false); //size


### PR DESCRIPTION
I think that in future it could be a good idea to implement sorting via Thread ID, but for now I think disabling is ok, to avoid the possibility of breaking the widget.