### PR TITLE
Add horizontal scrollbar to CPUInfoBox

### DIFF
--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -5,6 +5,11 @@ StdTable::StdTable(QWidget* parent) : AbstractStdTable(parent)
 {
 }
 
+void StdTable::enableColumnsAutoResize(bool enabled)
+{
+    mIsColumnsAutoResizeAllowed = enabled;
+}
+
 /************************************************************************************
                                    Sorting
 ************************************************************************************/
@@ -85,7 +90,20 @@ void StdTable::setRowCount(dsint count)
 void StdTable::setCellContent(int r, int c, QString s)
 {
     if(isValidIndex(r, c))
+    {
         mData[r][c].text = std::move(s);
+        if(mIsColumnsAutoResizeAllowed)
+        {
+            int maxColumnTextLength = 0;
+            for(size_t i = 0; i < mData.size(); i++)
+            {
+                int cellTextLength = mData[i][c].text.length();
+                if(cellTextLength > maxColumnTextLength)
+                    maxColumnTextLength = cellTextLength;
+            }
+            setColumnWidth(c, getCharWidth() * (maxColumnTextLength + 1));
+        }
+    }
 }
 
 QString StdTable::getCellContent(int r, int c)

--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -94,7 +94,7 @@ void StdTable::setCellContent(int r, int c, QString s)
         mData[r][c].text = std::move(s);
         if(mIsColumnsAutoResizeAllowed)
         {
-            int maxColumnTextLength = 0;
+            int maxColumnTextLength = getColTitle(c).length();
             for(size_t i = 0; i < mData.size(); i++)
             {
                 int cellTextLength = mData[i][c].text.length();

--- a/src/gui/Src/BasicView/StdTable.h
+++ b/src/gui/Src/BasicView/StdTable.h
@@ -17,6 +17,8 @@ public:
         static bool AsHex(const QString & a, const QString & b);
     };
 
+    void enableColumnsAutoResize(bool enabled);
+
     // Data Management
     void addColumnAt(int width, QString title, bool isClickable, QString copyTitle = "", SortBy::t sortFn = SortBy::AsText);
     void deleteAllColumns() override;
@@ -37,4 +39,6 @@ protected:
 
     std::vector<std::vector<CellData>> mData; //listof(row) where row = (listof(col) where col = CellData)
     std::vector<SortBy::t> mColumnSortFunctions;
+
+    bool mIsColumnsAutoResizeAllowed = false;
 };

--- a/src/gui/Src/Gui/CPUInfoBox.cpp
+++ b/src/gui/Src/Gui/CPUInfoBox.cpp
@@ -17,7 +17,8 @@ CPUInfoBox::CPUInfoBox(QWidget* parent) : StdTable(parent)
     setCellContent(2, 0, "");
     setCellContent(3, 0, "");
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    enableColumnsAutoResize(true);
 
     int height = getHeight();
     setMinimumHeight(height);
@@ -53,7 +54,7 @@ void CPUInfoBox::setupContextMenu()
 
 int CPUInfoBox::getHeight()
 {
-    return ((getRowHeight() + 1) * 4);
+    return (getRowHeight() + 1) * 4 + horizontalScrollBar()->sizeHint().height();
 }
 
 void CPUInfoBox::setInfoLine(int line, QString text)


### PR DESCRIPTION
closes #2698
Screenshots:
![изображение](https://user-images.githubusercontent.com/53598853/179247961-94aeeea5-b11c-49b4-84c3-0e4de6235131.png)

![изображение](https://user-images.githubusercontent.com/53598853/179248096-5df2a935-7ae4-4b20-8e09-d74015d72183.png)

Implemented via adding optional mode of `StdTable`: auto-resizing columns in proportion to the maximum text length in the cells. 