### PR TITLE
Add Commands: LogSave, LogRedirect, LogRedirectStop

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1361,6 +1361,21 @@ BRIDGE_IMPEXP void GuiLogClear()
     _gui_sendmessage(GUI_CLEAR_LOG, 0, 0);
 }
 
+BRIDGE_IMPEXP void GuiLogSave(const char* filename)
+{
+    _gui_sendmessage(GUI_SAVE_LOG, (void*)filename, 0);
+}
+
+BRIDGE_IMPEXP void GuiLogRedirect(const char* filename)
+{
+    _gui_sendmessage(GUI_REDIRECT_LOG, (void*)filename, 0);
+}
+
+BRIDGE_IMPEXP void GuiLogRedirectStop()
+{
+    _gui_sendmessage(GUI_STOP_REDIRECT_LOG, 0, 0);
+}
+
 BRIDGE_IMPEXP void GuiUpdateEnable(bool updateNow)
 {
     bDisableGUIUpdate = false;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1276,6 +1276,9 @@ typedef enum
     GUI_ADD_MSG_TO_LOG_HTML,        // param1=(const char*)msg,     param2=unused
     GUI_IS_LOG_ENABLED,             // param1=unused,               param2=unused
     GUI_IS_DEBUGGER_FOCUSED,        // param1=unused,               param2=unused
+    GUI_SAVE_LOG,                   // param1=const char* file name,param2=unused
+    GUI_REDIRECT_LOG,               // param1=const char* file name,param2=unused
+    GUI_STOP_REDIRECT_LOG,          // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1345,6 +1348,9 @@ BRIDGE_IMPEXP void GuiSetDebugStateFast(DBGSTATE state);
 BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg);
 BRIDGE_IMPEXP void GuiAddLogMessageHtml(const char* msg);
 BRIDGE_IMPEXP void GuiLogClear();
+BRIDGE_IMPEXP void GuiLogSave(const char* filename);
+BRIDGE_IMPEXP void GuiLogRedirect(const char* filename);
+BRIDGE_IMPEXP void GuiLogRedirectStop();
 BRIDGE_IMPEXP void GuiUpdateAllViews();
 BRIDGE_IMPEXP void GuiUpdateRegisterView();
 BRIDGE_IMPEXP void GuiUpdateDisassemblyView();

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -53,7 +53,7 @@ static bool cbClearLog(int argc, char* argv[])
 static bool cbSaveLog(int argc, char* argv[])
 {
     if(argc < 2)
-        GuiLogSave(0);
+        GuiLogSave(nullptr);
     else
         GuiLogSave(argv[1]);
     return true;
@@ -61,10 +61,9 @@ static bool cbSaveLog(int argc, char* argv[])
 
 static bool cbRedirectLog(int argc, char* argv[])
 {
-    if(argc < 2)
-        GuiLogRedirect(0);
-    else
-        GuiLogRedirect(argv[1]);
+    if(IsArgumentsLessThan(argc, 2))
+        return false;
+    GuiLogRedirect(argv[1]);
     return true;
 }
 

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -50,6 +50,30 @@ static bool cbClearLog(int argc, char* argv[])
     return true;
 }
 
+static bool cbSaveLog(int argc, char* argv[])
+{
+    if(argc < 2)
+        GuiLogSave(0);
+    else
+        GuiLogSave(argv[1]);
+    return true;
+}
+
+static bool cbRedirectLog(int argc, char* argv[])
+{
+    if(argc < 2)
+        GuiLogRedirect(0);
+    else
+        GuiLogRedirect(argv[1]);
+    return true;
+}
+
+static bool cbStopRedirectLog(int argc, char* argv[])
+{
+    GuiLogRedirectStop();
+    return true;
+}
+
 static bool cbPrintf(int argc, char* argv[])
 {
     if(argc < 2)
@@ -406,6 +430,9 @@ static void registercommands()
     dbgcmdnew("EnableLog,LogEnable", cbInstrEnableLog, false); //enable log
     dbgcmdnew("DisableLog,LogDisable", cbInstrDisableLog, false); //disable log
     dbgcmdnew("ClearLog,cls,lc,lclr", cbClearLog, false); //clear the log
+    dbgcmdnew("SaveLog,LogSave", cbSaveLog, false); //save the log
+    dbgcmdnew("RedirectLog,LogRedirect", cbRedirectLog, false); //redirect the log
+    dbgcmdnew("StopRedirectLog,LogRedirectStop", cbStopRedirectLog, false); //stop redirecting the log
     dbgcmdnew("AddFavouriteTool", cbInstrAddFavTool, false); //add favourite tool
     dbgcmdnew("AddFavouriteCommand", cbInstrAddFavCmd, false); //add favourite command
     dbgcmdnew("AddFavouriteToolShortcut,SetFavouriteToolShortcut", cbInstrSetFavToolShortcut, false); //set favourite tool shortcut

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -135,10 +135,7 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         break;
 
     case GUI_REDIRECT_LOG:
-        if(!param1)
-            emit redirectLogToFile(QString());
-        else
-            emit redirectLogToFile(QString((const char*)param1));
+        emit redirectLogToFile(QString((const char*)param1));
         break;
 
     case GUI_STOP_REDIRECT_LOG:

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -127,6 +127,24 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         emit clearLog();
         break;
 
+    case GUI_SAVE_LOG:
+        if(!param1)
+            emit saveLog();
+        else
+            emit saveLogToFile(QString((const char*)param1));
+        break;
+
+    case GUI_REDIRECT_LOG:
+        if(!param1)
+            emit redirectLogToFile(QString());
+        else
+            emit redirectLogToFile(QString((const char*)param1));
+        break;
+
+    case GUI_STOP_REDIRECT_LOG:
+        emit redirectLogStop();
+        break;
+
     case GUI_UPDATE_REGISTER_VIEW:
         emit updateRegisters();
         break;

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -53,6 +53,10 @@ signals:
     void addMsgToLog(QByteArray msg);
     void addMsgToLogHtml(QByteArray msg);
     void clearLog();
+    void saveLog();
+    void saveLogToFile(QString file);
+    void redirectLogStop();
+    void redirectLogToFile(QString filename);
     void shutdown();
     void updateRegisters();
     void updateBreakpoints();

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -479,7 +479,7 @@ void LogView::saveToFileSlot(QString fileName)
 void LogView::saveSlot()
 {
     QString fileName;
-    fileName = QString("log-%1.txt").arg(QDateTime::currentDateTime().toString().replace(QChar(':'), QChar('-')));
+    fileName = QString("log-%1.txt").arg(isoDateTime());
     saveToFileSlot(fileName);
 }
 

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -36,11 +36,11 @@ LogView::LogView(QWidget* parent) : QTextBrowser(parent), logRedirection(NULL)
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(updateStyle()));
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(updateStyle()));
     connect(Bridge::getBridge(), SIGNAL(addMsgToLog(QByteArray)), this, SLOT(addMsgToLogSlot(QByteArray)));
-    connect(Bridge::getBridge(), SIGNAL(addMsgToLogHtml(QByteArray)), this, SLOT(addMsgToLogSlotHtml(QByteArray)));
+    connect(Bridge::getBridge(), SIGNAL(addMsgToLogHtml(QByteArray)), this, SLOT(addMsgToLogHtmlSlot(QByteArray)));
     connect(Bridge::getBridge(), SIGNAL(clearLog()), this, SLOT(clearLogSlot()));
     connect(Bridge::getBridge(), SIGNAL(saveLog()), this, SLOT(saveSlot()));
-    connect(Bridge::getBridge(), SIGNAL(saveLogToFile(QString)), this, SLOT(saveSlotToFile(QString)));
-    connect(Bridge::getBridge(), SIGNAL(redirectLogToFile(QString)), this, SLOT(redirectLogSlotToFile(QString)));
+    connect(Bridge::getBridge(), SIGNAL(saveLogToFile(QString)), this, SLOT(saveToFileSlot(QString)));
+    connect(Bridge::getBridge(), SIGNAL(redirectLogToFile(QString)), this, SLOT(redirectLogToFileSlot(QString)));
     connect(Bridge::getBridge(), SIGNAL(redirectLogStop()), this, SLOT(stopRedirectLogSlot()));
     connect(Bridge::getBridge(), SIGNAL(setLogEnabled(bool)), this, SLOT(setLoggingEnabled(bool)));
     connect(Bridge::getBridge(), SIGNAL(flushLog()), this, SLOT(flushLogSlot()));
@@ -60,9 +60,9 @@ LogView::LogView(QWidget* parent) : QTextBrowser(parent), logRedirection(NULL)
  */
 LogView::~LogView()
 {
-    if(logRedirection != NULL)
+    if(logRedirection != nullptr)
         fclose(logRedirection);
-    logRedirection = NULL;
+    logRedirection = nullptr;
 }
 
 void LogView::updateStyle()
@@ -152,7 +152,7 @@ void LogView::contextMenuEvent(QContextMenuEvent* event)
     wMenu.addAction(actionFindInLog);
     wMenu.addAction(actionFindNext);
     wMenu.addAction(actionFindPrevious);
-    if(logRedirection == NULL)
+    if(logRedirection == nullptr)
         actionRedirectLog->setText(tr("&Redirect Log..."));
     else
         actionRedirectLog->setText(tr("Stop &Redirection"));
@@ -234,10 +234,10 @@ void LogView::linkify(QString & msg)
 }
 
 /**
-* @brief LogView::addMsgToLogSlotHtml Adds a HTML message to the log view. This function is a slot for Bridge::addMsgToLogHtml.
+* @brief LogView::addMsgToLogHtmlSlot Adds a HTML message to the log view. This function is a slot for Bridge::addMsgToLogHtml.
 * @param msg The log message (Which is assumed to contain HTML)
 */
-void LogView::addMsgToLogSlotHtml(QByteArray msg)
+void LogView::addMsgToLogHtmlSlot(QByteArray msg)
 {
     LogView::addMsgToLogSlotRaw(msg, false);
 }
@@ -269,7 +269,7 @@ void LogView::addMsgToLogSlotRaw(QByteArray msg, bool encodeHTML)
     // redirect the log
     QString msgUtf16;
     bool redirectError = false;
-    if(logRedirection != NULL)
+    if(logRedirection != nullptr)
     {
         if(utf16Redirect)
         {
@@ -278,7 +278,7 @@ void LogView::addMsgToLogSlotRaw(QByteArray msg, bool encodeHTML)
             if(!fwrite(msgUtf16.utf16(), msgUtf16.length(), 2, logRedirection))
             {
                 fclose(logRedirection);
-                logRedirection = NULL;
+                logRedirection = nullptr;
                 redirectError = true;
             }
         }
@@ -310,7 +310,7 @@ void LogView::addMsgToLogSlotRaw(QByteArray msg, bool encodeHTML)
             if(!fwrite(data, buffersize, 1, logRedirection))
             {
                 fclose(logRedirection);
-                logRedirection = NULL;
+                logRedirection = nullptr;
                 redirectError = true;
             }
             if(loggingEnabled)
@@ -381,10 +381,10 @@ void LogView::clearLogSlot()
 
 void LogView::stopRedirectLogSlot()
 {
-    if(logRedirection != NULL)
+    if(logRedirection != nullptr)
     {
         fclose(logRedirection);
-        logRedirection = NULL;
+        logRedirection = nullptr;
         GuiAddLogMessage(tr("Log redirection is stopped.\n").toUtf8().constData());
     }
     else
@@ -393,16 +393,16 @@ void LogView::stopRedirectLogSlot()
     }
 }
 
-void LogView::redirectLogSlotToFile(QString filename)
+void LogView::redirectLogToFileSlot(QString filename)
 {
-    if(logRedirection != NULL)
+    if(logRedirection != nullptr)
     {
         fclose(logRedirection);
-        logRedirection = NULL;
+        logRedirection = nullptr;
         GuiAddLogMessage(tr("Log redirection is stopped.\n").toUtf8().constData());
     }
     logRedirection = _wfopen(filename.toStdWString().c_str(), L"ab");
-    if(logRedirection == NULL)
+    if(logRedirection == nullptr)
         GuiAddLogMessage(tr("_wfopen() failed. Log will not be redirected to %1.\n").arg(QString::fromWCharArray(BridgeUserDirectory())).toUtf8().constData());
     else
     {
@@ -417,10 +417,10 @@ void LogView::redirectLogSlotToFile(QString filename)
 
 void LogView::redirectLogSlot()
 {
-    if(logRedirection != NULL)
+    if(logRedirection != nullptr)
     {
         fclose(logRedirection);
-        logRedirection = NULL;
+        logRedirection = nullptr;
         GuiAddLogMessage(tr("Log redirection is stopped.\n").toUtf8().constData());
     }
     else
@@ -428,7 +428,7 @@ void LogView::redirectLogSlot()
         BrowseDialog browse(this, tr("Redirect log to file"), tr("Enter the file to which you want to redirect log messages."), tr("Log files (*.txt);;All files (*.*)"), QString::fromWCharArray(BridgeUserDirectory()), true);
         if(browse.exec() == QDialog::Accepted)
         {
-            redirectLogSlotToFile(browse.path);
+            redirectLogToFileSlot(browse.path);
         }
     }
 }
@@ -457,7 +457,7 @@ void LogView::autoScrollSlot()
     autoScroll = !autoScroll;
 }
 
-void LogView::saveSlotToFile(QString fileName)
+void LogView::saveToFileSlot(QString fileName)
 {
     QFile savedLog(fileName);
     savedLog.open(QIODevice::Append | QIODevice::Text);
@@ -480,7 +480,7 @@ void LogView::saveSlot()
 {
     QString fileName;
     fileName = QString("log-%1.txt").arg(QDateTime::currentDateTime().toString().replace(QChar(':'), QChar('-')));
-    saveSlotToFile(fileName);
+    saveToFileSlot(fileName);
 }
 
 void LogView::toggleLoggingSlot()

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -41,7 +41,7 @@ LogView::LogView(QWidget* parent) : QTextBrowser(parent), logRedirection(NULL)
     connect(Bridge::getBridge(), SIGNAL(saveLog()), this, SLOT(saveSlot()));
     connect(Bridge::getBridge(), SIGNAL(saveLogToFile(QString)), this, SLOT(saveSlotToFile(QString)));
     connect(Bridge::getBridge(), SIGNAL(redirectLogToFile(QString)), this, SLOT(redirectLogSlotToFile(QString)));
-    connect(Bridge::getBridge(), SIGNAL(redirectLogStop()), this, SLOT(redirectLogSlotStop()));
+    connect(Bridge::getBridge(), SIGNAL(redirectLogStop()), this, SLOT(stopRedirectLogSlot()));
     connect(Bridge::getBridge(), SIGNAL(setLogEnabled(bool)), this, SLOT(setLoggingEnabled(bool)));
     connect(Bridge::getBridge(), SIGNAL(flushLog()), this, SLOT(flushLogSlot()));
     connect(this, SIGNAL(anchorClicked(QUrl)), this, SLOT(onAnchorClicked(QUrl)));
@@ -379,7 +379,7 @@ void LogView::clearLogSlot()
     this->clear();
 }
 
-void LogView::redirectLogSlotStop()
+void LogView::stopRedirectLogSlot()
 {
     if(logRedirection != NULL)
     {

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -21,9 +21,9 @@ public slots:
     void refreshShortcutsSlot();
     void updateStyle();
     void addMsgToLogSlot(QByteArray msg); /* Non-HTML Log Function*/
-    void addMsgToLogSlotHtml(QByteArray msg); /* HTML accepting Log Function */
+    void addMsgToLogHtmlSlot(QByteArray msg); /* HTML accepting Log Function */
     void stopRedirectLogSlot();
-    void redirectLogSlotToFile(QString directory);
+    void redirectLogToFileSlot(QString filename);
     void redirectLogSlot();
     void setLoggingEnabled(bool enabled);
     void autoScrollSlot();
@@ -37,7 +37,7 @@ public slots:
     void onAnchorClicked(const QUrl & link);
 
     void clearLogSlot();
-    void saveSlotToFile(QString filename);
+    void saveToFileSlot(QString filename);
     void saveSlot();
     void toggleLoggingSlot();
     void flushTimerSlot();

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -22,7 +22,7 @@ public slots:
     void updateStyle();
     void addMsgToLogSlot(QByteArray msg); /* Non-HTML Log Function*/
     void addMsgToLogSlotHtml(QByteArray msg); /* HTML accepting Log Function */
-    void redirectLogSlotStop();
+    void stopRedirectLogSlot();
     void redirectLogSlotToFile(QString directory);
     void redirectLogSlot();
     void setLoggingEnabled(bool enabled);

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -22,6 +22,8 @@ public slots:
     void updateStyle();
     void addMsgToLogSlot(QByteArray msg); /* Non-HTML Log Function*/
     void addMsgToLogSlotHtml(QByteArray msg); /* HTML accepting Log Function */
+    void redirectLogSlotStop();
+    void redirectLogSlotToFile(QString directory);
     void redirectLogSlot();
     void setLoggingEnabled(bool enabled);
     void autoScrollSlot();
@@ -35,6 +37,7 @@ public slots:
     void onAnchorClicked(const QUrl & link);
 
     void clearLogSlot();
+    void saveSlotToFile(QString filename);
     void saveSlot();
     void toggleLoggingSlot();
     void flushTimerSlot();

--- a/src/gui/Src/Utils/MiscUtil.cpp
+++ b/src/gui/Src/Utils/MiscUtil.cpp
@@ -374,15 +374,7 @@ QString getDbPath(const QString & filename, bool addDateTimeSuffix)
             {
                 extensionIdx = path.length();
             }
-            auto now = QDateTime::currentDateTime();
-            auto suffix = QString().sprintf("-%04d%02d%02d-%02d%02d%02d",
-                                            now.date().year(),
-                                            now.date().month(),
-                                            now.date().day(),
-                                            now.time().hour(),
-                                            now.time().minute(),
-                                            now.time().second()
-                                           );
+            auto suffix = "-" + isoDateTime();
             path.insert(extensionIdx, suffix);
         }
     }

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -219,6 +219,19 @@ QString GetDataTypeString(const void* buffer, duint size, ENCODETYPE type)
     }
 }
 
+QString isoDateTime()
+{
+    auto now = QDateTime::currentDateTime();
+    return QString().sprintf("%04d%02d%02d-%02d%02d%02d",
+                             now.date().year(),
+                             now.date().month(),
+                             now.date().day(),
+                             now.time().hour(),
+                             now.time().minute(),
+                             now.time().second()
+                            );
+}
+
 QString ToDateString(const QDate & date)
 {
     static const char* months[] =

--- a/src/gui/Src/Utils/StringUtil.h
+++ b/src/gui/Src/Utils/StringUtil.h
@@ -104,6 +104,9 @@ inline QString ToDoubleString(const void* buffer, int precision = std::numeric_l
 
 QString ToLongDoubleString(const void* buffer);
 
+// yyyyMMdd-HHmmss (useful for file suffix)
+QString isoDateTime();
+
 QString ToDateString(const QDate & date);
 
 QString fillValue(const char* value, int valsize = 2, bool bFpuRegistersLittleEndian = false);


### PR DESCRIPTION
Commands are designed as proposed in https://github.com/x64dbg/x64dbg/issues/2961#issuecomment-1292878777

The only different is for `logredir [arg1]`: ~~if arg1 is not provided, it'll fail just as providing the default value in the log redirect dialog, to be compatible with the dialog behaviour.~~ arg1 is now mandatory.

Let me know if anything needs to be changed (such as the command name), this is my first time contributing.