### PR TITLE
Fix and improve "Show PID/TID in HEX" feature

### DIFF
--- a/src/dbg/commands/cmd-thread-control.cpp
+++ b/src/dbg/commands/cmd-thread-control.cpp
@@ -37,9 +37,9 @@ bool cbDebugCreatethread(int argc, char* argv[])
         if(!LabelGet(Entry, label))
             label[0] = 0;
 #ifdef _WIN64
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %X created at %s %p(Argument=%llX)\n"), ThreadId, label, Entry, Argument);
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %s created at %s %p(Argument=%llX)\n"), formatpidtid(ThreadId).c_str(), label, Entry, Argument);
 #else //x86
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %X created at %s %p(Argument=%X)\n"), ThreadId, label, Entry, Argument);
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %s created at %s %p(Argument=%X)\n"), formatpidtid(ThreadId).c_str(), label, Entry, Argument);
 #endif
         varset("$result", ThreadId, false);
         return true;
@@ -54,7 +54,7 @@ bool cbDebugSwitchthread(int argc, char* argv[])
             return false;
     if(!ThreadIsValid((DWORD)threadid)) //check if the thread is valid
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     //switch thread
@@ -76,7 +76,7 @@ bool cbDebugSuspendthread(int argc, char* argv[])
             return false;
     if(!ThreadIsValid((DWORD)threadid)) //check if the thread is valid
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     //suspend thread
@@ -98,7 +98,7 @@ bool cbDebugResumethread(int argc, char* argv[])
             return false;
     if(!ThreadIsValid((DWORD)threadid)) //check if the thread is valid
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     //resume thread
@@ -124,7 +124,7 @@ bool cbDebugKillthread(int argc, char* argv[])
             return false;
     if(!ThreadIsValid((DWORD)threadid)) //check if the thread is valid
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     //terminate thread
@@ -203,7 +203,7 @@ bool cbDebugSetPriority(int argc, char* argv[])
     }
     if(!ThreadIsValid((DWORD)threadid)) //check if the thread is valid
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     //set thread priority
@@ -225,15 +225,15 @@ bool cbDebugSetthreadname(int argc, char* argv[])
     if(!valfromstring(argv[1], &threadid, false))
         return false;
     THREADINFO info;
-    if(!ThreadGetInfo(DWORD(threadid), info))
+    if(!ThreadGetInfo((DWORD)threadid, info))
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     auto newname = argc > 2 ? argv[2] : "";
-    if(!ThreadSetName(DWORD(threadid), newname))
+    if(!ThreadSetName((DWORD)threadid, newname))
     {
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Failed to change the name for thread %X\n"), DWORD(threadid));
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Failed to change the name for thread %s\n"), formatpidtid((DWORD)threadid).c_str());
         return false;
     }
     if(!*info.threadName)

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -473,6 +473,7 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
         _snprintf_s(modtext, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Module: %s - ")), modname);
     char threadswitch[256] = "";
     DWORD currentThreadId = ThreadGetId(hActiveThread);
+    bool PIDTIDinhex = settingboolget("Gui", "PidTidInHex");
     if(analyzeThreadSwitch)
     {
         static DWORD PrevThreadId = 0;
@@ -482,7 +483,10 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
         {
             char threadName2[MAX_THREAD_NAME_SIZE] = "";
             if(!ThreadGetName(PrevThreadId, threadName2) || threadName2[0] == 0)
-                sprintf_s(threadName2, "%X", PrevThreadId);
+                if(PIDTIDinhex)
+                    sprintf_s(threadName2, "%X", PrevThreadId);
+                else
+                    sprintf_s(threadName2, "%u", PrevThreadId);
             _snprintf_s(threadswitch, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", " (switched from %s)")), threadName2);
             PrevThreadId = currentThreadId;
         }
@@ -492,7 +496,7 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
     if(ThreadGetName(currentThreadId, threadName) && *threadName)
         strcat_s(threadName, " ");
     char PIDnumber[64], TIDnumber[64];
-    if(settingboolget("Gui", "PidInHex"))
+    if(PIDTIDinhex)
     {
         sprintf_s(PIDnumber, "%X", fdProcessInfo->dwProcessId);
         sprintf_s(TIDnumber, "%X", currentThreadId);

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -473,7 +473,6 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
         _snprintf_s(modtext, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Module: %s - ")), modname);
     char threadswitch[256] = "";
     DWORD currentThreadId = ThreadGetId(hActiveThread);
-    bool PIDTIDinhex = settingboolget("Gui", "PidTidInHex");
     if(analyzeThreadSwitch)
     {
         static DWORD PrevThreadId = 0;
@@ -483,10 +482,7 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
         {
             char threadName2[MAX_THREAD_NAME_SIZE] = "";
             if(!ThreadGetName(PrevThreadId, threadName2) || threadName2[0] == 0)
-                if(PIDTIDinhex)
-                    sprintf_s(threadName2, "%X", PrevThreadId);
-                else
-                    sprintf_s(threadName2, "%u", PrevThreadId);
+                strcpy_s(threadName2, formatpidtid(PrevThreadId).c_str());
             _snprintf_s(threadswitch, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", " (switched from %s)")), threadName2);
             PrevThreadId = currentThreadId;
         }
@@ -495,18 +491,7 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
     char threadName[MAX_THREAD_NAME_SIZE + 1] = "";
     if(ThreadGetName(currentThreadId, threadName) && *threadName)
         strcat_s(threadName, " ");
-    char PIDnumber[64], TIDnumber[64];
-    if(PIDTIDinhex)
-    {
-        sprintf_s(PIDnumber, "%X", fdProcessInfo->dwProcessId);
-        sprintf_s(TIDnumber, "%X", currentThreadId);
-    }
-    else
-    {
-        sprintf_s(PIDnumber, "%u", fdProcessInfo->dwProcessId);
-        sprintf_s(TIDnumber, "%u", currentThreadId);
-    }
-    _snprintf_s(title, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "%s - PID: %s - %sThread: %s%s%s")), szBaseFileName, PIDnumber, modtext, threadName, TIDnumber, threadswitch);
+    _snprintf_s(title, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "%s - PID: %s - %sThread: %s%s%s")), szBaseFileName, formatpidtid(fdProcessInfo->dwProcessId).c_str(), modtext, threadName, formatpidtid(currentThreadId).c_str(), threadswitch);
     GuiUpdateWindowTitle(title);
 }
 
@@ -1578,8 +1563,8 @@ static void cbCreateThread(CREATE_THREAD_DEBUG_INFO* CreateThread)
 
     auto entry = duint(CreateThread->lpStartAddress);
     auto parameter = GetContextDataEx(hActiveThread, ArchValue(UE_EBX, UE_RDX));
-    dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %X created, Entry: %s, Parameter: %s\n"),
-            dwThreadId,
+    dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %s created, Entry: %s, Parameter: %s\n"),
+            formatpidtid(dwThreadId).c_str(),
             SymGetSymbolicName(entry).c_str(),
             SymGetSymbolicName(parameter).c_str()
            );
@@ -1616,7 +1601,7 @@ static void cbCreateThread(CREATE_THREAD_DEBUG_INFO* CreateThread)
             MEMPAGE page;
             auto limit = duint(tib.StackLimit);
             auto base = duint(tib.StackBase);
-            sprintf_s(page.info, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Thread %X Stack")), dwThreadId);
+            sprintf_s(page.info, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Thread %s Stack")), formatpidtid(dwThreadId).c_str());
             page.mbi.BaseAddress = page.mbi.AllocationBase = tib.StackLimit;
             page.mbi.Protect = page.mbi.AllocationProtect = PAGE_READWRITE;
             page.mbi.RegionSize = base - limit;
@@ -1651,7 +1636,7 @@ static void cbExitThread(EXIT_THREAD_DEBUG_INFO* ExitThread)
     plugincbcall(CB_EXITTHREAD, &callbackInfo);
     HistoryClear();
     ThreadExit(dwThreadId);
-    dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %X exit\n"), dwThreadId);
+    dprintf(QT_TRANSLATE_NOOP("DBG", "Thread %s exit\n"), formatpidtid(dwThreadId).c_str());
 
     if(settingboolget("Events", "ThreadEnd"))
     {


### PR DESCRIPTION
There's still a lot of improvements that could be made, where the PID/TID is always hexadecimal, but this was the worst one IMO.