### PR TITLE
Add movups/movupd/movdqu commands to access XMM registers

### DIFF
--- a/src/dbg/commands/cmd-general-purpose.h
+++ b/src/dbg/commands/cmd-general-purpose.h
@@ -24,3 +24,5 @@ bool cbInstrPop(int argc, char* argv[]);
 bool cbInstrTest(int argc, char* argv[]);
 bool cbInstrCmp(int argc, char* argv[]);
 bool cbInstrMov(int argc, char* argv[]);
+
+bool cbInstrMovdqu(int argc, char* argv[]);

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -2251,75 +2251,14 @@ static void setfpuvalue(const char* string, duint value)
         string += STRLEN_USING_SIZEOF(XMM_PRE_FIELD_STRING);
         DWORD registerindex;
         bool found = true;
-        switch(atoi(string))
+        registerindex = atoi(string);
+        if(registerindex < ArchValue(8, 16))
         {
-        case 0:
-            registerindex = UE_XMM0;
-            break;
-
-        case 1:
-            registerindex = UE_XMM1;
-            break;
-
-        case 2:
-            registerindex = UE_XMM2;
-            break;
-
-        case 3:
-            registerindex = UE_XMM3;
-            break;
-
-        case 4:
-            registerindex = UE_XMM4;
-            break;
-
-        case 5:
-            registerindex = UE_XMM5;
-            break;
-
-        case 6:
-            registerindex = UE_XMM6;
-            break;
-
-        case 7:
-            registerindex = UE_XMM7;
-            break;
-#ifdef _WIN64
-        case 8:
-            registerindex = UE_XMM8;
-            break;
-
-        case 9:
-            registerindex = UE_XMM9;
-            break;
-
-        case 10:
-            registerindex = UE_XMM10;
-            break;
-
-        case 11:
-            registerindex = UE_XMM11;
-            break;
-
-        case 12:
-            registerindex = UE_XMM12;
-            break;
-
-        case 13:
-            registerindex = UE_XMM13;
-            break;
-
-        case 14:
-            registerindex = UE_XMM14;
-            break;
-
-        case 15:
-            registerindex = UE_XMM15;
-            break;
-#endif
-        default:
+            registerindex += UE_XMM0;
+        }
+        else
+        {
             found = false;
-            break;
         }
         if(found)
             SetContextDataEx(hActiveThread, registerindex, value);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -101,6 +101,9 @@ static void registercommands()
     dbgcmdnew("cmp", cbInstrCmp, false);
     dbgcmdnew("mov,set", cbInstrMov, false); //mov a variable, arg1:dest,arg2:src
 
+    //general purpose (SSE/AVX)
+    dbgcmdnew("movdqu,movups,movupd", cbInstrMovdqu, true); //move from and to XMM register
+
     //debug control
     dbgcmdnew("InitDebug,init,initdbg", cbDebugInit, false); //init debugger arg1:exefile,[arg2:commandline]
     dbgcmdnew("StopDebug,stop,dbgstop", cbDebugStop, true); //stop debugger


### PR DESCRIPTION
fix #3087.
MOVDQU currently only works with XMM registers. VMOVUPS could be added to modify YMM and ZMM registers. The goal is to match the behaviour of processor instruction, so that users don't have to read the x64dbg manual because they already know SSE and AVX.