### PR TITLE
Fix undecorated label display when it comes from exported symbols.

### DIFF
--- a/src/dbg/symcache.cpp
+++ b/src/dbg/symcache.cpp
@@ -37,6 +37,7 @@ bool SymbolFromAddressExact(duint address, SymbolInfo & symInfo)
                 symInfo.size = 0;
                 symInfo.disp = 0;
                 symInfo.decoratedName = modExport->name;
+                symInfo.undecoratedName = modExport->undecoratedName;
                 symInfo.publicSymbol = true;
                 return true;
             }


### PR DESCRIPTION
Hello,

This patch fix a regression where undecorated label wasn't shown in assembly view when it comes from exported symbols.
Fix #2726.

Regards,
Owerosu