### PR TITLE
Added "Follow in Symbols" to the Memory Map context menu

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1746,6 +1746,11 @@ BRIDGE_IMPEXP void GuiShowReferences()
     _gui_sendmessage(GUI_SHOW_REF, 0, 0);
 }
 
+BRIDGE_IMPEXP void GuiSelectInSymbolsTab(duint addr)
+{
+    _gui_sendmessage(GUI_SELECT_IN_SYMBOLS_TAB, (void*)addr, nullptr);
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInst = hinstDLL;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1197,6 +1197,7 @@ typedef enum
     GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
     GUI_GET_CURRENT_GRAPH,          // param1=BridgeCFGraphList*,   param2=unused
     GUI_SHOW_REF,                   // param1=unused,               param2=unused
+    GUI_SELECT_IN_SYMBOLS_TAB,      // param1=duint addr,           param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1378,6 +1379,7 @@ BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
 BRIDGE_IMPEXP void GuiExecuteOnGuiThreadEx(GUICALLBACKEX cbGuiThread, void* userdata);
 BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList);
 BRIDGE_IMPEXP void GuiShowReferences();
+BRIDGE_IMPEXP void GuiSelectInSymbolsTab(duint addr);
 
 #ifdef __cplusplus
 }

--- a/src/dbg/commands/cmd-gui.cpp
+++ b/src/dbg/commands/cmd-gui.cpp
@@ -304,3 +304,26 @@ bool cbShowReferences(int argc, char* argv[])
     GuiShowReferences();
     return true;
 }
+
+bool cbSymbolsFollow(int argc, char* argv[])
+{
+    if(argc < 2)
+        return false;
+    duint addr;
+    if(!valfromstring(argv[1], &addr, false) || !MemIsValidReadPtr(addr, true))
+    {
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid address \"%s\"!\n"), argv[1]);
+        return false;
+    }
+
+    duint base = ModBaseFromAddr(addr);
+    if(!base)
+    {
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Address \"%s\" doesn't belong to any module!\n"), argv[1]);
+        return false;
+    }
+
+    GuiSelectInSymbolsTab(base);
+    GuiFocusView(GUI_SYMMOD);
+    return true;
+}

--- a/src/dbg/commands/cmd-gui.h
+++ b/src/dbg/commands/cmd-gui.h
@@ -21,3 +21,4 @@ bool cbInstrSetFavToolShortcut(int argc, char* argv[]);
 bool cbInstrFoldDisassembly(int argc, char* argv[]);
 bool cbDebugUpdateTitle(int argc, char* argv[]);
 bool cbShowReferences(int argc, char* argv[]);
+bool cbSymbolsFollow(int argc, char* argv[]);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -406,7 +406,7 @@ static void registercommands()
     dbgcmdnew("FoldDisassembly", cbInstrFoldDisassembly, true); //fold disassembly segment
     dbgcmdnew("guiupdatetitle", cbDebugUpdateTitle, true); // set relevant disassembly title
     dbgcmdnew("showref", cbShowReferences, false); // show references window
-    dbgcmdnew("symfollow", cbSymbolsFollow, false); // show references window
+    dbgcmdnew("symfollow", cbSymbolsFollow, false); // follow address in symbols tab
 
     //misc
     dbgcmdnew("chd", cbInstrChd, false); //Change directory

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -406,6 +406,7 @@ static void registercommands()
     dbgcmdnew("FoldDisassembly", cbInstrFoldDisassembly, true); //fold disassembly segment
     dbgcmdnew("guiupdatetitle", cbDebugUpdateTitle, true); // set relevant disassembly title
     dbgcmdnew("showref", cbShowReferences, false); // show references window
+    dbgcmdnew("symfollow", cbSymbolsFollow, false); // show references window
 
     //misc
     dbgcmdnew("chd", cbInstrChd, false); //Change directory

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -879,6 +879,10 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
     case GUI_SHOW_REF:
         emit showReferences();
         break;
+
+    case GUI_SELECT_IN_SYMBOLS_TAB:
+        emit symbolSelectModule(duint(param1));
+        break;
     }
 
     return nullptr;

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -1225,8 +1225,8 @@ void CPUDisassembly::findNamesSlot()
         auto base = DbgFunctions()->ModBaseFromAddr(rvaToVa(getInitialSelection()));
         if(!base)
             return;
-        Bridge::getBridge()->symbolSelectModule(base);
-        emit displaySymbolsWidget();
+
+        DbgCmdExec(QString("symfollow %1").arg(base));
     }
 }
 

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -110,6 +110,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(Bridge::getBridge(), SIGNAL(addFavouriteItem(int, QString, QString)), this, SLOT(addFavouriteItem(int, QString, QString)));
     connect(Bridge::getBridge(), SIGNAL(setFavouriteItemShortcut(int, QString, QString)), this, SLOT(setFavouriteItemShortcut(int, QString, QString)));
     connect(Bridge::getBridge(), SIGNAL(selectInMemoryMap(duint)), this, SLOT(displayMemMapWidget()));
+    connect(Bridge::getBridge(), SIGNAL(symbolSelectModule(duint)), this, SLOT(displaySymbolWidget()));
     connect(Bridge::getBridge(), SIGNAL(closeApplication()), this, SLOT(close()));
 
     // Setup menu API

--- a/src/gui/Src/Gui/MemoryMapView.cpp
+++ b/src/gui/Src/Gui/MemoryMapView.cpp
@@ -54,6 +54,10 @@ void MemoryMapView::setupContextMenu()
     connect(this, SIGNAL(enterPressedSignal()), this, SLOT(doubleClickedSlot()));
     connect(this, SIGNAL(doubleClickedSignal()), this, SLOT(doubleClickedSlot()));
 
+    //Follow in Symbols
+    mFollowSymbols = new QAction(DIcon("pdb.png"), tr("&Follow in Symbols"), this);
+    connect(mFollowSymbols, SIGNAL(triggered()), this, SLOT(followSymbolsSlot()));
+
     //Set PageMemory Rights
     mPageMemoryRights = new QAction(DIcon("memmap_set_page_memory_rights.png"), tr("Set Page Memory Rights"), this);
     connect(mPageMemoryRights, SIGNAL(triggered()), this, SLOT(pageMemoryRights()));
@@ -205,9 +209,16 @@ void MemoryMapView::contextMenuSlot(const QPoint & pos)
 {
     if(!DbgIsDebugging())
         return;
+
+    duint selectedAddr = getCellUserdata(getInitialSelection(), 0);
+
     QMenu wMenu(this); //create context menu
     wMenu.addAction(mFollowDisassembly);
     wMenu.addAction(mFollowDump);
+
+    if(DbgFunctions()->ModBaseFromAddr(selectedAddr))
+        wMenu.addAction(mFollowSymbols);
+
     wMenu.addAction(mDumpMemory);
     //wMenu.addAction(mLoadMemory); //TODO:loaddata command
     wMenu.addAction(mComment);
@@ -235,7 +246,6 @@ void MemoryMapView::contextMenuSlot(const QPoint & pos)
         wMenu.addMenu(&wCopyMenu);
     }
 
-    duint selectedAddr = getCellUserdata(getInitialSelection(), 0);
     if((DbgGetBpxTypeAt(selectedAddr) & bp_memory) == bp_memory) //memory breakpoint set
     {
         mMemoryAccessMenu->menuAction()->setVisible(false);
@@ -472,6 +482,11 @@ void MemoryMapView::followDumpSlot()
 void MemoryMapView::followDisassemblerSlot()
 {
     DbgCmdExec(QString("disasm %1").arg(getCellContent(getInitialSelection(), 0)));
+}
+
+void MemoryMapView::followSymbolsSlot()
+{
+    DbgCmdExec(QString("symfollow %1").arg(getCellContent(getInitialSelection(), 0)));
 }
 
 void MemoryMapView::doubleClickedSlot()

--- a/src/gui/Src/Gui/MemoryMapView.h
+++ b/src/gui/Src/Gui/MemoryMapView.h
@@ -21,6 +21,7 @@ public slots:
     void stateChangedSlot(DBGSTATE state);
     void followDumpSlot();
     void followDisassemblerSlot();
+    void followSymbolsSlot();
     void doubleClickedSlot();
     void memoryExecuteSingleshootToggleSlot();
     void memoryAllocateSlot();
@@ -49,6 +50,7 @@ private:
 
     QAction* mFollowDump;
     QAction* mFollowDisassembly;
+    QAction* mFollowSymbols;
     QAction* mSwitchView;
     QAction* mPageMemoryRights;
     QAction* mDumpMemory;


### PR DESCRIPTION
-Added new command "symfollow" to follow base address in the symbols tab (not sure if this is good idea)
-Implemented feature suggested in #2515 - added "Follow in symbols" to Memory Map context menu