### PR TITLE
Upgrade actions/checkout package to v3

### DIFF
--- a/.github/workflows/gitee.yml
+++ b/.github/workflows/gitee.yml
@@ -10,7 +10,7 @@ jobs:
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 100
       


### PR DESCRIPTION
Upgrade actions/checkout package from v2 to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Austin Vazquez <macedonv@amazon.com>