### PR TITLE
remember window topmost configuration

### DIFF
--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -294,6 +294,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     guiBool.insert("AutoRepeatOnEnter", false);
     guiBool.insert("AutoFollowInStack", true);
     guiBool.insert("EnableQtHighDpiScaling", true);
+    guiBool.insert("Topmost", false);
     //Named menu settings
     insertMenuBuilderBools(&guiBool, "CPUDisassembly", 50); //CPUDisassembly
     insertMenuBuilderBools(&guiBool, "CPUDump", 50); //CPUDump


### PR DESCRIPTION
fix #2097.
The user can always reinstall x64dbg if there is a problem with topmost
This pull request also fixes the main window being shown in the default position for a brief moment before being moved to its remembered position on start up.