### PR TITLE
Add actions to copy DWord/QWord and Comments in the Stack view

### DIFF
--- a/src/gui/Src/Gui/CPUStack.h
+++ b/src/gui/Src/Gui/CPUStack.h
@@ -54,6 +54,8 @@ public slots:
     void dbgStateChangedSlot(DBGSTATE state);
     void disasmSelectionChanged(dsint parVA);
     void updateSlot();
+    void copyPtrColumnSlot();
+    void copyCommentsColumnSlot();
 
 private:
     duint mCsp = 0;


### PR DESCRIPTION
It would be nice to be able to copy the second (data) column from the stack view.
I found several ways to do it which are not very intuitive or simple (copy the entire row with Ctrl-C and then somehow extract the needed column text, open the Modify dialog and copy the value from there, choose the "Copy data" tab of the Edit dialog and select "C-Style DWord" or something, copy raw bytes with Shift-C and then somehow reverse the endianness and remove spaces).
Besides, almost all other tables allow you to copy each column contents separately.
The added actions also can copy several rows of the selected column for no particular reason (the disassembly table behaves similarly).
