### PR TITLE
AssembleDialog - OpCode to newline

### DIFF
--- a/src/gui/Src/Gui/AssembleDialog.cpp
+++ b/src/gui/Src/Gui/AssembleDialog.cpp
@@ -137,7 +137,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         {
             QString message = tr("<font color='red'><b>Instruction bigger by %1 %2...</b></font>")
                               .arg(sizeDifference)
-                              .arg(sizeDifference == 1 ? tr("byte") : tr("bytes")).append(data);
+                              .arg(sizeDifference == 1 ? tr("byte") : tr("bytes")).append("<br>OpCode: " + data);
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(false);
@@ -147,7 +147,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         {
             QString message = tr("<font color='#00cc00'><b>Instruction smaller by %1 %2...</b></font>")
                               .arg(-sizeDifference)
-                              .arg(sizeDifference == -1 ? tr("byte") : tr("bytes")).append(data);
+                              .arg(sizeDifference == -1 ? tr("byte") : tr("bytes")).append("<br>OpCode: " + data);
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(true);
@@ -155,7 +155,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         // SizeDifference == 0 <=> Both instruction have same size
         else
         {
-            QString message = tr("<font color='#00cc00'><b>Instruction is same size!</b></font>").append(data);
+            QString message = tr("<font color='#00cc00'><b>Instruction is same size!</b></font>").append("<br>OpCode: " + data);
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(true);
@@ -163,7 +163,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
     }
     else
     {
-        QString message = tr("<font color='#00cc00'><b>Instruction encoded successfully!</b></font>").append(data);
+        QString message = tr("<font color='#00cc00'><b>Instruction encoded successfully!</b></font>").append("<br>OpCode: " + data);
 
         setKeepSizeLabel(message);
         setOkButtonEnabled(true);

--- a/src/gui/Src/Gui/AssembleDialog.cpp
+++ b/src/gui/Src/Gui/AssembleDialog.cpp
@@ -137,7 +137,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         {
             QString message = tr("<font color='red'><b>Instruction bigger by %1 %2...</b></font>")
                               .arg(sizeDifference)
-                              .arg(sizeDifference == 1 ? tr("byte") : tr("bytes")).append("<br>OpCode: " + data);
+                              .arg(sizeDifference == 1 ? tr("byte") : tr("bytes")).append(tr("<br>Bytes: %1").arg(data));
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(false);
@@ -147,7 +147,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         {
             QString message = tr("<font color='#00cc00'><b>Instruction smaller by %1 %2...</b></font>")
                               .arg(-sizeDifference)
-                              .arg(sizeDifference == -1 ? tr("byte") : tr("bytes")).append("<br>OpCode: " + data);
+                              .arg(sizeDifference == -1 ? tr("byte") : tr("bytes")).append(tr("<br>Bytes: %1").arg(data));
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(true);
@@ -155,7 +155,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         // SizeDifference == 0 <=> Both instruction have same size
         else
         {
-            QString message = tr("<font color='#00cc00'><b>Instruction is same size!</b></font>").append("<br>OpCode: " + data);
+            QString message = tr("<font color='#00cc00'><b>Instruction is same size!</b></font>").append(tr("<br>Bytes: %1").arg(data));
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(true);
@@ -163,7 +163,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
     }
     else
     {
-        QString message = tr("<font color='#00cc00'><b>Instruction encoded successfully!</b></font>").append("<br>OpCode: " + data);
+        QString message = tr("<font color='#00cc00'><b>Instruction encoded successfully!</b></font>").append(tr("<br>Bytes: %1").arg(data));
 
         setKeepSizeLabel(message);
         setOkButtonEnabled(true);

--- a/src/gui/Src/Gui/AssembleDialog.ui
+++ b/src/gui/Src/Gui/AssembleDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>526</width>
-    <height>86</height>
+    <height>96</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
Just a small code change to set the OpCode at the AssembleDialog to a newline. In my opinion it looks a bit squeezed now.
Thanks to torusrxxx for implementing this feature, it's really neat.

before:
![grafik](https://user-images.githubusercontent.com/8084390/150006120-4b771cb8-769d-465d-90c7-0a5c9327fd70.png)

after:
![grafik](https://user-images.githubusercontent.com/8084390/150006146-1ef6ed80-3bbe-49a8-b3aa-4e8b7845e262.png)
