### PR TITLE
Resolve command line arguments from shortcuts

### DIFF
--- a/src/dbg/_global.cpp
+++ b/src/dbg/_global.cpp
@@ -313,7 +313,7 @@ bool IsWow64()
 
 //Taken from: http://www.cplusplus.com/forum/windows/64088/
 //And: https://codereview.stackexchange.com/a/2917
-bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolvedPath, size_t nSize)
+bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolvedPath, size_t nPathSize, wchar_t* szResolvedArgs, size_t nArgsSize)
 {
     if(szResolvedPath == NULL)
         return SUCCEEDED(E_INVALIDARG);
@@ -352,7 +352,16 @@ bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolv
 
                     if(SUCCEEDED(hres) && expandSuccess)
                     {
-                        wcscpy_s(szResolvedPath, nSize, expandedTarget);
+                        // Optionally fill the resolved arguments
+                        if(szResolvedArgs) {
+                            wchar_t linkArgs[MAX_PATH];
+                            hres = psl->GetArguments(linkArgs, _countof(linkArgs));
+
+                            if(SUCCEEDED(hres)) {
+                                wcscpy_s(szResolvedArgs, nArgsSize, linkArgs);
+                            }
+                        }
+                        wcscpy_s(szResolvedPath, nPathSize, expandedTarget);
                     }
                 }
             }

--- a/src/dbg/_global.cpp
+++ b/src/dbg/_global.cpp
@@ -353,11 +353,13 @@ bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolv
                     if(SUCCEEDED(hres) && expandSuccess)
                     {
                         // Optionally fill the resolved arguments
-                        if(szResolvedArgs) {
+                        if(szResolvedArgs)
+                        {
                             wchar_t linkArgs[MAX_PATH];
                             hres = psl->GetArguments(linkArgs, _countof(linkArgs));
 
-                            if(SUCCEEDED(hres)) {
+                            if(SUCCEEDED(hres))
+                            {
                                 wcscpy_s(szResolvedArgs, nArgsSize, linkArgs);
                             }
                         }

--- a/src/dbg/_global.h
+++ b/src/dbg/_global.h
@@ -62,7 +62,7 @@ bool GetFileNameFromProcessHandle(HANDLE hProcess, char* szFileName, size_t nCou
 bool GetFileNameFromModuleHandle(HANDLE hProcess, HMODULE hModule, char* szFileName, size_t nCount);
 bool settingboolget(const char* section, const char* name);
 bool IsWow64();
-bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolvedPath, size_t nSize);
+bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolvedPath, size_t nPathSize, wchar_t* szResolvedArgs, size_t nArgsSize);
 void WaitForThreadTermination(HANDLE hThread, DWORD timeout = INFINITE);
 void WaitForMultipleThreadsTermination(const HANDLE* hThread, int count, DWORD timeout = INFINITE);
 

--- a/src/dbg/_global.h
+++ b/src/dbg/_global.h
@@ -62,7 +62,7 @@ bool GetFileNameFromProcessHandle(HANDLE hProcess, char* szFileName, size_t nCou
 bool GetFileNameFromModuleHandle(HANDLE hProcess, HMODULE hModule, char* szFileName, size_t nCount);
 bool settingboolget(const char* section, const char* name);
 bool IsWow64();
-bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, wchar_t* szResolvedPath, size_t nPathSize, wchar_t* szResolvedArgs, size_t nArgsSize);
+bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, std::wstring & executable, std::wstring & arguments, std::wstring & workingDir);
 void WaitForThreadTermination(HANDLE hThread, DWORD timeout = INFINITE);
 void WaitForMultipleThreadsTermination(const HANDLE* hThread, int count, DWORD timeout = INFINITE);
 

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -75,11 +75,23 @@ bool cbDebugInit(int argc, char* argv[])
     static char arg1[deflen] = "";
     strcpy_s(arg1, argv[1]);
     wchar_t szResolvedPath[MAX_PATH] = L"";
-    if(ResolveShortcut(GuiGetWindowHandle(), StringUtils::Utf8ToUtf16(arg1).c_str(), szResolvedPath, _countof(szResolvedPath)))
+    wchar_t szResolvedArgs[MAX_PATH] = L"";
+
+    static char arg2[deflen] = "";
+    if (argc > 2)
+        strcpy_s(arg2, argv[2]);
+
+    if(ResolveShortcut(GuiGetWindowHandle(), StringUtils::Utf8ToUtf16(arg1).c_str(), szResolvedPath, _countof(szResolvedPath), szResolvedArgs, _countof(szResolvedArgs)))
     {
         auto resolvedPathUtf8 = StringUtils::Utf16ToUtf8(szResolvedPath);
         dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved shortcut \"%s\"->\"%s\"\n"), arg1, resolvedPathUtf8.c_str());
         strcpy_s(arg1, resolvedPathUtf8.c_str());
+        // Assign a command line from the shortcut if it wasn't overriden
+        if(argc <= 2) {
+            auto resolvedArgsUtf8 = StringUtils::Utf16ToUtf8(szResolvedArgs);
+            dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved arguments from shortcut \"%s\"\n"), resolvedArgsUtf8.c_str());
+            strcpy_s(arg2, resolvedArgsUtf8.c_str());
+        }
     }
     if(!FileExists(arg1))
     {
@@ -124,9 +136,6 @@ bool cbDebugInit(int argc, char* argv[])
         break;
     }
 
-    static char arg2[deflen] = "";
-    if(argc > 2)
-        strcpy_s(arg2, argv[2]);
     char* commandline = 0;
     if(strlen(arg2))
         commandline = arg2;

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -78,7 +78,7 @@ bool cbDebugInit(int argc, char* argv[])
     wchar_t szResolvedArgs[MAX_PATH] = L"";
 
     static char arg2[deflen] = "";
-    if (argc > 2)
+    if(argc > 2)
         strcpy_s(arg2, argv[2]);
 
     if(ResolveShortcut(GuiGetWindowHandle(), StringUtils::Utf8ToUtf16(arg1).c_str(), szResolvedPath, _countof(szResolvedPath), szResolvedArgs, _countof(szResolvedArgs)))
@@ -87,7 +87,8 @@ bool cbDebugInit(int argc, char* argv[])
         dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved shortcut \"%s\"->\"%s\"\n"), arg1, resolvedPathUtf8.c_str());
         strcpy_s(arg1, resolvedPathUtf8.c_str());
         // Assign a command line from the shortcut if it wasn't overriden
-        if(argc <= 2) {
+        if(argc <= 2)
+        {
             auto resolvedArgsUtf8 = StringUtils::Utf16ToUtf8(szResolvedArgs);
             dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved arguments from shortcut \"%s\"\n"), resolvedArgsUtf8.c_str());
             strcpy_s(arg2, resolvedArgsUtf8.c_str());

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -72,33 +72,48 @@ bool cbDebugInit(int argc, char* argv[])
     cbDebugStop(argc, argv);
     ASSERT_TRUE(hDebugLoopThread == nullptr);
 
-    static char arg1[deflen] = "";
+    char arg1[deflen] = "";
     strcpy_s(arg1, argv[1]);
-    wchar_t szResolvedPath[MAX_PATH] = L"";
-    wchar_t szResolvedArgs[MAX_PATH] = L"";
 
-    static char arg2[deflen] = "";
+    char arg2[deflen] = "";
     if(argc > 2)
         strcpy_s(arg2, argv[2]);
 
-    if(ResolveShortcut(GuiGetWindowHandle(), StringUtils::Utf8ToUtf16(arg1).c_str(), szResolvedPath, _countof(szResolvedPath), szResolvedArgs, _countof(szResolvedArgs)))
+    char arg3[deflen] = "";
+    if(argc > 3)
+        strcpy_s(arg3, argv[3]);
+
+    // Process .lnk files
+    std::wstring executable, arguments, workingDir;
+    if(ResolveShortcut(GuiGetWindowHandle(), StringUtils::Utf8ToUtf16(arg1).c_str(), executable, arguments, workingDir))
     {
-        auto resolvedPathUtf8 = StringUtils::Utf16ToUtf8(szResolvedPath);
-        dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved shortcut \"%s\"->\"%s\"\n"), arg1, resolvedPathUtf8.c_str());
+        auto resolvedPathUtf8 = StringUtils::Utf16ToUtf8(executable);
+        dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved shortcut \"%s\" -> \"%s\"\n"), arg1, resolvedPathUtf8.c_str());
         strcpy_s(arg1, resolvedPathUtf8.c_str());
-        // Assign a command line from the shortcut if it wasn't overriden
+
+        // Assign a command line from the shortcut if it wasn't overwritten
         if(argc <= 2)
         {
-            auto resolvedArgsUtf8 = StringUtils::Utf16ToUtf8(szResolvedArgs);
+            auto resolvedArgsUtf8 = StringUtils::Utf16ToUtf8(arguments);
             dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved arguments from shortcut \"%s\"\n"), resolvedArgsUtf8.c_str());
             strcpy_s(arg2, resolvedArgsUtf8.c_str());
         }
+
+        // Assign a working directory from the shortcut if it wasn't overwritten
+        if(argc <= 3)
+        {
+            auto resolvedWorkingDirUtf8 = StringUtils::Utf16ToUtf8(workingDir);
+            dprintf(QT_TRANSLATE_NOOP("DBG", "Resolved working directory from shortcut \"%s\"\n"), resolvedWorkingDirUtf8.c_str());
+            strcpy_s(arg3, resolvedWorkingDirUtf8.c_str());
+        }
     }
+
     if(!FileExists(arg1))
     {
         dputs(QT_TRANSLATE_NOOP("DBG", "File does not exist!"));
         return false;
     }
+
     auto arg1w = StringUtils::Utf8ToUtf16(arg1);
     Handle hFile = CreateFileW(arg1w.c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, 0, 0);
     if(hFile == INVALID_HANDLE_VALUE)
@@ -137,29 +152,23 @@ bool cbDebugInit(int argc, char* argv[])
         break;
     }
 
-    char* commandline = 0;
-    if(strlen(arg2))
-        commandline = arg2;
-
-    char arg3[deflen] = "";
-    if(argc > 3)
-        strcpy_s(arg3, argv[3]);
-
-    static char currentfolder[deflen] = "";
+    // Default to the application folder
+    char currentfolder[deflen] = "";
     strcpy_s(currentfolder, arg1);
     int len = (int)strlen(currentfolder);
     while(currentfolder[len] != '\\' && len != 0)
         len--;
     currentfolder[len] = 0;
 
+    // Allow the user to overwrite the working directory
     if(DirExists(arg3))
         strcpy_s(currentfolder, arg3);
 
     static INIT_STRUCT init;
     init.exe = arg1;
-    init.commandline = commandline;
-    if(*currentfolder)
-        init.currentfolder = currentfolder;
+    init.commandline = arg2;
+    init.currentfolder = currentfolder;
+
     dbgcreatedebugthread(&init);
     return true;
 }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2735,7 +2735,7 @@ static void debugLoopFunction(INIT_STRUCT* init)
     else
     {
         gInitExe = StringUtils::Utf8ToUtf16(init->exe);
-        strcpy_s(szDebuggeePath, init->exe);
+        strncpy_s(szDebuggeePath, init->exe.c_str(), _TRUNCATE);
     }
 
     pDebuggedEntry = GetPE32DataW(gInitExe.c_str(), 0, UE_OEP);

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -28,9 +28,9 @@ enum class ExceptionHandledBy
 struct INIT_STRUCT
 {
     HANDLE event = nullptr;
-    char* exe = nullptr;
-    char* commandline = nullptr;
-    char* currentfolder = nullptr;
+    std::string exe;
+    std::string commandline;
+    std::string currentfolder;
     DWORD pid = 0;
     bool attach = false;
 };


### PR DESCRIPTION
`ResolveShortcut` now optionally fills resolved arguments which are passed onto the command line.

Closes #3110