### PR TITLE
Don't break on SetThreadName exception

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2022,6 +2022,7 @@ static void cbException(EXCEPTION_DEBUG_INFO* ExceptionData)
                 String ThreadNameEscaped = StringUtils::Escape(ThreadName());
                 dprintf(QT_TRANSLATE_NOOP("DBG", "SetThreadName(%X, \"%s\")\n"), nameInfo.dwThreadID, ThreadNameEscaped.c_str());
                 ThreadSetName(nameInfo.dwThreadID, ThreadNameEscaped.c_str());
+                return;
             }
         }
     }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2020,9 +2020,10 @@ static void cbException(EXCEPTION_DEBUG_INFO* ExceptionData)
             if(MemRead((duint)nameInfo.szName, ThreadName(), MAX_THREAD_NAME_SIZE - 1))
             {
                 String ThreadNameEscaped = StringUtils::Escape(ThreadName());
-                dprintf(QT_TRANSLATE_NOOP("DBG", "SetThreadName(%X, \"%s\")\n"), nameInfo.dwThreadID, ThreadNameEscaped.c_str());
+                dprintf(QT_TRANSLATE_NOOP("DBG", "SetThreadName exception on %p (%X, \"%s\")\n"), addr, nameInfo.dwThreadID, ThreadNameEscaped.c_str());
                 ThreadSetName(nameInfo.dwThreadID, ThreadNameEscaped.c_str());
-                return;
+                if(ThreadNameEscaped.length() > 0 && !settingboolget("Events", "ThreadNameSet"))
+                    return;
             }
         }
     }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2022,7 +2022,7 @@ static void cbException(EXCEPTION_DEBUG_INFO* ExceptionData)
                 String ThreadNameEscaped = StringUtils::Escape(ThreadName());
                 dprintf(QT_TRANSLATE_NOOP("DBG", "SetThreadName exception on %p (%X, \"%s\")\n"), addr, nameInfo.dwThreadID, ThreadNameEscaped.c_str());
                 ThreadSetName(nameInfo.dwThreadID, ThreadNameEscaped.c_str());
-                if(ThreadNameEscaped.length() > 0 && !settingboolget("Events", "ThreadNameSet"))
+                if(!settingboolget("Events", "ThreadNameSet"))
                     return;
             }
         }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1791,9 +1791,9 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
             dprintf(QT_TRANSLATE_NOOP("DBG", "%d invalid TLS callback addresses...\n"), invalidCount);
     }
 
-    auto breakOnDll = dbghandledllbreakpoint(modname, true);
-
-    if((breakOnDll || (settingboolget("Events", "DllEntry") && party != mod_system || settingboolget("Events", "DllEntrySystem") && party == mod_system)) && !bAlreadySetEntry)
+    auto shouldBreakOnDll = dbghandledllbreakpoint(modname, true);
+    auto dllEntrySetting = party == mod_system ? "DllEntrySystem" : "DllEntry";
+    if(!bAlreadySetEntry && (shouldBreakOnDll || settingboolget("Events", dllEntrySetting)))
     {
         auto entry = ModEntryFromAddr(duint(base));
         if(entry)
@@ -1873,11 +1873,12 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     callbackInfo.modname = modname;
     plugincbcall(CB_LOADDLL, &callbackInfo);
 
-    if(breakOnDll)
+    auto dllLoadSetting = party == mod_system ? "DllLoadSystem" : "DllLoad";
+    if(shouldBreakOnDll)
     {
         cbGenericBreakpoint(BPDLL, DLLDebugFileName);
     }
-    else if(!isNtdll && (settingboolget("Events", "DllLoad") && party != mod_system || settingboolget("Events", "DllLoadSystem") && party == mod_system))
+    else if(!isNtdll && settingboolget("Events", dllLoadSetting))
     {
         //update GUI
         DebugUpdateGuiSetStateAsync(GetContextDataEx(hActiveThread, UE_CIP), true);
@@ -1907,11 +1908,12 @@ static void cbUnloadDll(UNLOAD_DLL_DEBUG_INFO* UnloadDll)
     DebugUpdateBreakpointsViewAsync();
     dprintf(QT_TRANSLATE_NOOP("DBG", "DLL Unloaded: %p %s\n"), base, modname);
 
+    auto dllUnloadSetting = party == mod_system ? "DllUnloadSystem" : "DllUnload";
     if(dbghandledllbreakpoint(modname, false))
     {
         cbGenericBreakpoint(BPDLL, modname);
     }
-    else if(settingboolget("Events", "DllUnload") && party != mod_system || settingboolget("Events", "DllUnloadSystem") && party == mod_system)
+    else if(settingboolget("Events", dllUnloadSetting))
     {
         //update GUI
         DebugUpdateGuiSetStateAsync(GetContextDataEx(hActiveThread, UE_CIP), true);

--- a/src/dbg/thread.cpp
+++ b/src/dbg/thread.cpp
@@ -39,7 +39,7 @@ void ThreadCreate(CREATE_THREAD_DEBUG_INFO* CreateThread)
 
     // The first thread (#0) is always the main program thread
     if(curInfo.ThreadNumber <= 0)
-        strcpy_s(curInfo.threadName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Main Thread")));
+        strncpy_s(curInfo.threadName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Main Thread")), _TRUNCATE);
     else
         curInfo.threadName[0] = 0;
 
@@ -290,7 +290,7 @@ bool ThreadGetName(DWORD ThreadId, char* Name)
     SHARED_ACQUIRE(LockThreads);
     if(threadList.find(ThreadId) != threadList.end())
     {
-        strcpy_s(Name, MAX_THREAD_NAME_SIZE, threadList[ThreadId].threadName);
+        strncpy_s(Name, MAX_THREAD_NAME_SIZE, threadList[ThreadId].threadName, _TRUNCATE);
         return true;
     }
     return false;

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -107,6 +107,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Events", "DllUnloadSystem", &settings.eventDllUnloadSystem);
     GetSettingBool("Events", "ThreadStart", &settings.eventThreadStart);
     GetSettingBool("Events", "ThreadEnd", &settings.eventThreadEnd);
+    GetSettingBool("Events", "ThreadNameSet", &settings.eventThreadNameSet);
     GetSettingBool("Events", "DebugStrings", &settings.eventDebugStrings);
     ui->chkSystemBreakpoint->setCheckState(bool2check(settings.eventSystemBreakpoint));
     ui->chkExitBreakpoint->setCheckState(bool2check(settings.eventExitBreakpoint));
@@ -122,6 +123,7 @@ void SettingsDialog::LoadSettings()
     ui->chkDllUnloadSystem->setCheckState(bool2check(settings.eventDllUnloadSystem));
     ui->chkThreadStart->setCheckState(bool2check(settings.eventThreadStart));
     ui->chkThreadEnd->setCheckState(bool2check(settings.eventThreadEnd));
+    ui->chkThreadNameSet->setCheckState(bool2check(settings.eventThreadNameSet));
     ui->chkDebugStrings->setCheckState(bool2check(settings.eventDebugStrings));
 
     //Engine tab
@@ -402,6 +404,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Events", "DllUnloadSystem", settings.eventDllUnloadSystem);
     BridgeSettingSetUint("Events", "ThreadStart", settings.eventThreadStart);
     BridgeSettingSetUint("Events", "ThreadEnd", settings.eventThreadEnd);
+    BridgeSettingSetUint("Events", "ThreadNameSet", settings.eventThreadNameSet);
     BridgeSettingSetUint("Events", "DebugStrings", settings.eventDebugStrings);
 
     //Engine tab
@@ -761,6 +764,11 @@ void SettingsDialog::on_chkThreadStart_stateChanged(int arg1)
 void SettingsDialog::on_chkThreadEnd_stateChanged(int arg1)
 {
     settings.eventThreadEnd = arg1 != Qt::Unchecked;
+}
+
+void SettingsDialog::on_chkThreadNameSet_stateChanged(int arg1)
+{
+    settings.eventThreadNameSet = arg1 != Qt::Unchecked;
 }
 
 void SettingsDialog::on_chkDebugStrings_stateChanged(int arg1)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -42,6 +42,7 @@ private slots:
     void on_chkDllUnloadSystem_stateChanged(int arg1);
     void on_chkThreadStart_stateChanged(int arg1);
     void on_chkThreadEnd_stateChanged(int arg1);
+    void on_chkThreadNameSet_stateChanged(int arg1);
     void on_chkDebugStrings_stateChanged(int arg1);
     //Engine tab
     void on_radioUnsigned_clicked();
@@ -188,6 +189,7 @@ private:
         bool eventDllUnloadSystem;
         bool eventThreadStart;
         bool eventThreadEnd;
+        bool eventThreadNameSet;
         bool eventDebugStrings;
         //Engine Tab
         CalcType engineCalcType;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -115,6 +115,13 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="chkThreadNameSet">
+         <property name="text">
+          <string>Thread Name Set</string>
+         </property>
+        </widget>
+       </item>
        <item row="8" column="0">
         <widget class="QCheckBox" name="chkDllEntry">
          <property name="text">
@@ -167,7 +174,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="4" column="0">
         <widget class="QCheckBox" name="chkDebugStrings">
          <property name="text">
           <string>Debug Strings</string>

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>386</width>
-    <height>542</height>
+    <height>555</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -40,20 +40,31 @@
        <string>Events</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="2" column="0">
-        <widget class="QCheckBox" name="chkEntryBreakpoint">
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="chkDllLoad">
          <property name="text">
-          <string>Entry Breakpoint*</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
+          <string>User DLL Load</string>
          </property>
         </widget>
        </item>
        <item row="2" column="1">
         <widget class="QCheckBox" name="chkThreadStart">
          <property name="text">
-          <string>Thread Start</string>
+          <string>Thread Create</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="chkExitBreakpoint">
+         <property name="text">
+          <string>Exit Breakpoint*</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="chkThreadNameSet">
+         <property name="text">
+          <string>SetThreadName exceptions</string>
          </property>
         </widget>
        </item>
@@ -61,20 +72,6 @@
         <widget class="QCheckBox" name="chkDllLoadSystem">
          <property name="text">
           <string>System DLL Load</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="chkThreadEntry">
-         <property name="text">
-          <string>Thread Entry</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QCheckBox" name="chkDllUnloadSystem">
-         <property name="text">
-          <string>System DLL Unload</string>
          </property>
         </widget>
        </item>
@@ -91,48 +88,38 @@
          </property>
         </spacer>
        </item>
-       <item row="3" column="0">
-        <widget class="QCheckBox" name="chkExitBreakpoint">
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="chkThreadEntry">
          <property name="text">
-          <string>Exit Breakpoint*</string>
+          <string>Thread Entry</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
-        <widget class="QCheckBox" name="chkTlsCallbacks">
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="chkDebugStrings">
          <property name="text">
-          <string>TLS Callbacks*</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
+          <string>Debug Strings</string>
          </property>
         </widget>
        </item>
        <item row="3" column="1">
         <widget class="QCheckBox" name="chkThreadEnd">
          <property name="text">
-          <string>Thread End</string>
+          <string>Thread Exit</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QCheckBox" name="chkThreadNameSet">
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="chkTlsCallbacksSystem">
          <property name="text">
-          <string>Thread Name Set</string>
+          <string>System TLS Callbacks*</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QCheckBox" name="chkDllEntry">
+       <item row="11" column="1">
+        <widget class="QCheckBox" name="chkDllUnloadSystem">
          <property name="text">
-          <string>DLL Entry</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="chkDllLoad">
-         <property name="text">
-          <string>DLL Load</string>
+          <string>System DLL Unload</string>
          </property>
         </widget>
        </item>
@@ -140,6 +127,23 @@
         <widget class="QLabel" name="lblBreakOn">
          <property name="text">
           <string>Break on:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QCheckBox" name="chkDllUnload">
+         <property name="text">
+          <string>User DLL Unload</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QCheckBox" name="chkTlsCallbacks">
+         <property name="text">
+          <string>User TLS Callbacks*</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -153,10 +157,13 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
-        <widget class="QCheckBox" name="chkTlsCallbacksSystem">
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="chkEntryBreakpoint">
          <property name="text">
-          <string>System TLS Callbacks*</string>
+          <string>Entry Breakpoint*</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -167,17 +174,23 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
-        <widget class="QCheckBox" name="chkDllUnload">
+       <item row="8" column="0">
+        <widget class="QCheckBox" name="chkDllEntry">
          <property name="text">
-          <string>DLL Unload</string>
+          <string>User DLL Entry</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QCheckBox" name="chkDebugStrings">
+       <item row="14" column="1">
+        <widget class="QLabel" name="label_2">
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
          <property name="text">
-          <string>Debug Strings</string>
+          <string>* Requires debuggee restart</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -457,13 +470,26 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::MinimumExpanding</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>* Requires debugger restart</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -1062,6 +1088,16 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>* Requires debuggee restart</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
My arguments for this change:
- this gets spammed a lot in some apps during startup or runtime, forcing you to keep pressing Go or disable first-chance exception breaking altogether (it doesn't look like there's another way to just filter out that one)
- it's supposed to be just an information for the debugger itself rather than a real exception
- it shouldn't be missed if needed since the operation is logged in the debug log

In case of the game I'm debugging this changed from having to press Go 30 times on startup and regularly during runtime, to literally nothing (because all these random exceptions I was getting were apparently just setting thread name on the debugger). 

So I think it would be a nice QoL change. I *think* most people shouldn't really need an exception like this, if someone wants to watch a thread being created, there are better ways to do it than wait on this exception by default...