### PR TITLE
Don't delete 'unknown exceptions' filter in settings dialog

### DIFF
--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -536,7 +536,7 @@ void SettingsDialog::AddExceptionFilterToList(ExceptionFilter filter)
     unsigned long start = filter.range.start;
     unsigned long end = filter.range.end;
 
-    for(int i = settings.exceptionFilters->size() - 1; i > -1; i--)
+    for(int i = settings.exceptionFilters->size() - 1; i > 0; i--)
     {
         unsigned long curStart = settings.exceptionFilters->at(i).range.start;
         unsigned long curEnd = settings.exceptionFilters->at(i).range.end;


### PR DESCRIPTION
What happens: the 'unknown exceptions' filter. which is a special filter that is not supposed to be deletable in settings, can be accidentally deleted. This was reported to me by someone who added an exception filter for `00000000-FFFFFFFF`, but adding any filter that includes 0 in its range will cause this. The result is a broken settings dialog that will stay broken even if x64dbg is restarted, because the invalid list will be persisted in the INI.

Cause of above is an off-by-one error; this PR fixes it.

Related (maybe, the issue is not overly descriptive but it seems to match): closes #2708