### PR TITLE
Add the DbgGetSymbolInfoAt API

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1301,6 +1301,11 @@ BRIDGE_IMPEXP DEBUG_ENGINE DbgGetDebugEngine()
     return (DEBUG_ENGINE)setting;
 }
 
+BRIDGE_IMPEXP bool DbgGetSymbolInfoAt(duint addr, SYMBOLINFO* info)
+{
+    return !!_dbg_sendmessage(DBG_GET_SYMBOL_INFO_AT, (void*)addr, info);
+}
+
 BRIDGE_IMPEXP const char* GuiTranslateText(const char* Source)
 {
     EnterCriticalSection(&csTranslate);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -335,6 +335,7 @@ typedef enum
     DBG_MENU_PREPARE,               // param1=int hMenu,                 param2=unused
     DBG_GET_SYMBOL_INFO,            // param1=void* symbol,              param2=SYMBOLINFO* info
     DBG_GET_DEBUG_ENGINE,           // param1=unused,                    param2-unused
+    DBG_GET_SYMBOL_INFO_AT,         // param1=duint addr,                param2=SYMBOLINFO* info
 } DBGMSG;
 
 typedef enum
@@ -1070,6 +1071,7 @@ BRIDGE_IMPEXP bool DbgAnalyzeFunction(duint entry, BridgeCFGraphList* graph);
 BRIDGE_IMPEXP duint DbgEval(const char* expression, bool* DEFAULT_PARAM(success, nullptr));
 BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info);
 BRIDGE_IMPEXP DEBUG_ENGINE DbgGetDebugEngine();
+BRIDGE_IMPEXP bool DbgGetSymbolInfoAt(duint addr, SYMBOLINFO* info);
 
 //Gui defines
 typedef enum

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1667,6 +1667,18 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
         return debugEngine;
     }
     break;
+
+    case DBG_GET_SYMBOL_INFO_AT:
+    {
+        SymbolInfo symInfo;
+        if(!SymbolFromAddressExact((duint)param1, symInfo))
+            return false;
+
+        auto modbase = ModBaseFromAddr((duint)param1);
+        symInfo.copyToGuiSymbol(modbase, (SYMBOLINFO*)param2);
+        return true;
+    }
+    break;
     }
     return 0;
 }

--- a/src/dbg/_scriptapi_symbol.cpp
+++ b/src/dbg/_scriptapi_symbol.cpp
@@ -39,6 +39,11 @@ static bool cbSymbolEnum(const SYMBOLPTR* ptr, void* user)
         __debugbreak();
     }
 
+    if(info.freeDecorated)
+        BridgeFree(info.decoratedSymbol);
+    if(info.freeUndecorated)
+        BridgeFree(info.undecoratedSymbol);
+
     ctx->symbols->push_back(symbol);
     return true;
 }

--- a/src/dbg/symbolsourcebase.h
+++ b/src/dbg/symbolsourcebase.h
@@ -24,6 +24,29 @@ static ForwardIt binary_find(ForwardIt first, ForwardIt last, const T & value, C
 struct SymbolInfoGui
 {
     virtual void convertToGuiSymbol(duint base, SYMBOLINFO* info) const = 0;
+
+    void copyToGuiSymbol(duint modbase, SYMBOLINFO* info) const
+    {
+        convertToGuiSymbol(modbase, info);
+
+        if(!info->freeDecorated)
+        {
+            const char* name = info->decoratedSymbol;
+            size_t len = strlen(name);
+            info->decoratedSymbol = (char*)BridgeAlloc(len + 1);
+            memcpy(info->decoratedSymbol, name, len + 1);
+            info->freeDecorated = true;
+        }
+
+        if(!info->freeUndecorated)
+        {
+            const char* name = info->undecoratedSymbol;
+            size_t len = strlen(name);
+            info->undecoratedSymbol = (char*)BridgeAlloc(len + 1);
+            memcpy(info->undecoratedSymbol, name, len + 1);
+            info->freeUndecorated = true;
+        }
+    }
 };
 
 struct SymbolInfo : SymbolInfoGui


### PR DESCRIPTION
Mainly to overcome the restrictive `MAX_LABEL_SIZE` limit, and to be a able to get heavily templated symbols.