### PR TITLE
Increase `MAX_LABEL_SIZE` which is way too small

### DIFF
--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -56,7 +56,7 @@ BRIDGE_IMPEXP bool BridgeSettingRead(int* errorLine);
 BRIDGE_IMPEXP int BridgeGetDbgVersion();
 
 //Debugger defines
-#define MAX_LABEL_SIZE 256
+#define MAX_LABEL_SIZE 2048
 #define MAX_COMMENT_SIZE 512
 #define MAX_MODULE_SIZE 256
 #define MAX_BREAKPOINT_SIZE 256


### PR DESCRIPTION
I had to debug a XAML, heavy C++ templated program, and symbol labels for it are way way larger than 256 characters.
Example (not fun):
`public: virtual int __cdecl winrt::impl::produce_base<class VectorBase<struct winrt::Windows::UI::Composition::Interactions::InteractionTrackerInertiaModifier,1,0,1,0,struct VectorOptions<struct winrt::Windows::UI::Composition::Interactions::InteractionTrackerInertiaModifier,1,0,1,0> >,struct winrt::Windows::Foundation::Collections::IIterable<struct winrt::Windows::UI::Composition::Interactions::InteractionTrackerInertiaModifier>,void>::GetTrustLevel(enum winrt::Windows::Foundation::TrustLevel * __ptr64) __ptr64`

Ghidra uses a limit of 2000 ([source](https://github.com/NationalSecurityAgency/ghidra/issues/2470#issuecomment-728176069)), which is much much better than 256 which is not enough for many symbols in this kind of code.