### PR TITLE
Set proper default style for example text in appearance dialog

### DIFF
--- a/src/gui/Src/Gui/AppearanceDialog.h
+++ b/src/gui/Src/Gui/AppearanceDialog.h
@@ -89,6 +89,8 @@ private:
         QString propertyName;
         QString colorName;
         QString backgroundColorName;
+        QString defaultBackgroundColorName;
+        QString defaultFontName;
     };
 
     QList<ColorInfo> colorInfoList;
@@ -101,10 +103,12 @@ private:
     QAction* defaultValueAction;
     QAction* currentSettingAction;
     QTreeWidgetItem* currentCategory;
+    QString currentBackgroundColorName;
+    QString currentFontName;
 
     bool isInit;
 
-    void colorInfoListCategory(QString categoryName);
+    void colorInfoListCategory(QString categoryName, const QString & currentBackgroundColorName, const QString & currentFontName);
     void colorInfoListAppend(QString propertyName, QString colorName, QString backgroundColorName);
     void colorInfoListInit();
     void fontInit();

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -64,7 +64,7 @@ LogView::~LogView()
 void LogView::updateStyle()
 {
     setFont(ConfigFont("Log"));
-    setStyleSheet(QString("QTextEdit { color: %1; background-color: %2 }").arg(ConfigColor("AbstractTableViewTextColor").name(), ConfigColor("AbstractTableViewBackgroundColor").name()));
+    setStyleSheet(QString("QTextEdit { color: %1; background-color: %2 }").arg(ConfigColor("LogColor").name(), ConfigColor("LogBackgroundColor").name()));
     QColor LogLinkBackgroundColor = ConfigColor("LogLinkBackgroundColor");
 
     this->document()->setDefaultStyleSheet(QString("a {color: %1; background-color: %2 }").arg(ConfigColor("LogLinkColor").name(), LogLinkBackgroundColor == Qt::transparent ? "transparent" : LogLinkBackgroundColor.name()));

--- a/src/gui/Src/Gui/ScriptView.cpp
+++ b/src/gui/Src/Gui/ScriptView.cpp
@@ -533,7 +533,8 @@ void ScriptView::unload()
 void ScriptView::edit()
 {
     if(!filename.isEmpty())
-        QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(filename)));
+        if(!QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(filename))))
+            SimpleWarningBox(this, tr("Error!"), tr("File open failed! Please open the file yourself..."));
 }
 
 void ScriptView::run()

--- a/src/gui/Src/Gui/SystemBreakpointScriptDialog.cpp
+++ b/src/gui/Src/Gui/SystemBreakpointScriptDialog.cpp
@@ -110,7 +110,12 @@ void SystemBreakpointScriptDialog::on_openDebuggee_clicked()
 {
     // First open the script if that is available
     if(!ui->lineEditDebuggee->text().isEmpty())
-        QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(ui->lineEditDebuggee->text())));
+    {
+        if(!QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(ui->lineEditDebuggee->text()))))
+        {
+            SimpleWarningBox(this, tr("Error!"), tr("File open failed! Please open the file yourself..."));
+        }
+    }
     else
     {
         // Ask the user to create a new script
@@ -129,7 +134,10 @@ void SystemBreakpointScriptDialog::on_openDebuggee_clicked()
             ui->lineEditDebuggee->setText(defaultFileName);
             ui->openDebuggee->setText(tr("Open"));
             // Open the file
-            QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(ui->lineEditDebuggee->text())));
+            if(!QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(ui->lineEditDebuggee->text()))))
+            {
+                SimpleWarningBox(this, tr("Error!"), tr("File open failed! Please open the file yourself..."));
+            }
         }
     }
 }

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -248,6 +248,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultColors.insert("SymbolLoadedTextColor", QColor("#008000"));
     defaultColors.insert("BackgroundFlickerColor", QColor("#ff6961"));
     defaultColors.insert("LinkColor", QColor("#0000ff"));
+    defaultColors.insert("LogColor", QColor("#000000"));
+    defaultColors.insert("LogBackgroundColor", QColor("#FFF8F0"));
 
     //bool settings
     QMap<QString, bool> disassemblyBool;


### PR DESCRIPTION
Fine tuned the style of example text when using the transparent background color.
Qt cannot open text file with Chinese characters in file name??? Add error messages (releases from 2021 cannot open it either)