### PR TITLE
Quote image paths in the Dark theme stylesheet

### DIFF
--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -655,10 +655,11 @@ void MainWindow::loadSelectedTheme(bool reloadOnlyStyleCss)
     {
         auto style = QTextStream(&cssFile).readAll();
         cssFile.close();
-        style = style.replace("url(./", QString("url(%1/../themes/%2/").arg(applicationDirPath, selectedTheme));
-        style = style.replace("url(\"./", QString("url(\"%1/../themes/%2/").arg(applicationDirPath, selectedTheme));
-        style = style.replace("url('./", QString("url('%1/../themes/%2/").arg(applicationDirPath, selectedTheme));
-        style = style.replace("$RELPATH", QString("%1/../themes/%2").arg(applicationDirPath, selectedTheme));
+
+        style = style.replace("url(./", QString("url(approot:/themes/%1/").arg(selectedTheme));
+        style = style.replace("url(\"./", QString("url(\"approot:/themes/%1/").arg(selectedTheme));
+        style = style.replace("url('./", QString("url('approot:/themes/%1/").arg(selectedTheme));
+        style = style.replace("$RELPATH", QString("approot:/themes/%1").arg(selectedTheme));
         qApp->setStyleSheet(style);
     }
 

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -8,6 +8,7 @@
 #include <QTextStream>
 #include <QLibraryInfo>
 #include <QDebug>
+#include <QDir>
 #include "MiscUtil.h"
 
 MyApplication::MyApplication(int & argc, char** argv)
@@ -180,6 +181,9 @@ int main(int argc, char* argv[])
     QPalette appPalette = application.palette();
     appPalette.setColor(QPalette::Link, ConfigColor("LinkColor"));
     application.setPalette(appPalette);
+
+    // Register a path prefix for the program main directory
+    QDir::addSearchPath("approot", QApplication::applicationDirPath() + "/..");
 
     // Load the selected theme
     MainWindow::loadSelectedTheme(true);


### PR DESCRIPTION
When I place the program in a directory whose path contains an uneven number of opening and closing parentheses (like "C:/exa(mple" or "C:/e(x)am(ple"), images referenced in the css file do not load properly (and the whole file gets messed up during parsing). I guess the right way would be to escape the paths with backslashes at runtime, but then the url has to be parsed properly, and parsing is hard, who knows what might happen, etc. On the other hand, simple quoting is safe, and because `(` and `)` (as well as `\`) are not valid path characters in Windows, you can't escape from a quoted string.

![Pasted image 20230803152408](https://github.com/x64dbg/x64dbg/assets/8329446/798bf18b-223a-4ffa-9f17-c29ebb0478b1)
