### PR TITLE
Set dump index from ACTIVEVIEW

### DIFF
--- a/src/dbg/commands/cmd-gui.cpp
+++ b/src/dbg/commands/cmd-gui.cpp
@@ -36,8 +36,6 @@ bool cbDebugDump(int argc, char* argv[])
         dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid address \"%s\"!\n"), argv[1]);
         return false;
     }
-    ACTIVEVIEW activeView;
-    GuiGetActiveView(&activeView);
     if(argc > 2)
     {
         duint index = 0;
@@ -48,18 +46,16 @@ bool cbDebugDump(int argc, char* argv[])
         }
         GuiDumpAtN(addr, int(index));
     }
-    else if(strcmp(activeView.title, "Dump 1") == 0)
-        GuiDumpAtN(addr, 1);
-    else if(strcmp(activeView.title, "Dump 2") == 0)
-        GuiDumpAtN(addr, 2);
-    else if(strcmp(activeView.title, "Dump 3") == 0)
-        GuiDumpAtN(addr, 3);
-    else if(strcmp(activeView.title, "Dump 4") == 0)
-        GuiDumpAtN(addr, 4);
-    else if(strcmp(activeView.title, "Dump 5") == 0)
-        GuiDumpAtN(addr, 5);
     else
-        GuiDumpAt(addr);
+    {
+        ACTIVEVIEW activeView;
+        GuiGetActiveView(&activeView);
+        int dumpIndex;
+        if(sscanf_s(activeView.title, "Dump %d", &dumpIndex) == 1)
+            GuiDumpAtN(addr, dumpIndex);
+        else
+            GuiDumpAt(addr);
+    }
     GuiShowCpu();
     GuiFocusView(GUI_DUMP);
     return true;

--- a/src/dbg/commands/cmd-gui.cpp
+++ b/src/dbg/commands/cmd-gui.cpp
@@ -7,6 +7,7 @@
 #include "stringformat.h"
 #include "value.h"
 #include "variable.h"
+#include <regex>
 
 bool cbDebugDisasm(int argc, char* argv[])
 {
@@ -36,8 +37,6 @@ bool cbDebugDump(int argc, char* argv[])
         dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid address \"%s\"!\n"), argv[1]);
         return false;
     }
-    ACTIVEVIEW activeView;
-    GuiGetActiveView(&activeView);
     if(argc > 2)
     {
         duint index = 0;
@@ -48,18 +47,21 @@ bool cbDebugDump(int argc, char* argv[])
         }
         GuiDumpAtN(addr, int(index));
     }
-    else if(strcmp(activeView.title, "Dump 1") == 0)
-        GuiDumpAtN(addr, 1);
-    else if(strcmp(activeView.title, "Dump 2") == 0)
-        GuiDumpAtN(addr, 2);
-    else if(strcmp(activeView.title, "Dump 3") == 0)
-        GuiDumpAtN(addr, 3);
-    else if(strcmp(activeView.title, "Dump 4") == 0)
-        GuiDumpAtN(addr, 4);
-    else if(strcmp(activeView.title, "Dump 5") == 0)
-        GuiDumpAtN(addr, 5);
     else
-        GuiDumpAt(addr);
+    {
+        ACTIVEVIEW activeView;
+        GuiGetActiveView(&activeView);
+        std::string titleString = activeView.title;
+        std::regex dumpPattern("Dump ([1-9][0-9]*)");
+        std::smatch matchResult;
+        if(std::regex_match(titleString, matchResult, dumpPattern))
+        {
+            int n = std::stoi(matchResult[1].str());
+            GuiDumpAtN(addr, n);
+        }
+        else
+            GuiDumpAt(addr);
+    }
     GuiShowCpu();
     GuiFocusView(GUI_DUMP);
     return true;

--- a/src/dbg/commands/cmd-gui.cpp
+++ b/src/dbg/commands/cmd-gui.cpp
@@ -7,7 +7,6 @@
 #include "stringformat.h"
 #include "value.h"
 #include "variable.h"
-#include <regex>
 
 bool cbDebugDisasm(int argc, char* argv[])
 {
@@ -37,6 +36,8 @@ bool cbDebugDump(int argc, char* argv[])
         dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid address \"%s\"!\n"), argv[1]);
         return false;
     }
+    ACTIVEVIEW activeView;
+    GuiGetActiveView(&activeView);
     if(argc > 2)
     {
         duint index = 0;
@@ -47,21 +48,18 @@ bool cbDebugDump(int argc, char* argv[])
         }
         GuiDumpAtN(addr, int(index));
     }
+    else if(strcmp(activeView.title, "Dump 1") == 0)
+        GuiDumpAtN(addr, 1);
+    else if(strcmp(activeView.title, "Dump 2") == 0)
+        GuiDumpAtN(addr, 2);
+    else if(strcmp(activeView.title, "Dump 3") == 0)
+        GuiDumpAtN(addr, 3);
+    else if(strcmp(activeView.title, "Dump 4") == 0)
+        GuiDumpAtN(addr, 4);
+    else if(strcmp(activeView.title, "Dump 5") == 0)
+        GuiDumpAtN(addr, 5);
     else
-    {
-        ACTIVEVIEW activeView;
-        GuiGetActiveView(&activeView);
-        std::string titleString = activeView.title;
-        std::regex dumpPattern("Dump ([1-9][0-9]*)");
-        std::smatch matchResult;
-        if(std::regex_match(titleString, matchResult, dumpPattern))
-        {
-            int n = std::stoi(matchResult[1].str());
-            GuiDumpAtN(addr, n);
-        }
-        else
-            GuiDumpAt(addr);
-    }
+        GuiDumpAt(addr);
     GuiShowCpu();
     GuiFocusView(GUI_DUMP);
     return true;

--- a/src/dbg/commands/cmd-gui.cpp
+++ b/src/dbg/commands/cmd-gui.cpp
@@ -36,6 +36,8 @@ bool cbDebugDump(int argc, char* argv[])
         dprintf(QT_TRANSLATE_NOOP("DBG", "Invalid address \"%s\"!\n"), argv[1]);
         return false;
     }
+    ACTIVEVIEW activeView;
+    GuiGetActiveView(&activeView);
     if(argc > 2)
     {
         duint index = 0;
@@ -46,6 +48,16 @@ bool cbDebugDump(int argc, char* argv[])
         }
         GuiDumpAtN(addr, int(index));
     }
+    else if(strcmp(activeView.title, "Dump 1") == 0)
+        GuiDumpAtN(addr, 1);
+    else if(strcmp(activeView.title, "Dump 2") == 0)
+        GuiDumpAtN(addr, 2);
+    else if(strcmp(activeView.title, "Dump 3") == 0)
+        GuiDumpAtN(addr, 3);
+    else if(strcmp(activeView.title, "Dump 4") == 0)
+        GuiDumpAtN(addr, 4);
+    else if(strcmp(activeView.title, "Dump 5") == 0)
+        GuiDumpAtN(addr, 5);
     else
         GuiDumpAt(addr);
     GuiShowCpu();


### PR DESCRIPTION
Fixes #3113 and #1596.

Fixes an issue with the "Follow DWORD/QWORD in Current Dump" commmand, as well as the "Go to..." expression box when a dump view is detached. It's not the most elegant but it's not terrible either.

If nativeTitle is ever changed [here](https://github.com/x64dbg/x64dbg/blob/6a970e657dc2279c9d2f584dc56cea14a2ba3e2f/src/gui/Src/Gui/CPUMultiDump.cpp#L30) this fix will break. The current user set dump view name does not affect this, nor does any language changes.