### PR TITLE
add isdebuggerfocused() to determine if x64dbg is focused

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1997,6 +1997,11 @@ BRIDGE_IMPEXP DWORD GuiGetMainThreadId()
     return (DWORD)(duint)_gui_sendmessage(GUI_GET_MAIN_THREAD_ID, nullptr, nullptr);
 }
 
+BRIDGE_IMPEXP bool GuiIsDebuggerFocused()
+{
+    return (bool)(duint)_gui_sendmessage(GUI_IS_DEBUGGER_FOCUSED, nullptr, nullptr);
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInst = hinstDLL;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1126,6 +1126,7 @@ BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info
 BRIDGE_IMPEXP DEBUG_ENGINE DbgGetDebugEngine();
 BRIDGE_IMPEXP bool DbgGetSymbolInfoAt(duint addr, SYMBOLINFO* info);
 BRIDGE_IMPEXP duint DbgXrefAddMulti(const XREF_EDGE* edges, duint count);
+BRIDGE_IMPEXP bool GuiIsDebuggerFocused();
 
 //Gui defines
 typedef enum
@@ -1274,6 +1275,7 @@ typedef enum
     GUI_GET_MAIN_THREAD_ID,         // param1=unused,               param2=unused
     GUI_ADD_MSG_TO_LOG_HTML,        // param1=(const char*)msg,     param2=unused
     GUI_IS_LOG_ENABLED,             // param1=unused,               param2=unused
+    GUI_IS_DEBUGGER_FOCUSED,        // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -152,6 +152,9 @@ void ExpressionFunctions::Init()
     //Undocumented
     RegisterEasy("bpgoto", bpgoto);
 
+    //Other
+    RegisterEasy("isdebuggerfocused", isdebuggerfocused);
+
     // Strings
     ExpressionFunctions::Register("utf8", ValueTypeString, { ValueTypeNumber }, Exprfunc::utf8, nullptr);
     ExpressionFunctions::Register("utf16", ValueTypeString, { ValueTypeNumber }, Exprfunc::utf16, nullptr);

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -600,6 +600,11 @@ namespace Exprfunc
         return getLastExceptionInfo().ExceptionRecord.ExceptionInformation[index];
     }
 
+    duint isdebuggerfocused()
+    {
+        return GuiIsDebuggerFocused();
+    }
+
     bool streq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata)
     {
         assert(argc == 2);

--- a/src/dbg/exprfunc.h
+++ b/src/dbg/exprfunc.h
@@ -86,6 +86,8 @@ namespace Exprfunc
     duint exinfocount();
     duint exinfo(duint index);
 
+    duint isdebuggerfocused();
+
     bool streq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);
     bool strieq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);
     bool strstr(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -905,6 +905,9 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
 
     case GUI_GET_MAIN_THREAD_ID:
         return (void*)dwMainThreadId;
+
+    case GUI_IS_DEBUGGER_FOCUSED:
+        return (void*)!!QApplication::activeWindow();
     }
 
     return nullptr;


### PR DESCRIPTION
The new expression function returns 1 if x64dbg is focused. It can be used in a conditional breakpoint so that you're able to break when you're playing the game but not when you're looking at CPU.
It doesn't return 1 when a plugin window is focused. Currently there's also no way to break when the debuggee is focused after 1 seconds so that it doesn't break just when it is focused.
I also evaluated approach of a system variable that changes when x64dbg is focused, but I'm concerned that event filter may impact GUI responsiveness too much. (some old games with DirectInput lock up the entire system with low-level keyboard & mouse hooks that you either don't put a breakpoint there, or disable these hooks and can't play it)