### PR TITLE
fixed trace browser crash

### DIFF
--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -345,7 +345,7 @@ QString TraceBrowser::paintContent(QPainter* painter, dsint rowBase, int rowOffs
     if(index >= mTraceFile->Length())
         return "";
 
-    const Instruction_t & inst = mTraceFile->Instruction(index);
+    Instruction_t inst = mTraceFile->Instruction(index);
 
     switch(static_cast<TableColumnIndex>(col))
     {


### PR DESCRIPTION
The reference obtained may be paged out when used later, causing the crash #3106