### PR TITLE
Fix the enter key on the keypad not working in CPUStack widget

### DIFF
--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -647,7 +647,7 @@ void AbstractTableView::leaveEvent(QEvent* event)
 void AbstractTableView::keyPressEvent(QKeyEvent* event)
 {
     int wKey = event->key();
-    if(event->modifiers())
+    if(event->modifiers() && event->modifiers() != Qt::KeypadModifier)
         return;
 
     if(wKey == Qt::Key_Up)

--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -647,7 +647,7 @@ void AbstractTableView::leaveEvent(QEvent* event)
 void AbstractTableView::keyPressEvent(QKeyEvent* event)
 {
     int wKey = event->key();
-    if(event->modifiers() && event->modifiers() != Qt::KeypadModifier)
+    if(event->modifiers() != Qt::NoModifier && event->modifiers() != Qt::KeypadModifier)
         return;
 
     if(wKey == Qt::Key_Up)

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -565,7 +565,7 @@ void HexDump::keyPressEvent(QKeyEvent* event)
             break;
         }
     }
-    if(modifiers == 0) //No modifier
+    if(modifiers == Qt::NoModifier)
     {
         //selStart -= selStart % granularity; //Align the selection to word boundary. TODO: Unaligned data?
         switch(key)
@@ -634,6 +634,8 @@ void HexDump::keyPressEvent(QKeyEvent* event)
             action = 0;
             verticalScrollBar()->triggerAction(QAbstractSlider::SliderSingleStepAdd);
             break;
+        default:
+            AbstractTableView::keyPressEvent(event);
         }
         if(action != 0)
         {
@@ -642,9 +644,9 @@ void HexDump::keyPressEvent(QKeyEvent* event)
                 printDumpAt(offsetVa, false);
         }
     }
-    else if(modifiers == Qt::ShiftModifier)
+    else
     {
-        //TODO
+        AbstractTableView::keyPressEvent(event);
     }
     /*
         Let's keep the old code for a while until nobody remembers previous behaviour.

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -644,9 +644,9 @@ void HexDump::keyPressEvent(QKeyEvent* event)
                 printDumpAt(offsetVa, false);
         }
     }
-    else
+    else if(modifiers == Qt::ShiftModifier)
     {
-        AbstractTableView::keyPressEvent(event);
+        //TODO
     }
     /*
         Let's keep the old code for a while until nobody remembers previous behaviour.


### PR DESCRIPTION
The built-in "enter" shortcut of the CPUStack widget only works with Qt::Key_Return, and doesn't work with Qt::Key_Enter, both should work.