### PR TITLE
added some C++ datatypes to HexEditDialog

### DIFF
--- a/src/gui/Src/Gui/HexEditDialog.cpp
+++ b/src/gui/Src/Gui/HexEditDialog.cpp
@@ -57,7 +57,7 @@ HexEditDialog::HexEditDialog(QWidget* parent) : QDialog(parent), ui(new Ui::HexE
     mTypes[DataCString] = FormatType { tr("C-Style String"), 1 };
     mTypes[DataCUnicodeString] = FormatType { tr("C-Style Unicode String"), 1 };
     mTypes[DataCShellcodeString] = FormatType { tr("C-Style Shellcode String"), 1 };
-    mTypes[DataCppString] = FormatType { tr("C++-Style String"), 16 };
+    mTypes[DataCppString] = FormatType { tr("C++-Style String"), 1 };
     mTypes[DataCppCharVector] = FormatType { tr("C++-Style Char Vector (Hex)"), 16 };
     mTypes[DataASMByte] = FormatType { tr("ASM-Style BYTE (Hex)"), 16 };
     mTypes[DataASMWord] = FormatType { tr("ASM-Style WORD (Hex)"), 12 };

--- a/src/gui/Src/Gui/HexEditDialog.cpp
+++ b/src/gui/Src/Gui/HexEditDialog.cpp
@@ -57,6 +57,8 @@ HexEditDialog::HexEditDialog(QWidget* parent) : QDialog(parent), ui(new Ui::HexE
     mTypes[DataCString] = FormatType { tr("C-Style String"), 1 };
     mTypes[DataCUnicodeString] = FormatType { tr("C-Style Unicode String"), 1 };
     mTypes[DataCShellcodeString] = FormatType { tr("C-Style Shellcode String"), 1 };
+    mTypes[DataCppString] = FormatType { tr("C++-Style String"), 16 };
+    mTypes[DataCppCharVector] = FormatType { tr("C++-Style Char Vector (Hex)"), 16 };
     mTypes[DataASMByte] = FormatType { tr("ASM-Style BYTE (Hex)"), 16 };
     mTypes[DataASMWord] = FormatType { tr("ASM-Style WORD (Hex)"), 12 };
     mTypes[DataASMDWord] = FormatType { tr("ASM-Style DWORD (Hex)"), 8 };
@@ -511,6 +513,27 @@ void HexEditDialog::printData(DataType type)
             data += QString().sprintf("\\x%02X", ch);
         }
         data += "\"";
+    }
+    break;
+
+    case DataCppString:
+    {
+        data += "\"";
+        for(int i = 0; i < mData.size(); i++)
+        {
+            byte_t ch = mData.at(i);
+            data += QString().sprintf("\\\\x%02X", ch);
+        }
+        data += "\"";
+    }
+    break;
+
+    case DataCppCharVector:
+    {
+        data = "{\n" + formatLoop<unsigned char>(mData, mTypes[mIndex].itemsPerLine, [](unsigned char n)
+        {
+            return QString().sprintf("\'\\x%02X\'", n);
+        }) + "\n};";
     }
     break;
 

--- a/src/gui/Src/Gui/HexEditDialog.h
+++ b/src/gui/Src/Gui/HexEditDialog.h
@@ -66,6 +66,8 @@ private:
         DataCString,
         DataCUnicodeString,
         DataCShellcodeString,
+        DataCppString,
+        DataCppCharVector,
         DataASMByte,
         DataASMWord,
         DataASMDWord,


### PR DESCRIPTION
Dear x64dbg team,

I've just added two new datatypes to the HexEditDialog,
std::string = "\\x90\\x90"
std::vector<char> = { '\x90', '\x90' }

Why?
I'm currently writing a cpp application and wanted to go away from these old C-datatypes (eg. char *) and use some modern things. I'm not a professional coder so I read much things on the web. Most people say that std::vector is commonly used as a flexible data storage. So I think that adding std::string and std::vector<char> could be useful for someone.