### PR TITLE
Use same link as found in CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also [compile](https://github.com/x64dbg/x64dbg/wiki/Compiling-the-whole
 
 ## Contributing
 
-This is a community effort and we accept pull requests! See the [CONTRIBUTING](.github/CONTRIBUTING.md) document for more information. If you have any questions you can always [contact us](https://x64dbg.com/#contact) or open an [issue](https://github.com/x64dbg/x64dbg/issues). You can take a look at the [good first issues](https://github.com/x64dbg/x64dbg/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy) to get started.
+This is a community effort and we accept pull requests! See the [CONTRIBUTING](.github/CONTRIBUTING.md) document for more information. If you have any questions you can always [contact us](https://x64dbg.com/#contact) or open an [issue](https://github.com/x64dbg/x64dbg/issues). You can take a look at the [good first issues](https://easy.x64dbg.com/) to get started.
 
 ## Credits
 


### PR DESCRIPTION
Hi there,
I'm trying to get into contributing to open source projects and as I'm interested in reverse engineering I thought I might give it a go with this project.
When I was reading through `README.md` and clicked on the "good first issues" link it showed an empty list, which left me a bit puzzled. I guess the reason is that this hyperlink uses the "Easy" label to filter:
![image](https://github.com/x64dbg/x64dbg/assets/33932864/c1cc6abd-d8bb-4985-b559-b2aae8c20e6d)

Luckily I found a link that works while reading through `CONTRIBUTING.md` and thought I might start off with this simple PR. Now the same link is used in `README.md` and it should apply the correct filter to anyone who clicks it.

I haven't compiled x64dbg yet as described in the list, I hope it is still fine to already open this PR. I'll give the rest of the things in the document a go as well and tried to follow the steps for creating this PR, please let me know if something is off and needs to be done differently.