### PR TITLE
Copy a memory address formatted as a raw data. (edit)

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -288,13 +288,12 @@ void CPUDisassembly::setupRightClickContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("&Binary")), binaryMenu);
 
     MenuBuilder* copyMenu = new MenuBuilder(this);
-    QAction* rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     copyMenu->addAction(makeShortcutAction(DIcon("copy_selection.png"), tr("&Selection"), SLOT(copySelectionSlot()), "ActionCopy"));
     copyMenu->addAction(makeAction(DIcon("copy_selection.png"), tr("Selection to &File"), SLOT(copySelectionToFileSlot())));
     copyMenu->addAction(makeAction(DIcon("copy_selection_no_bytes.png"), tr("Selection (&No Bytes)"), SLOT(copySelectionNoBytesSlot())));
     copyMenu->addAction(makeAction(DIcon("copy_selection_no_bytes.png"), tr("Selection to File (No Bytes)"), SLOT(copySelectionToFileNoBytesSlot())));
     copyMenu->addAction(makeShortcutAction(DIcon("copy_address.png"), tr("&Address"), SLOT(copyAddressSlot()), "ActionCopyAddress"));
-    copyMenu->addAction(rawAddrAction);
+    copyMenu->addAction(makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot())));
     copyMenu->addAction(makeShortcutAction(DIcon("copy_address.png"), tr("&RVA"), SLOT(copyRvaSlot()), "ActionCopyRva"));
     copyMenu->addAction(makeShortcutAction(DIcon("fileoffset.png"), tr("&File Offset"), SLOT(copyFileOffsetSlot()), "ActionCopyFileOffset"));
     copyMenu->addAction(makeAction(tr("&Header VA"), SLOT(copyHeaderVaSlot())));

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -288,11 +288,13 @@ void CPUDisassembly::setupRightClickContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("&Binary")), binaryMenu);
 
     MenuBuilder* copyMenu = new MenuBuilder(this);
+    auto rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     copyMenu->addAction(makeShortcutAction(DIcon("copy_selection.png"), tr("&Selection"), SLOT(copySelectionSlot()), "ActionCopy"));
     copyMenu->addAction(makeAction(DIcon("copy_selection.png"), tr("Selection to &File"), SLOT(copySelectionToFileSlot())));
     copyMenu->addAction(makeAction(DIcon("copy_selection_no_bytes.png"), tr("Selection (&No Bytes)"), SLOT(copySelectionNoBytesSlot())));
     copyMenu->addAction(makeAction(DIcon("copy_selection_no_bytes.png"), tr("Selection to File (No Bytes)"), SLOT(copySelectionToFileNoBytesSlot())));
     copyMenu->addAction(makeShortcutAction(DIcon("copy_address.png"), tr("&Address"), SLOT(copyAddressSlot()), "ActionCopyAddress"));
+    copyMenu->addAction(rawAddrAction);
     copyMenu->addAction(makeShortcutAction(DIcon("copy_address.png"), tr("&RVA"), SLOT(copyRvaSlot()), "ActionCopyRva"));
     copyMenu->addAction(makeShortcutAction(DIcon("fileoffset.png"), tr("&File Offset"), SLOT(copyFileOffsetSlot()), "ActionCopyFileOffset"));
     copyMenu->addAction(makeAction(tr("&Header VA"), SLOT(copyHeaderVaSlot())));
@@ -1551,6 +1553,25 @@ void CPUDisassembly::copyAddressSlot()
         if(i)
             clipboard += "\r\n";
         clipboard += ToPtrString(rvaToVa(inst.rva));
+        return true;
+    });
+    Bridge::CopyToClipboard(clipboard);
+}
+
+void CPUDisassembly::copyRawAddressSlot()
+{
+    QString clipboard = "";
+    auto format_raw = [&] ( duint data )-> QString
+    {
+        HexEditDialog hexEdit(this);
+        hexEdit.mHexEdit->setData(QByteArray((const char*)&data, sizeof(duint) ));
+        return hexEdit.mHexEdit->pattern(true);
+    };
+    prepareDataRange(getSelectionStart(), getSelectionEnd(), [&](int i, const Instruction_t & inst)
+    {
+        if(i)
+            clipboard += "\r\n";
+        clipboard += format_raw(rvaToVa(inst.rva));
         return true;
     });
     Bridge::CopyToClipboard(clipboard);

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -288,7 +288,7 @@ void CPUDisassembly::setupRightClickContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("&Binary")), binaryMenu);
 
     MenuBuilder* copyMenu = new MenuBuilder(this);
-    auto rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
+    QAction* rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     copyMenu->addAction(makeShortcutAction(DIcon("copy_selection.png"), tr("&Selection"), SLOT(copySelectionSlot()), "ActionCopy"));
     copyMenu->addAction(makeAction(DIcon("copy_selection.png"), tr("Selection to &File"), SLOT(copySelectionToFileSlot())));
     copyMenu->addAction(makeAction(DIcon("copy_selection_no_bytes.png"), tr("Selection (&No Bytes)"), SLOT(copySelectionNoBytesSlot())));
@@ -1561,10 +1561,10 @@ void CPUDisassembly::copyAddressSlot()
 void CPUDisassembly::copyRawAddressSlot()
 {
     QString clipboard = "";
-    auto format_raw = [&] ( duint data )-> QString
+    auto format_raw = [&](const duint data) -> QString
     {
         HexEditDialog hexEdit(this);
-        hexEdit.mHexEdit->setData(QByteArray((const char*)&data, sizeof(duint) ));
+        hexEdit.mHexEdit->setData(QByteArray((const char*)&data, sizeof(duint)));
         return hexEdit.mHexEdit->pattern(true);
     };
     prepareDataRange(getSelectionStart(), getSelectionEnd(), [&](int i, const Instruction_t & inst)

--- a/src/gui/Src/Gui/CPUDisassembly.h
+++ b/src/gui/Src/Gui/CPUDisassembly.h
@@ -80,6 +80,7 @@ public slots:
     void copySelectionNoBytesSlot();
     void copySelectionToFileNoBytesSlot();
     void copyAddressSlot();
+    void copyRawAddressSlot();
     void copyRvaSlot();
     void copyFileOffsetSlot();
     void copyHeaderVaSlot();

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -63,10 +63,9 @@ void CPUDump::setupContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("B&inary")), wBinaryMenu);
 
     MenuBuilder* wCopyMenu = new MenuBuilder(this);
-    auto rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     wCopyMenu->addAction(mCopySelection);
     wCopyMenu->addAction(mCopyAddress);
-    wCopyMenu->addAction(rawAddrAction);
+    wCopyMenu->addAction(makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot())));
     wCopyMenu->addAction(mCopyRva, [this](QMenu*)
     {
         return DbgFunctions()->ModBaseFromAddr(rvaToVa(getInitialSelection())) != 0;

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -63,8 +63,10 @@ void CPUDump::setupContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("B&inary")), wBinaryMenu);
 
     MenuBuilder* wCopyMenu = new MenuBuilder(this);
+    auto rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     wCopyMenu->addAction(mCopySelection);
     wCopyMenu->addAction(mCopyAddress);
+    wCopyMenu->addAction(rawAddrAction);
     wCopyMenu->addAction(mCopyRva, [this](QMenu*)
     {
         return DbgFunctions()->ModBaseFromAddr(rvaToVa(getInitialSelection())) != 0;
@@ -1387,6 +1389,14 @@ void CPUDump::binaryCopySlot()
     mMemPage->read(data, selStart, selSize);
     hexEdit.mHexEdit->setData(QByteArray((const char*)data, selSize));
     delete [] data;
+    Bridge::CopyToClipboard(hexEdit.mHexEdit->pattern(true));
+}
+
+void CPUDump::copyRawAddressSlot()
+{
+    HexEditDialog hexEdit(this);
+    const duint addr = rvaToVa(getInitialSelection());
+    hexEdit.mHexEdit->setData(QByteArray((const char*)&addr, sizeof(duint)));
     Bridge::CopyToClipboard(hexEdit.mHexEdit->pattern(true));
 }
 

--- a/src/gui/Src/Gui/CPUDump.h
+++ b/src/gui/Src/Gui/CPUDump.h
@@ -70,6 +70,7 @@ public slots:
     void binaryEditSlot();
     void binaryFillSlot();
     void binaryCopySlot();
+    void copyRawAddressSlot();
     void binaryPasteSlot();
     void binaryPasteIgnoreSizeSlot();
     void binarySaveToFileSlot();

--- a/src/gui/Src/Gui/CPUStack.cpp
+++ b/src/gui/Src/Gui/CPUStack.cpp
@@ -120,10 +120,9 @@ void CPUStack::setupContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("B&inary")), binaryMenu);
 
     auto copyMenu = new MenuBuilder(this);
-    auto rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     copyMenu->addAction(mCopySelection);
     copyMenu->addAction(mCopyAddress);
-    copyMenu->addAction(rawAddrAction);
+    copyMenu->addAction(makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot())));
     copyMenu->addAction(mCopyRva, [this](QMenu*)
     {
         return DbgFunctions()->ModBaseFromAddr(rvaToVa(getInitialSelection())) != 0;

--- a/src/gui/Src/Gui/CPUStack.cpp
+++ b/src/gui/Src/Gui/CPUStack.cpp
@@ -120,8 +120,10 @@ void CPUStack::setupContextMenu()
     mMenuBuilder->addMenu(makeMenu(DIcon("binary.png"), tr("B&inary")), binaryMenu);
 
     auto copyMenu = new MenuBuilder(this);
+    auto rawAddrAction = makeAction(DIcon("copy_address.png"), tr("Address to pattern"), SLOT(copyRawAddressSlot()));
     copyMenu->addAction(mCopySelection);
     copyMenu->addAction(mCopyAddress);
+    copyMenu->addAction(rawAddrAction);
     copyMenu->addAction(mCopyRva, [this](QMenu*)
     {
         return DbgFunctions()->ModBaseFromAddr(rvaToVa(getInitialSelection())) != 0;
@@ -815,6 +817,14 @@ void CPUStack::binaryCopySlot()
     mMemPage->read(data, selStart, selSize);
     hexEdit.mHexEdit->setData(QByteArray((const char*)data, selSize));
     delete [] data;
+    Bridge::CopyToClipboard(hexEdit.mHexEdit->pattern(true));
+}
+
+void CPUStack::copyRawAddressSlot()
+{
+    HexEditDialog hexEdit(this);
+    const duint addr = rvaToVa(getInitialSelection());
+    hexEdit.mHexEdit->setData(QByteArray((const char*)&addr, sizeof(duint)));
     Bridge::CopyToClipboard(hexEdit.mHexEdit->pattern(true));
 }
 

--- a/src/gui/Src/Gui/CPUStack.h
+++ b/src/gui/Src/Gui/CPUStack.h
@@ -44,6 +44,7 @@ public slots:
     void binaryEditSlot();
     void binaryFillSlot();
     void binaryCopySlot();
+    void copyRawAddressSlot();
     void binaryPasteSlot();
     void findPattern();
     void binaryPasteIgnoreSizeSlot();


### PR DESCRIPTION
Implement a memory address copying in the clipboard as a raw-data format from the x64dbg's context menu.