### PR TITLE
Extra Log method for HTML

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1130,6 +1130,11 @@ BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg)
     _gui_sendmessage(GUI_ADD_MSG_TO_LOG, (void*)msg, 0);
 }
 
+BRIDGE_IMPEXP void GuiAddLogMessageHtml(const char* msg)
+{
+    _gui_sendmessage(GUI_ADD_MSG_TO_LOG_HTML, (void*)msg, 0);
+}
+
 BRIDGE_IMPEXP void GuiLogClear()
 {
     _gui_sendmessage(GUI_CLEAR_LOG, 0, 0);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1089,6 +1089,7 @@ typedef enum
     GUI_DISASSEMBLE_AT,             // param1=(duint)va,            param2=(duint)cip
     GUI_SET_DEBUG_STATE,            // param1=(DBGSTATE)state,      param2=unused
     GUI_ADD_MSG_TO_LOG,             // param1=(const char*)msg,     param2=unused
+    GUI_ADD_MSG_TO_LOG_HTML,        // param1=(const char*)msg,     param2=unused
     GUI_CLEAR_LOG,                  // param1=unused,               param2=unused
     GUI_UPDATE_REGISTER_VIEW,       // param1=unused,               param2=unused
     GUI_UPDATE_DISASSEMBLY_VIEW,    // param1=unused,               param2=unused
@@ -1265,6 +1266,7 @@ BRIDGE_IMPEXP void GuiDisasmAt(duint addr, duint cip);
 BRIDGE_IMPEXP void GuiSetDebugState(DBGSTATE state);
 BRIDGE_IMPEXP void GuiSetDebugStateFast(DBGSTATE state);
 BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg);
+BRIDGE_IMPEXP void GuiAddLogMessageHtml(const char* msg);
 BRIDGE_IMPEXP void GuiLogClear();
 BRIDGE_IMPEXP void GuiUpdateAllViews();
 BRIDGE_IMPEXP void GuiUpdateRegisterView();

--- a/src/dbg/_plugins.cpp
+++ b/src/dbg/_plugins.cpp
@@ -41,6 +41,15 @@ PLUG_IMPEXP void _plugin_logprintf(const char* format, ...)
     va_end(args);
 }
 
+PLUG_IMPEXP void _plugin_logprintf_html(const char* format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    dprintf_args_untranslated_html(format, args);
+    va_end(args);
+}
+
 PLUG_IMPEXP void _plugin_logputs(const char* text)
 {
     dputs_untranslated(text);

--- a/src/dbg/_plugins.cpp
+++ b/src/dbg/_plugins.cpp
@@ -41,13 +41,9 @@ PLUG_IMPEXP void _plugin_logprintf(const char* format, ...)
     va_end(args);
 }
 
-PLUG_IMPEXP void _plugin_logprintf_html(const char* format, ...)
+PLUG_IMPEXP void _plugin_lograw_html(const char* text)
 {
-    va_list args;
-
-    va_start(args, format);
-    dprintf_args_untranslated_html(format, args);
-    va_end(args);
+    dputs_untranslated_html(text);
 }
 
 PLUG_IMPEXP void _plugin_logputs(const char* text)

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -322,7 +322,7 @@ PLUG_IMPEXP bool _plugin_unregistercallback(int pluginHandle, CBTYPE cbType);
 PLUG_IMPEXP bool _plugin_registercommand(int pluginHandle, const char* command, CBPLUGINCOMMAND cbCommand, bool debugonly);
 PLUG_IMPEXP bool _plugin_unregistercommand(int pluginHandle, const char* command);
 PLUG_IMPEXP void _plugin_logprintf(const char* format, ...);
-PLUG_IMPEXP void _plugin_logprintf_html(const char* format, ...);
+PLUG_IMPEXP void _plugin_lograw_html(const char* text);
 PLUG_IMPEXP void _plugin_logputs(const char* text);
 PLUG_IMPEXP void _plugin_logprint(const char* text);
 PLUG_IMPEXP void _plugin_debugpause();

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -322,6 +322,7 @@ PLUG_IMPEXP bool _plugin_unregistercallback(int pluginHandle, CBTYPE cbType);
 PLUG_IMPEXP bool _plugin_registercommand(int pluginHandle, const char* command, CBPLUGINCOMMAND cbCommand, bool debugonly);
 PLUG_IMPEXP bool _plugin_unregistercommand(int pluginHandle, const char* command);
 PLUG_IMPEXP void _plugin_logprintf(const char* format, ...);
+PLUG_IMPEXP void _plugin_logprintf_html(const char* format, ...);
 PLUG_IMPEXP void _plugin_logputs(const char* text);
 PLUG_IMPEXP void _plugin_logprint(const char* text);
 PLUG_IMPEXP void _plugin_debugpause();

--- a/src/dbg/console.cpp
+++ b/src/dbg/console.cpp
@@ -15,6 +15,15 @@ static void GuiAddLogMessageAsync(_In_z_ const char* msg)
     task.WakeUp(msg);
 }
 
+static void GuiAddLogMessageHtmlAsync(_In_z_ const char* msg)
+{
+    static StringConcatTaskThread_<void(*)(const std::string &)> task([](const std::string & msg)
+    {
+        GuiAddLogMessageHtml(msg.c_str());
+    });
+    task.WakeUp(msg);
+}
+
 /**
 \brief Print a line with text, terminated with a newline to the console.
 \param text The text to print.
@@ -101,4 +110,16 @@ void dprintf_args_untranslated(_In_z_ _Printf_format_string_ const char* Format,
     vsnprintf_s(buffer, _TRUNCATE, Format, Args);
 
     GuiAddLogMessageAsync(buffer);
+}
+/**
+\brief Print a html formatted string to the console.
+\param format The printf format to use (see documentation of printf for more information).
+\param Args The argument buffer passed to the string parser.
+*/
+void dprintf_args_untranslated_html(_In_z_ _Printf_format_string_ const char* Format, va_list Args)
+{
+    char buffer[16384];
+    vsnprintf_s(buffer, _TRUNCATE, Format, Args);
+
+    GuiAddLogMessageHtmlAsync(buffer);
 }

--- a/src/dbg/console.cpp
+++ b/src/dbg/console.cpp
@@ -112,14 +112,10 @@ void dprintf_args_untranslated(_In_z_ _Printf_format_string_ const char* Format,
     GuiAddLogMessageAsync(buffer);
 }
 /**
-\brief Print a html formatted string to the console.
-\param format The printf format to use (see documentation of printf for more information).
-\param Args The argument buffer passed to the string parser.
+\brief Print a html string to the console.
+\param Text The message to use.
 */
-void dprintf_args_untranslated_html(_In_z_ _Printf_format_string_ const char* Format, va_list Args)
+void dputs_untranslated_html(_In_z_ _Printf_format_string_ const char* Text)
 {
-    char buffer[16384];
-    vsnprintf_s(buffer, _TRUNCATE, Format, Args);
-
-    GuiAddLogMessageHtmlAsync(buffer);
+    GuiAddLogMessageHtmlAsync(Text);
 }

--- a/src/dbg/console.h
+++ b/src/dbg/console.h
@@ -9,5 +9,6 @@ void dprintf_args(_In_z_ _Printf_format_string_ const char* Format, va_list Args
 void dputs_untranslated(_In_z_ const char* Text);
 void dprintf_untranslated(_In_z_ _Printf_format_string_ const char* Format, ...);
 void dprintf_args_untranslated(_In_z_ _Printf_format_string_ const char* Format, va_list Args);
+void dprintf_args_untranslated_html(_In_z_ _Printf_format_string_ const char* Format, va_list Args);
 
 #endif // _CONSOLE_H

--- a/src/dbg/console.h
+++ b/src/dbg/console.h
@@ -9,6 +9,6 @@ void dprintf_args(_In_z_ _Printf_format_string_ const char* Format, va_list Args
 void dputs_untranslated(_In_z_ const char* Text);
 void dprintf_untranslated(_In_z_ _Printf_format_string_ const char* Format, ...);
 void dprintf_args_untranslated(_In_z_ _Printf_format_string_ const char* Format, va_list Args);
-void dprintf_args_untranslated_html(_In_z_ _Printf_format_string_ const char* Format, va_list Args);
+void dputs_untranslated_html(_In_z_ _Printf_format_string_ const char* Text);
 
 #endif // _CONSOLE_H

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -116,6 +116,13 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
     }
     break;
 
+    case GUI_ADD_MSG_TO_LOG_HTML:
+    {
+        auto msg = (const char*)param1;
+        emit addMsgToLogHtml(QByteArray(msg, int(strlen(msg)) + 1)); //Speed up performance: don't convert to UCS-2 QString
+    }
+    break;
+
     case GUI_CLEAR_LOG:
         emit clearLog();
         break;

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -50,6 +50,7 @@ signals:
     void updateDisassembly();
     void dbgStateChanged(DBGSTATE state);
     void addMsgToLog(QByteArray msg);
+    void addMsgToLogHtml(QByteArray msg);
     void clearLog();
     void close();
     void updateRegisters();

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -36,6 +36,7 @@ LogView::LogView(QWidget* parent) : QTextBrowser(parent), logRedirection(NULL)
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(updateStyle()));
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(updateStyle()));
     connect(Bridge::getBridge(), SIGNAL(addMsgToLog(QByteArray)), this, SLOT(addMsgToLogSlot(QByteArray)));
+    connect(Bridge::getBridge(), SIGNAL(addMsgToLogHtml(QByteArray)), this, SLOT(addMsgToLogSlotHtml(QByteArray)));
     connect(Bridge::getBridge(), SIGNAL(clearLog()), this, SLOT(clearLogSlot()));
     connect(Bridge::getBridge(), SIGNAL(setLogEnabled(bool)), this, SLOT(setLoggingEnabled(bool)));
     connect(Bridge::getBridge(), SIGNAL(flushLog()), this, SLOT(flushLogSlot()));
@@ -180,29 +181,36 @@ static void linkify(QString & msg)
 }
 
 /**
-* @brief Color message where applicable via HTML.
-* @param msg The message passed by reference.
+* @brief LogView::addMsgToLogSlotHtml Adds a HTML message to the log view. This function is a slot for Bridge::addMsgToLogHtml.
+* @param msg The log message (Which is assumed to contain HTML)
 */
-static QRegularExpression colourRegExp("\\[color@([#0-9A-Za-z]+)\\]");
-static QRegularExpression colourEndRegExp("\\[stopcolor\\]");
-static void colorize(QString & msg)
+void LogView::addMsgToLogSlotHtml(QByteArray msg)
 {
-    msg.replace(colourRegExp, "<span style=\"color:\\1;\">");
-    msg.replace(colourEndRegExp, "</span>");
+    LogView::addMsgToLogSlotRaw(msg, false);
 }
 
 /**
- * @brief LogView::addMsgToLogSlot Adds a message to the log view. This function is a slot for Bridge::addMsgToLog.
- * @param msg The log message
- */
+* @brief LogView::addMsgToLogSlot Adds a message to the log view. This function is a slot for Bridge::addMsgToLog.
+* @param msg The log message
+*/
 void LogView::addMsgToLogSlot(QByteArray msg)
 {
+    LogView::addMsgToLogSlotRaw(msg, true);
+}
+
+/**
+ * @brief LogView::addMsgToLogSlotRaw Adds a message to the log view.
+ * @param msg The log message
+ * @param encodeHTML HTML-encode the log message or not
+ */
+void LogView::addMsgToLogSlotRaw(QByteArray msg, bool encodeHTML)
+{
     /*
-     * This supports the 'UTF-8 Everywhere' manifesto.
-     * - UTF-8 (http://utf8everywhere.org);
-     * - No BOM (http://utf8everywhere.org/#faq.boms);
-     * - No carriage return (http://utf8everywhere.org/#faq.crlf).
-     */
+    * This supports the 'UTF-8 Everywhere' manifesto.
+    * - UTF-8 (http://utf8everywhere.org);
+    * - No BOM (http://utf8everywhere.org/#faq.boms);
+    * - No carriage return (http://utf8everywhere.org/#faq.crlf).
+    */
 
     // fix Unix-style line endings.
     // redirect the log
@@ -227,7 +235,7 @@ void LogView::addMsgToLogSlot(QByteArray msg)
             std::string temp;
             size_t offset = 0;
             size_t buffersize = 0;
-            if(strstr(msg.constData(), "\r\n") != nullptr) // Don't replace "\r\n" to "\n" if there is none
+            if(strstr(msg.constData(), "\r\n") != nullptr)  // Don't replace "\r\n" to "\n" if there is none
             {
                 temp = msg.constData();
                 while(true)
@@ -256,12 +264,20 @@ void LogView::addMsgToLogSlot(QByteArray msg)
                 msgUtf16 = QString::fromUtf8(data, int(buffersize));
         }
     }
-    else
-        msgUtf16 = QString::fromUtf8(msg);
+    else msgUtf16 = QString::fromUtf8(msg);
+
     if(!loggingEnabled)
         return;
-    msgUtf16 = msgUtf16.toHtmlEscaped();
-    msgUtf16.replace(QChar(' '), QString("&nbsp;"));
+
+    if(encodeHTML)
+    {
+        msgUtf16 = msgUtf16.toHtmlEscaped();
+        /* Below line will break HTML tags with spaces separating the HTML tag name and attributes.
+            ie <a href="aaaa"> -> <a&nbsp;href="aaaa">
+            so we don't escape spaces where we deliberately passed in HTML.
+        */
+        msgUtf16.replace(QChar(' '), QString("&nbsp;"));
+    }
     if(logRedirection)
     {
         if(utf16Redirect)
@@ -274,8 +290,13 @@ void LogView::addMsgToLogSlot(QByteArray msg)
         msgUtf16.replace(QChar('\n'), QString("<br/>\n"));
         msgUtf16.replace(QString("\r\n"), QString("<br/>\n"));
     }
-    linkify(msgUtf16);
-    colorize(msgUtf16);
+    if(encodeHTML)
+    {
+        /* If we passed in non-html log string, we look for address links.
+        * otherwise, if our HTML contains any address-looking word, ie in our CSS, it would be mangled
+        * linking to addresses when passing in HTML log message is an exercise left to the plugin developer */
+        linkify(msgUtf16);
+    }
 
     if(redirectError)
         msgUtf16.append(tr("fwrite() failed (GetLastError()= %1 ). Log redirection stopped.\n").arg(GetLastError()));

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -180,6 +180,18 @@ static void linkify(QString & msg)
 }
 
 /**
+* @brief Color message where applicable via HTML.
+* @param msg The message passed by reference.
+*/
+static QRegularExpression colourRegExp("\\[color@([#0-9A-Za-z]+)\\]");
+static QRegularExpression colourEndRegExp("\\[stopcolor\\]");
+static void colorize(QString & msg)
+{
+    msg.replace(colourRegExp, "<span style=\"color:\\1;\">");
+    msg.replace(colourEndRegExp, "</span>");
+}
+
+/**
  * @brief LogView::addMsgToLogSlot Adds a message to the log view. This function is a slot for Bridge::addMsgToLog.
  * @param msg The log message
  */
@@ -263,6 +275,8 @@ void LogView::addMsgToLogSlot(QByteArray msg)
         msgUtf16.replace(QString("\r\n"), QString("<br/>\n"));
     }
     linkify(msgUtf16);
+    colorize(msgUtf16);
+
     if(redirectError)
         msgUtf16.append(tr("fwrite() failed (GetLastError()= %1 ). Log redirection stopped.\n").arg(GetLastError()));
 

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -17,7 +17,8 @@ public:
 public slots:
     void refreshShortcutsSlot();
     void updateStyle();
-    void addMsgToLogSlot(QByteArray msg);
+    void addMsgToLogSlot(QByteArray msg); /* Non-HTML Log Function*/
+    void addMsgToLogSlotHtml(QByteArray msg); /* HTML accepting Log Function */
     void redirectLogSlot();
     void setLoggingEnabled(bool enabled);
     void autoScrollSlot();
@@ -35,6 +36,8 @@ public slots:
 
 private:
     static const int MAX_LOG_BUFFER_SIZE = 1024 * 1024;
+
+    void addMsgToLogSlotRaw(QByteArray msg, bool htmlEscape); /* Non-HTML Log Function*/
 
     bool loggingEnabled;
     bool autoScroll;


### PR DESCRIPTION
Allow developers to add HTML to the displayed log window, for instance to highlight certain parts of the log messages.

```
Log.msg("<span style="color:red;">This message will be colored</span>);
```

Original PR;
> 
> Allow developers to add color styling to the displayed log window, to highlight certain parts of the messages.
> 
> ```
> Log.msg("[color@red] This message will be colored. [stopcolor]")
> ```
> 
> ![2022-02-12-18_36-NKtTQNO8JA](https://user-images.githubusercontent.com/1904543/153702017-c0e6ed30-b16c-4af3-b282-a204b21fb8cb.png)
> 
> 
> -----
> 
> This is probably not the syntax we would ideally want, but we cannot directly enter HTML into the log due to the escaping in LogView.cpp on line 263:
> ```   
> msgUtf16 = msgUtf16.toHtmlEscaped();
> ```
> 
> Additionally, we cannot use the `{stringformat}` syntax as described [here](https://help.x64dbg.com/en/latest/introduction/Formatting.html) as this is processed prior to the HTML escaping.
> 
> 