### PR TITLE
Fix trace export and search being extremely slow on large trace files

### DIFF
--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -255,7 +255,7 @@ TraceFilePage* TraceFileReader::getPage(unsigned long long index, unsigned long 
     {
         FILETIME pageOutTime = pages.begin()->second.lastAccessed;
         Range pageOutIndex = pages.begin()->first;
-        for(auto i : pages)
+        for(auto & i : pages)
         {
             if(pageOutTime.dwHighDateTime < i.second.lastAccessed.dwHighDateTime || (pageOutTime.dwHighDateTime == i.second.lastAccessed.dwHighDateTime && pageOutTime.dwLowDateTime < i.second.lastAccessed.dwLowDateTime))
             {


### PR DESCRIPTION
Here, I made a GIF of the exporting process (the columns are current row, time taken to write 4096 rows, ram usage).

![qtcreator_pITPqXLMAj](https://github.com/x64dbg/x64dbg/assets/8329446/2bcc53e4-fd23-4cc2-9bad-05609af9c037)

You can see how it suddenly slows down after the counter reaches something around 1 million rows. It quickly eats up all "cachable" 2048 pages and then just spends most of the time trying to find the oldest one to evict. With searching the situation is the same except the ram usage goes up to 1200MB. 