### PR TITLE
Using SetProcessDpiAwarenessContext instead of QTAPI on Win10 above 1703

### DIFF
--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -80,7 +80,7 @@ enableHighDpiScaling()
     static HMODULE user32 = LoadLibraryW(L"user32.dll");
     if(user32)
     {
-        typedef unsigned int(WINAPI * pfnSetProcessDpiAwarenessContext)(unsigned int value);
+        typedef unsigned int(WINAPI * pfnSetProcessDpiAwarenessContext)(size_t value);
         static pfnSetProcessDpiAwarenessContext pSetProcessDpiAwarenessContext =
             (pfnSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
         if(pSetProcessDpiAwarenessContext)

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -73,8 +73,35 @@ static bool isValidLocale(const QString & locale)
     return false;
 }
 
+static void enableHighDpiScaling()
+{
+    // https://www.vergiliusproject.com/kernels/x64/Windows%2010%20%7C%202016/2009%2020H2%20(October%202020%20Update)/_KUSER_SHARED_DATA
+    uint32_t NtBuildNumber = *(uint32_t*)(0x7FFE0000 + 0x260); 
+    if(NtBuildNumber == 0 /* pre Windows-10 */ || NtBuildNumber < 15063)
+    {
+        // old windows version
+        QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    }
+    else
+    {
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext
+        static auto user32 = LoadLibraryW(L"user32.dll");
+        if(user32)
+        {
+            typedef BOOL(*pfnSetProcessDpiAwarenessContext)(int value);
+            static auto pSetProcessDpiAwarenessContext = (pfnSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+            if(pSetProcessDpiAwarenessContext)
+            {
+                pSetProcessDpiAwarenessContext(/*DPI_AWARENESS_CONTEXT_SYSTEM_AWARE*/-2);
+            }
+
+        }
+    }
+}
+
 int main(int argc, char* argv[])
 {
+    enableHighDpiScaling();
     MyApplication application(argc, argv);
     MainWindow::loadSelectedStyle(true);
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -76,7 +76,7 @@ static bool isValidLocale(const QString & locale)
 static void enableHighDpiScaling()
 {
     // https://www.vergiliusproject.com/kernels/x64/Windows%2010%20%7C%202016/2009%2020H2%20(October%202020%20Update)/_KUSER_SHARED_DATA
-    uint32_t NtBuildNumber = *(uint32_t*)(0x7FFE0000 + 0x260); 
+    unsigned int NtBuildNumber = *(unsigned int*)(0x7FFE0000 + 0x260); 
     if(NtBuildNumber == 0 /* pre Windows-10 */ || NtBuildNumber < 15063)
     {
         // old windows version
@@ -88,13 +88,12 @@ static void enableHighDpiScaling()
         static auto user32 = LoadLibraryW(L"user32.dll");
         if(user32)
         {
-            typedef BOOL(*pfnSetProcessDpiAwarenessContext)(int value);
+            typedef unsigned int(*pfnSetProcessDpiAwarenessContext)(int value);
             static auto pSetProcessDpiAwarenessContext = (pfnSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
             if(pSetProcessDpiAwarenessContext)
             {
                 pSetProcessDpiAwarenessContext(/*DPI_AWARENESS_CONTEXT_SYSTEM_AWARE*/-2);
             }
-
         }
     }
 }

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -76,7 +76,7 @@ static bool isValidLocale(const QString & locale)
 static void enableHighDpiScaling()
 {
     // https://www.vergiliusproject.com/kernels/x64/Windows%2010%20%7C%202016/2009%2020H2%20(October%202020%20Update)/_KUSER_SHARED_DATA
-    unsigned int NtBuildNumber = *(unsigned int*)(0x7FFE0000 + 0x260); 
+    unsigned int NtBuildNumber = *(unsigned int*)(0x7FFE0000 + 0x260);
     if(NtBuildNumber == 0 /* pre Windows-10 */ || NtBuildNumber < 15063)
     {
         // old windows version
@@ -92,7 +92,7 @@ static void enableHighDpiScaling()
             static pfnSetProcessDpiAwarenessContext pSetProcessDpiAwarenessContext = (pfnSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
             if(pSetProcessDpiAwarenessContext)
             {
-                pSetProcessDpiAwarenessContext(/*DPI_AWARENESS_CONTEXT_SYSTEM_AWARE*/-2);
+                pSetProcessDpiAwarenessContext(/*DPI_AWARENESS_CONTEXT_SYSTEM_AWARE*/ -2);
             }
         }
     }

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -85,11 +85,11 @@ static void enableHighDpiScaling()
     else
     {
         // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext
-        static auto user32 = LoadLibraryW(L"user32.dll");
+        static HMODULE user32 = LoadLibraryW(L"user32.dll");
         if(user32)
         {
             typedef unsigned int(*pfnSetProcessDpiAwarenessContext)(int value);
-            static auto pSetProcessDpiAwarenessContext = (pfnSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+            static pfnSetProcessDpiAwarenessContext pSetProcessDpiAwarenessContext = (pfnSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
             if(pSetProcessDpiAwarenessContext)
             {
                 pSetProcessDpiAwarenessContext(/*DPI_AWARENESS_CONTEXT_SYSTEM_AWARE*/-2);


### PR DESCRIPTION
[#2876](https://github.com/x64dbg/x64dbg/issues/2876)