### PR TITLE
More detailed description of menu actions in status bar

### DIFF
--- a/src/gui/Src/Gui/LogStatusLabel.cpp
+++ b/src/gui/Src/Gui/LogStatusLabel.cpp
@@ -1,6 +1,7 @@
 #include "LogStatusLabel.h"
 #include <QTextDocument>
 #include <QApplication>
+#include <QStatusBar>
 
 LogStatusLabel::LogStatusLabel(QStatusBar* parent) : QLabel(parent)
 {
@@ -20,7 +21,6 @@ void LogStatusLabel::logUpdate(QString message)
     labelText += message.replace("\r\n", "\n");
     QStringList lineList = labelText.split('\n');
     labelText = lineList.last(); //if the last character is a newline this will be an empty string
-    QString finalLabel;
     for(int i = 0; i < lineList.length(); i++)
     {
         const QString & line = lineList[lineList.size() - i - 1];
@@ -78,4 +78,15 @@ void LogStatusLabel::getActiveView(ACTIVEVIEW* active)
     strncpy_s(active->title, findTitle(now, active->titleHwnd).toUtf8().constData(), _TRUNCATE);
     strncpy_s(active->className, className(now, active->classHwnd).toUtf8().constData(), _TRUNCATE);
     Bridge::getBridge()->setResult(BridgeResult::GetActiveView);
+}
+
+void LogStatusLabel::showMessage(const QString & message)
+{
+    statusTip = message;
+    if(statusTip.isEmpty())
+        setText(finalLabel);
+    else
+    {
+        setText(statusTip);
+    }
 }

--- a/src/gui/Src/Gui/LogStatusLabel.h
+++ b/src/gui/Src/Gui/LogStatusLabel.h
@@ -2,8 +2,9 @@
 #define LOGSTATUSLABEL_H
 
 #include <QLabel>
-#include <QStatusBar>
 #include "Bridge.h"
+
+class QStatusBar;
 
 class LogStatusLabel : public QLabel
 {
@@ -16,9 +17,13 @@ public slots:
     void logUpdateUtf8(QByteArray message);
     void focusChanged(QWidget* old, QWidget* now);
     void getActiveView(ACTIVEVIEW* active);
+    // show status tip
+    void showMessage(const QString & message);
 
 private:
+    QString finalLabel;
     QString labelText;
+    QString statusTip;
 };
 
 #endif // LOGSTATUSLABEL_H

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include <QFileDialog>
 #include <QMimeData>
 #include <QDesktopServices>
+#include <QStatusTipEvent>
 #include "Configuration.h"
 #include "SettingsDialog.h"
 #include "AppearanceDialog.h"
@@ -1078,6 +1079,12 @@ bool MainWindow::event(QEvent* event)
     {
         mTabWidget->setCurrentIndex(mTabWidget->currentIndex());
     }
+    else if(event->type() == QEvent::StatusTip)
+    {
+        QStatusTipEvent* tip = dynamic_cast<QStatusTipEvent*>(event);
+        mLastLogLabel->showMessage(tip->tip());
+        return true;
+    }
 
     return QMainWindow::event(event);
 }
@@ -2064,7 +2071,7 @@ void MainWindow::clickFavouriteTool()
             auto format = toolPath.mid(sfStart + 2, sfEnd - sfStart - 2);
             toolPath.replace(sfStart, sfEnd - sfStart + 2, stringFormatInline(format));
         }
-        mLastLogLabel->setText(toolPath);
+        GuiAddLogMessage(tr("Starting tool %1\n").arg(toolPath).toUtf8().constData());
         PROCESS_INFORMATION procinfo;
         STARTUPINFO startupinfo;
         memset(&procinfo, 0, sizeof(PROCESS_INFORMATION));
@@ -2104,6 +2111,7 @@ void MainWindow::chooseLanguage()
     {
         QDir translationsDir(QString("%1/../translations/").arg(QCoreApplication::applicationDirPath()));
         QFile file(translationsDir.absoluteFilePath(QString("x64dbg_%1.qm").arg(localeName)));
+        // A translation file less than 0.5KB is probably not useful
         if(file.size() < 512)
         {
             QMessageBox msg(this);
@@ -2369,6 +2377,11 @@ void MainWindow::on_actionDefaultTheme_triggered()
     // Remove custom colors
     BridgeSettingSet("Colors", "CustomColorCount", nullptr);
     updateDarkTitleBar();
+}
+
+void MainWindow::on_actionAbout_Qt_triggered()
+{
+    QMessageBox::aboutQt(this);
 }
 
 void MainWindow::updateStyle()

--- a/src/gui/Src/Gui/MainWindow.h
+++ b/src/gui/Src/Gui/MainWindow.h
@@ -287,6 +287,7 @@ private slots:
     void on_actionPlugins_triggered();
     void on_actionCheckUpdates_triggered();
     void on_actionDefaultTheme_triggered();
+    void on_actionAbout_Qt_triggered();
 };
 
 #endif // MAINWINDOW_H

--- a/src/gui/Src/Gui/MainWindow.ui
+++ b/src/gui/Src/Gui/MainWindow.ui
@@ -159,6 +159,7 @@
     <addaction name="actionManual"/>
     <addaction name="actionFaq"/>
     <addaction name="actionAbout"/>
+    <addaction name="actionAbout_Qt"/>
     <addaction name="separator"/>
     <addaction name="actionCrashDump"/>
    </widget>
@@ -316,6 +317,9 @@
    <property name="text">
     <string>&amp;Open</string>
    </property>
+   <property name="statusTip">
+    <string>Run the file and start debugging.</string>
+   </property>
   </action>
   <action name="actionExit">
    <property name="icon">
@@ -351,6 +355,9 @@
    </property>
    <property name="text">
     <string>Re&amp;start</string>
+   </property>
+   <property name="statusTip">
+    <string>Stop the debuggee and restart it, or restart the last debugged file.</string>
    </property>
   </action>
   <action name="actionClose">
@@ -1261,6 +1268,14 @@
    </property>
    <property name="text">
     <string>&amp;Clear database</string>
+   </property>
+  </action>
+  <action name="actionAbout_Qt">
+   <property name="text">
+    <string>About Qt</string>
+   </property>
+   <property name="statusTip">
+    <string>Display information about Qt</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This change allows more detailed description of each menu action to be shown in the status bar to help users understand what that action will do more precisely.
Currently the detailed description is available for only 3 menu actions for testing. The next step is to write these descriptions for more menu actions!
This change also adds "About Qt" in the help menu.