### PR TITLE
New Option to Show Path of Debuggee in Window Title

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1202,10 +1202,15 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
 
         // check if we need to change the main window title
         bool bNewWindowLongPath = settingboolget("Gui", "WindowLongPath");
-        if(bWindowLongPath != bNewWindowLongPath)
+        if(DbgIsDebugging() && bWindowLongPath != bNewWindowLongPath)
         {
             bWindowLongPath = bNewWindowLongPath;
-            duint addr = GetContextDataEx(hActiveThread, UE_CIP);
+            duint addr = 0;
+            SELECTIONDATA selection;
+            if(GuiSelectionGet(GUI_DISASSEMBLY, &selection))
+                addr = selection.start;
+            else
+                addr = GetContextDataEx(hActiveThread, UE_CIP);
             DebugUpdateTitleAsync(addr, false);
         }
 

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1200,6 +1200,15 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
             dbgaddexceptionfilter(unknownExceptionsFilter);
         }
 
+        // check if we need to change the main window title
+        bool bNewWindowLongPath = settingboolget("Gui", "WindowLongPath");
+        if(bWindowLongPath != bNewWindowLongPath)
+        {
+            bWindowLongPath = bNewWindowLongPath;
+            duint addr = GetContextDataEx(hActiveThread, UE_CIP);
+            DebugUpdateTitleAsync(addr, false);
+        }
+
         if(BridgeSettingGet("Symbols", "CachePath", settingText.data()))
         {
             // Trim the buffer to fit inside MAX_PATH

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -475,11 +475,9 @@ void updateSEHChainAsync()
 
 static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
 {
-    if(!DbgIsDebugging())
-    {
-        GuiUpdateWindowTitle("");
+    if(GuiIsUpdateDisabled() || !DbgIsDebugging())
         return;
-    }
+
     char modname[MAX_MODULE_SIZE] = "";
     char modtext[MAX_MODULE_SIZE * 2] = "";
     if(!ModNameFromAddr(disasm_addr, modname, true))

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -90,6 +90,7 @@ bool bTraceBrowserNeedsUpdate = false;
 bool bForceLoadSymbols = false;
 bool bNewStringAlgorithm = false;
 bool bPidTidInHex = false;
+bool bWindowLongPath = false;
 duint DbgEvents = 0;
 duint maxSkipExceptionCount = 0;
 HANDLE mProcHandle;
@@ -474,6 +475,11 @@ void updateSEHChainAsync()
 
 static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
 {
+    if(!DbgIsDebugging())
+    {
+        GuiUpdateWindowTitle("");
+        return;
+    }
     char modname[MAX_MODULE_SIZE] = "";
     char modtext[MAX_MODULE_SIZE * 2] = "";
     if(!ModNameFromAddr(disasm_addr, modname, true))
@@ -500,7 +506,10 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
     char threadName[MAX_THREAD_NAME_SIZE + 1] = "";
     if(ThreadGetName(currentThreadId, threadName) && *threadName)
         strcat_s(threadName, " ");
-    _snprintf_s(title, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "%s - PID: %s - %sThread: %s%s%s")), szBaseFileName, formatpidtid(fdProcessInfo->dwProcessId).c_str(), modtext, threadName, formatpidtid(currentThreadId).c_str(), threadswitch);
+    // choose between title here
+    auto debugeeName = bWindowLongPath ? szDebuggeePath : szBaseFileName;
+    _snprintf_s(title, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "%s - PID: %s - %sThread: %s%s%s")), debugeeName, formatpidtid(fdProcessInfo->dwProcessId).c_str(), modtext, threadName, formatpidtid(currentThreadId).c_str(), threadswitch);
+
     GuiUpdateWindowTitle(title);
 }
 

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -156,6 +156,7 @@ extern bool bNoWow64SingleStepWorkaround;
 extern bool bForceLoadSymbols;
 extern bool bNewStringAlgorithm;
 extern bool bPidTidInHex;
+extern bool bWindowLongPath;
 extern duint maxSkipExceptionCount;
 extern HANDLE mProcHandle;
 extern HANDLE mForegroundHandle;

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -91,6 +91,7 @@ void SettingsDialog::LoadSettings()
     settings.guiAutoFollowInStack = false;
     settings.guiHideSeasonalIcons = false;
     settings.guiEnableQtHighDpiScaling = true;
+    settings.guiEnableWindowLongPath = false;
 
     //Events tab
     GetSettingBool("Events", "SystemBreakpoint", &settings.eventSystemBreakpoint);
@@ -308,6 +309,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Gui", "AutoFollowInStack", &settings.guiAutoFollowInStack);
     GetSettingBool("Gui", "NoSeasons", &settings.guiHideSeasonalIcons);
     GetSettingBool("Gui", "EnableQtHighDpiScaling", &settings.guiEnableQtHighDpiScaling);
+    GetSettingBool("Gui", "WindowLongPath", &settings.guiEnableWindowLongPath);
     ui->chkFpuRegistersLittleEndian->setChecked(settings.guiFpuRegistersLittleEndian);
     ui->chkSaveColumnOrder->setChecked(settings.guiSaveColumnOrder);
     ui->chkNoCloseDialog->setChecked(settings.guiNoCloseDialog);
@@ -323,6 +325,7 @@ void SettingsDialog::LoadSettings()
     ui->chkHideSeasonalIcons->setChecked(settings.guiHideSeasonalIcons);
     ui->chkHideSeasonalIcons->setVisible(isSeasonal());
     ui->chkQtHighDpiScaling->setChecked(settings.guiEnableQtHighDpiScaling);
+    ui->chkWindowLongPath->setChecked(settings.guiEnableWindowLongPath);
 
     //Misc tab
     if(DbgFunctions()->GetJit)
@@ -472,6 +475,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Gui", "AutoFollowInStack", settings.guiAutoFollowInStack);
     BridgeSettingSetUint("Gui", "NoSeasons", settings.guiHideSeasonalIcons);
     BridgeSettingSetUint("Gui", "EnableQtHighDpiScaling", settings.guiEnableQtHighDpiScaling);
+    BridgeSettingSetUint("Gui", "WindowLongPath", settings.guiEnableWindowLongPath);
 
     //Misc tab
     if(DbgFunctions()->GetJit)
@@ -1178,3 +1182,7 @@ void SettingsDialog::on_chkQtHighDpiScaling_toggled(bool checked)
     settings.guiEnableQtHighDpiScaling = checked;
 }
 
+void SettingsDialog::on_chkWindowLongPath_toggled(bool checked)
+{
+    settings.guiEnableWindowLongPath = checked;
+}

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -119,6 +119,7 @@ private slots:
     void on_chkTransparentExceptionStepping_toggled(bool checked);
 
     void on_chkQtHighDpiScaling_toggled(bool checked);
+    void on_chkWindowLongPath_toggled(bool checked);
 
 private:
     //enums
@@ -240,6 +241,7 @@ private:
         bool guiAutoFollowInStack;
         bool guiHideSeasonalIcons;
         bool guiEnableQtHighDpiScaling;
+        bool guiEnableWindowLongPath;
         //Misc Tab
         bool miscSetJIT;
         bool miscSymbolStore;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>386</width>
-    <height>542</height>
+    <width>433</width>
+    <height>635</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -909,6 +909,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkWindowLongPath">
+         <property name="text">
+          <string>Set Long Window Path</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacerGUI">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -1135,8 +1142,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>358</x>
-     <y>252</y>
+     <x>420</x>
+     <y>622</y>
     </hint>
     <hint type="destinationlabel">
      <x>357</x>
@@ -1151,8 +1158,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>286</x>
-     <y>250</y>
+     <x>320</x>
+     <y>622</y>
     </hint>
     <hint type="destinationlabel">
      <x>279</x>

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -911,7 +911,7 @@
        <item>
         <widget class="QCheckBox" name="chkWindowLongPath">
          <property name="text">
-          <string>Set Long Window Path</string>
+          <string>Full executable path in title</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
# Issue

Closes #2885
Closes #2946

>**Feature type**
>
>Quality of life
>
>**Describe the feature**
>
>When debugging different versions of a program, it could be you lose track of which version you looking at. Showing the file path in the window title like IDA does could quickly help there.

# Solution

Under the GUI settings we find the new option `Set Long Window Path`. If this is enabled, instead of the normal window title (showing current thread and other parameters) the absolute path to the debugge is shown instead.

![image](https://user-images.githubusercontent.com/14185207/221940617-1072fef2-7dd8-4d6e-be15-d283825b37f7.png)

When we attach to a target we can now choose between the two views shown below, by toggling the option:

![image](https://user-images.githubusercontent.com/14185207/221943059-2db8f355-0146-461c-b2b2-651ead8b9152.png)

![image](https://user-images.githubusercontent.com/14185207/221953808-d1d6aef8-b3ca-4ead-94b0-e486c9e21914.png)