### PR TITLE
Add breakpoint background color in call stack view

### DIFF
--- a/src/gui/Src/Gui/AppearanceDialog.ui
+++ b/src/gui/Src/Gui/AppearanceDialog.ui
@@ -392,6 +392,9 @@ border-width: 1px 2px 2px 1px;</string>
               <height>18</height>
              </size>
             </property>
+            <property name="toolTip">
+             <string>Open color selector</string>
+            </property>
             <property name="styleSheet">
              <string notr="true">background-color: #FFFFFF; border : 2px solid black</string>
             </property>
@@ -421,6 +424,9 @@ border-width: 1px 2px 2px 1px;</string>
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Transparent</string>
               </property>
               <property name="styleSheet">
                <string notr="true">background-color: #C0C0C0;
@@ -592,6 +598,9 @@ border-width: 1px 2px 2px 1px;</string>
               <width>30</width>
               <height>18</height>
              </size>
+            </property>
+            <property name="toolTip">
+             <string>Open color selector</string>
             </property>
             <property name="styleSheet">
              <string notr="true">background-color: #FFFFFF; border : 2px solid black</string>

--- a/src/gui/Src/Gui/CallStackView.cpp
+++ b/src/gui/Src/Gui/CallStackView.cpp
@@ -96,6 +96,25 @@ QString CallStackView::paintContent(QPainter* painter, dsint rowBase, int rowOff
         auto mid = h / 2.0;
         painter->drawLine(QPointF(x, y + mid), QPointF(x + w, y + mid));
     }
+    else if(col == ColFrom || col == ColTo || col == ColAddress)
+    {
+        QString ret = getCellContent(rowBase + rowOffset, col);
+        BPXTYPE bpxtype = DbgGetBpxTypeAt(getCellUserdata(rowBase + rowOffset, col));
+        if(bpxtype & bp_normal)
+        {
+            painter->fillRect(QRect(x, y, w, h), QBrush(ConfigColor("DisassemblyBreakpointBackgroundColor")));
+            painter->setPen(QPen(ConfigColor("DisassemblyBreakpointColor")));
+            painter->drawText(QRect(x + 4, y, w - 4, h), Qt::AlignVCenter | Qt::AlignLeft, ret);
+            return "";
+        }
+        else if(bpxtype & bp_hardware)
+        {
+            painter->fillRect(QRect(x, y, w, h), QBrush(ConfigColor("DisassemblyHardwareBreakpointBackgroundColor")));
+            painter->setPen(QPen(ConfigColor("DisassemblyHardwareBreakpointColor")));
+            painter->drawText(QRect(x + 4, y, w - 4, h), Qt::AlignVCenter | Qt::AlignLeft, ret);
+            return "";
+        }
+    }
     return StdIconTable::paintContent(painter, rowBase, rowOffset, col, x, y, w, h);
 }
 
@@ -140,6 +159,8 @@ void CallStackView::updateCallStack()
                 setCellContent(currentRow, ColFrom, addrText);
             }
             setCellUserdata(currentRow, ColFrom, callstack.entries[i].from);
+            setCellUserdata(currentRow, ColTo, callstack.entries[i].to);
+            setCellUserdata(currentRow, ColAddress, callstack.entries[i].addr);
             if(i != callstack.total - 1)
                 setCellContent(currentRow, ColSize, ToHexString(callstack.entries[i + 1].addr - callstack.entries[i].addr));
             else

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -39,7 +39,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultColors.insert("DisassemblyBreakpointColor", QColor("#000000"));
     defaultColors.insert("DisassemblyBreakpointBackgroundColor", QColor("#FF0000"));
     defaultColors.insert("DisassemblyHardwareBreakpointColor", QColor("#000000"));
-    defaultColors.insert("DisassemblyHardwareBreakpointBackgroundColor", Qt::transparent);
+    defaultColors.insert("DisassemblyHardwareBreakpointBackgroundColor", QColor("#FF8080"));
     defaultColors.insert("DisassemblyBookmarkColor", QColor("#000000"));
     defaultColors.insert("DisassemblyBookmarkBackgroundColor", QColor("#FEE970"));
     defaultColors.insert("DisassemblyLabelColor", QColor("#FF0000"));


### PR DESCRIPTION
It is possible to press F2 to add a breakpoint directly in call stack view, but the visual indicator is missing.
Added a default color for hardware breakpoints as well.