### PR TITLE
Add ability to set breakpoints on multiple selected lines in the References tab

### DIFF
--- a/src/gui/Src/BasicView/ReferenceView.cpp
+++ b/src/gui/Src/BasicView/ReferenceView.cpp
@@ -11,6 +11,7 @@ ReferenceView::ReferenceView(bool sourceView, QWidget* parent) : StdSearchListVi
 {
     // Setup SearchListView settings
     mSearchStartCol = 1;
+    enableMultiSelection(true);
 
     // Widget container for progress
     QWidget* progressWidget = new QWidget(this);
@@ -317,7 +318,8 @@ void ReferenceView::toggleBreakpoint()
     if(!mCurList->getRowCount())
         return;
 
-    setBreakpointAt(mCurList->getInitialSelection(), Toggle);
+    foreach(int i, mCurList->getSelection())
+        setBreakpointAt(i, Toggle);
 }
 
 void ReferenceView::setBreakpointOnAllCommands()

--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -377,9 +377,8 @@ bool SearchListView::eventFilter(QObject* obj, QEvent* event)
         }
 
         // Printable characters go to the search box
-        QChar key = keyEvent->text().toUtf8().at(0);
-
-        if(key.isPrint())
+        QString keyText = keyEvent->text();
+        if(!keyText.isEmpty() && QChar(keyText.toUtf8().at(0)).isPrint())
             return QWidget::eventFilter(obj, event);
 
         // By default, all other keys are forwarded to the search view


### PR DESCRIPTION
issue #2589

Also I fixed array out of bounds assertion failure at this line:
https://github.com/x64dbg/x64dbg/blob/56eef9553ec2d45f45b5036078be9cff013e64df/src/gui/Src/BasicView/SearchListView.cpp#L380
Return value of `QKeyEvent::text()` can be empty string for modifier key press event (Ctrl, Shift, ...)