### PR TITLE
API GuiSetFavouriteCommandShortcut

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1665,6 +1665,11 @@ BRIDGE_IMPEXP void GuiSetFavouriteToolShortcut(const char* name, const char* sho
     _gui_sendmessage(GUI_SET_FAVOURITE_TOOL_SHORTCUT, (void*)name, (void*)shortcut);
 }
 
+BRIDGE_IMPEXP void GuiSetFavouriteCommandShortcut(const char* name, const char* shortcut)
+{
+	_gui_sendmessage(GUI_SET_FAVOURITE_COMMAND_SHORTCUT, (void*)name, (void*)shortcut);
+}
+
 BRIDGE_IMPEXP void GuiFoldDisassembly(duint startAddress, duint length)
 {
     _gui_sendmessage(GUI_FOLD_DISASSEMBLY, (void*)startAddress, (void*)length);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1199,6 +1199,7 @@ typedef enum
     GUI_GET_CURRENT_GRAPH,          // param1=BridgeCFGraphList*,   param2=unused
     GUI_SHOW_REF,                   // param1=unused,               param2=unused
     GUI_SELECT_IN_SYMBOLS_TAB,      // param1=duint addr,           param2=unused
+    GUI_SET_FAVOURITE_COMMAND_SHORTCUT,// param1=const char* name      param2=const char* shortcut
 } GUIMSG;
 
 //GUI Typedefs
@@ -1363,6 +1364,7 @@ BRIDGE_IMPEXP void GuiDisableLog();
 BRIDGE_IMPEXP void GuiEnableLog();
 BRIDGE_IMPEXP void GuiAddFavouriteTool(const char* name, const char* description);
 BRIDGE_IMPEXP void GuiAddFavouriteCommand(const char* name, const char* shortcut);
+BRIDGE_IMPEXP void GuiSetFavouriteCommandShortcut(const char* name, const char* shortcut);
 BRIDGE_IMPEXP void GuiSetFavouriteToolShortcut(const char* name, const char* shortcut);
 BRIDGE_IMPEXP void GuiFoldDisassembly(duint startAddress, duint length);
 BRIDGE_IMPEXP void GuiSelectInMemoryMap(duint addr);

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -763,6 +763,19 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
     }
     break;
 
+	case GUI_SET_FAVOURITE_COMMAND_SHORTCUT:
+	{
+		QString name;
+		QString shortcut;
+		if (param1 == nullptr)
+			return nullptr;
+		name = QString((const char*)param1);
+		if (param2 != nullptr)
+			shortcut = QString((const char*)param2);
+		emit setFavouriteItemShortcut(2, name, shortcut);
+	}
+	break;
+
     case GUI_SET_FAVOURITE_TOOL_SHORTCUT:
     {
         QString name;

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -2174,15 +2174,24 @@ void MainWindow::addFavouriteItem(int type, const QString & name, const QString 
     {
         char buffer[MAX_SETTING_SIZE];
         unsigned int i;
+        bool check;
         for(i = 1; BridgeSettingGet("Favourite", (QString("Tool") + QString::number(i)).toUtf8().constData(), buffer); i++)
         {
+            if(buffer == name)
+            {
+                check = false;
+                break;
+            }
         }
-        BridgeSettingSet("Favourite", (QString("Tool") + QString::number(i)).toUtf8().constData(), name.toUtf8().constData());
-        BridgeSettingSet("Favourite", (QString("ToolDescription") + QString::number(i)).toUtf8().constData(), description.toUtf8().constData());
-        if(BridgeSettingGet("Favourite", (QString("Tool") + QString::number(i + 1)).toUtf8().constData(), buffer))
+        if(check)
         {
-            buffer[0] = 0;
-            BridgeSettingSet("Favourite", (QString("Tool") + QString::number(i + 1)).toUtf8().constData(), buffer);
+            BridgeSettingSet("Favourite", (QString("Tool") + QString::number(i)).toUtf8().constData(), name.toUtf8().constData());
+            BridgeSettingSet("Favourite", (QString("ToolDescription") + QString::number(i)).toUtf8().constData(), description.toUtf8().constData());
+            if(BridgeSettingGet("Favourite", (QString("Tool") + QString::number(i + 1)).toUtf8().constData(), buffer))
+            {
+                buffer[0] = 0;
+                BridgeSettingSet("Favourite", (QString("Tool") + QString::number(i + 1)).toUtf8().constData(), buffer);
+            }
         }
         updateFavouriteTools();
     }
@@ -2190,15 +2199,24 @@ void MainWindow::addFavouriteItem(int type, const QString & name, const QString 
     {
         char buffer[MAX_SETTING_SIZE];
         unsigned int i;
+        bool check;
         for(i = 1; BridgeSettingGet("Favourite", (QString("Command") + QString::number(i)).toUtf8().constData(), buffer); i++)
         {
+            if(buffer == name)
+            {
+                check = false;
+                break;
+            }
         }
-        BridgeSettingSet("Favourite", (QString("Command") + QString::number(i)).toUtf8().constData(), name.toUtf8().constData());
-        BridgeSettingSet("Favourite", (QString("CommandShortcut") + QString::number(i)).toUtf8().constData(), description.toUtf8().constData());
-        if(BridgeSettingGet("Favourite", (QString("Command") + QString::number(i + 1)).toUtf8().constData(), buffer))
+        if(check)
         {
-            buffer[0] = 0;
-            BridgeSettingSet("Favourite", (QString("Command") + QString::number(i + 1)).toUtf8().constData(), buffer);
+            BridgeSettingSet("Favourite", (QString("Command") + QString::number(i)).toUtf8().constData(), name.toUtf8().constData());
+            BridgeSettingSet("Favourite", (QString("CommandShortcut") + QString::number(i)).toUtf8().constData(), description.toUtf8().constData());
+            if(BridgeSettingGet("Favourite", (QString("Command") + QString::number(i + 1)).toUtf8().constData(), buffer))
+            {
+                buffer[0] = 0;
+                BridgeSettingSet("Favourite", (QString("Command") + QString::number(i + 1)).toUtf8().constData(), buffer);
+            }
         }
         updateFavouriteTools();
     }
@@ -2206,7 +2224,7 @@ void MainWindow::addFavouriteItem(int type, const QString & name, const QString 
 
 void MainWindow::setFavouriteItemShortcut(int type, const QString & name, const QString & shortcut)
 {
-    if(type == 0)
+    if(type == 0) // Tools
     {
         char buffer[MAX_SETTING_SIZE];
         for(unsigned int i = 1; BridgeSettingGet("Favourite", QString("Tool%1").arg(i).toUtf8().constData(), buffer); i++)
@@ -2219,6 +2237,19 @@ void MainWindow::setFavouriteItemShortcut(int type, const QString & name, const 
             }
         }
     }
+	else if (type == 2) // Commands
+	{
+		char buffer[MAX_SETTING_SIZE];
+		for (unsigned int i = 1; BridgeSettingGet("Favourite", QString("Command%1").arg(i).toUtf8().constData(), buffer); i++)
+		{
+			if (QString(buffer) == name)
+			{
+				BridgeSettingSet("Favourite", (QString("CommandShortcut") + QString::number(i)).toUtf8().constData(), shortcut.toUtf8().constData());
+				updateFavouriteTools();
+				break;
+			}
+		}
+	}
 }
 
 void MainWindow::animateIntoSlot()


### PR DESCRIPTION
Solution：
1， write plug-ins to use GuiAddFavouriteCommand, x64dbg repeatedly add items every time you start the problem
2，add API GuiSetFavouriteCommandShortcut for plug-in use

Problems
Tested. Writing plugins to register hotkeys using GuiSetFavouriteCommandShortcut or _plugin_menuentrysethotkey has a lower priority than x64dbg internal setGlobalShortcut, if a new hotkey registered by the plugin has already been setGlobalShortcut is already used, the plugin registration hotkey will be invalid.
