### PR TITLE
Use common undecorate flags

### DIFF
--- a/src/dbg/symbolundecorator.h
+++ b/src/dbg/symbolundecorator.h
@@ -81,7 +81,7 @@ inline bool undecorateName(const std::string & decoratedName, std::string & unde
                     mymalloc,
                     myfree,
                     nullptr,
-                    X_UNDNAME_COMPLETE))
+                    X_UNDNAME_COMPLETE | X_UNDNAME_32_BIT_DECODE | X_UNDNAME_NO_PTR64))
     {
         undecoratedName.clear();
         return false;


### PR DESCRIPTION
To make the output more similar to other tools such as WinDbg.

For example:

x64dbg:
`public: class _bstr_t & __ptr64 __cdecl _bstr_t::operator=(class _bstr_t const & __ptr64) __ptr64`

WinDbg:
`public: class _bstr_t & __cdecl _bstr_t::operator=(class _bstr_t const &)`

I got the value `0x20800` by looking at the assembly of `get_undecoratedName` in msdia140, which calls `get_undecoratedNameEx` with these flags.