### PR TITLE
Support for MemoryModule recognition and debugging via virtualmod.

### DIFF
--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -119,6 +119,8 @@ struct MODINFO
     ULONG_PTR fileMapVA = 0;
 
     MODULEPARTY party;  // Party. Currently used value: 0: User, 1: System
+    bool isVirtual = false;
+    Memory<unsigned char*> mappedData;
 
     MODINFO()
     {


### PR DESCRIPTION
- Fixed some bugs in virtualmod: loadedSize was never set + the mapped data would be destroyed prematurely, causing a crash after initially parsing the module.
- Use raw RVA instead of rebasing when reading module information from memory.
- Set MappedAsImage = true when calling RtlImageDirectoryEntryToData on in-memory sections, as expected.
- This works out of the box for some basic stuff (e.g. symbols, imports, exports are loaded properly) but for full functionality a fix is needed in MemoryModule (see https://github.com/ynwarcs/MemoryModule/commit/10250ad4b7ee464579dfb13605427bad1626cbd9). TL;DR: VirtualSize field in the section header is not properly set by MemoryModule, leading to sections not being parsed properly during page sorting, leading to an error spam and some other annoying behaviour.