### PR TITLE
MemoyDump - "modify" dialog fix

### DIFF
--- a/src/gui/Src/Gui/WordEditDialog.cpp
+++ b/src/gui/Src/Gui/WordEditDialog.cpp
@@ -112,23 +112,23 @@ void WordEditDialog::expressionChanged(bool validExpression, bool validPointer, 
         // Byte edit line
         ui->hexLineEdit->setText(ToPtrString(hexWord));
         // Signed edit
-        if(byteCount == sizeof(int8_t))
-            ui->signedLineEdit->setText(QString::number((int8_t)mWord));
-        else if(byteCount == sizeof(int16_t))
-            ui->signedLineEdit->setText(QString::number((int16_t)mWord));
-        else if(byteCount == sizeof(int32_t))
-            ui->signedLineEdit->setText(QString::number((int32_t)mWord));
+        if(byteCount == sizeof(signed char))
+            ui->signedLineEdit->setText(QString::number((signed char)mWord));
+        else if(byteCount == sizeof(signed short))
+            ui->signedLineEdit->setText(QString::number((signed short)mWord));
+        else if(byteCount == sizeof(signed int))
+            ui->signedLineEdit->setText(QString::number((signed int)mWord));
         else
-            ui->signedLineEdit->setText(QString::number((int64_t)mWord));
+            ui->signedLineEdit->setText(QString::number((long long)mWord));
         // Unsigned edit
-        if(byteCount == sizeof(uint8_t))
-            ui->unsignedLineEdit->setText(QString::number((uint8_t)mWord));
-        else if(byteCount == sizeof(uint16_t))
-            ui->unsignedLineEdit->setText(QString::number((uint16_t)mWord));
-        else if(byteCount == sizeof(uint32_t))
-            ui->unsignedLineEdit->setText(QString::number((uint32_t)mWord));
+        if(byteCount == sizeof(unsigned char))
+            ui->unsignedLineEdit->setText(QString::number((unsigned char)mWord));
+        else if(byteCount == sizeof(unsigned short))
+            ui->unsignedLineEdit->setText(QString::number((unsigned short)mWord));
+        else if(byteCount == sizeof(unsigned int))
+            ui->unsignedLineEdit->setText(QString::number((unsigned int)mWord));
         else
-            ui->unsignedLineEdit->setText(QString::number((uint64_t)mWord));
+            ui->unsignedLineEdit->setText(QString::number((unsigned long long)mWord));
         // ASCII edit
         QString asciiExp;
         for(int i = 0; i < asciiWidth; i++)

--- a/src/gui/Src/Gui/WordEditDialog.cpp
+++ b/src/gui/Src/Gui/WordEditDialog.cpp
@@ -61,6 +61,7 @@ void WordEditDialog::hideEvent(QHideEvent* event)
 void WordEditDialog::setup(QString title, duint defVal, int byteCount)
 {
     this->setWindowTitle(title);
+    this->byteCount = byteCount;
     ui->hexLineEdit->setInputMask(QString("hh").repeated(byteCount));
     ui->expressionLineEdit->setText(QString("%1").arg(defVal, byteCount * 2, 16, QChar('0')).toUpper());
 
@@ -111,9 +112,23 @@ void WordEditDialog::expressionChanged(bool validExpression, bool validPointer, 
         // Byte edit line
         ui->hexLineEdit->setText(ToPtrString(hexWord));
         // Signed edit
-        ui->signedLineEdit->setText(QString::number((dsint)mWord));
+        if(byteCount == sizeof(int8_t))
+            ui->signedLineEdit->setText(QString::number((int8_t)mWord));
+        else if(byteCount == sizeof(int16_t))
+            ui->signedLineEdit->setText(QString::number((int16_t)mWord));
+        else if(byteCount == sizeof(int32_t))
+            ui->signedLineEdit->setText(QString::number((int32_t)mWord));
+        else
+            ui->signedLineEdit->setText(QString::number((int64_t)mWord));
         // Unsigned edit
-        ui->unsignedLineEdit->setText(QString::number((duint)mWord));
+        if(byteCount == sizeof(uint8_t))
+            ui->unsignedLineEdit->setText(QString::number((uint8_t)mWord));
+        else if(byteCount == sizeof(uint16_t))
+            ui->unsignedLineEdit->setText(QString::number((uint16_t)mWord));
+        else if(byteCount == sizeof(uint32_t))
+            ui->unsignedLineEdit->setText(QString::number((uint32_t)mWord));
+        else
+            ui->unsignedLineEdit->setText(QString::number((uint64_t)mWord));
         // ASCII edit
         QString asciiExp;
         for(int i = 0; i < asciiWidth; i++)
@@ -143,7 +158,7 @@ void WordEditDialog::on_signedLineEdit_textEdited(const QString & arg1)
     {
         ui->signedLineEdit->setStyleSheet("");
         ui->btnOk->setEnabled(true);
-        ui->expressionLineEdit->setText(ToPtrString((duint)value));
+        ui->expressionLineEdit->setText(convertValueToHexString((duint)value));
     }
     else
     {
@@ -159,13 +174,27 @@ void WordEditDialog::on_unsignedLineEdit_textEdited(const QString & arg1)
     {
         ui->unsignedLineEdit->setStyleSheet("");
         ui->btnOk->setEnabled(true);
-        ui->expressionLineEdit->setText(ToPtrString((duint)value));
+        ui->expressionLineEdit->setText(convertValueToHexString((duint)value));
     }
     else
     {
         ui->unsignedLineEdit->setStyleSheet("border: 1px solid red");
         ui->btnOk->setEnabled(false);
     }
+}
+
+QString WordEditDialog::convertValueToHexString(duint value)
+{
+    if(byteCount == sizeof(unsigned char))
+        return ToByteString(value);
+
+    else if(byteCount == sizeof(unsigned short))
+        return ToWordString(value);
+
+    else if(byteCount == sizeof(unsigned int))
+        return ToDwordString(value);
+
+    return ToPtrString(value);
 }
 
 void WordEditDialog::saveCursorPositions()

--- a/src/gui/Src/Gui/WordEditDialog.h
+++ b/src/gui/Src/Gui/WordEditDialog.h
@@ -36,6 +36,7 @@ private slots:
     void on_unsignedLineEdit_textEdited(const QString & arg1);
 
 private:
+    QString convertValueToHexString(duint value);
     Ui::WordEditDialog* ui;
     duint mWord;
     ValidateExpressionThread* mValidateThread;
@@ -44,6 +45,7 @@ private:
     int mSignedEditPos;
     int mUnsignedEditPos;
     int mAsciiLineEditPos;
+    int byteCount;
 };
 
 #endif // WORDEDITDIALOG_H

--- a/src/gui/Src/Utils/StringUtil.h
+++ b/src/gui/Src/Utils/StringUtil.h
@@ -70,6 +70,13 @@ inline QString ToWordString(unsigned short Value)
     return QString(temp);
 }
 
+inline QString ToDwordString(unsigned int Value)
+{
+    char temp[16];
+    sprintf_s(temp, "%08X", Value);
+    return QString(temp);
+}
+
 template<typename T>
 inline QString ToFloatingString(const void* buffer, int precision)
 {


### PR DESCRIPTION
In the current version of x64dbg the value is always treated as duint, thus for example when modifying the value in 1 byte mode, the signed/unsigned values are converted to duint/int as in the #2665. Also in the current version, the "Signed" field input value will never be less than zero when double clicking the value in dump in signed word/byte mode.
This pull request changes this behavior.