### PR TITLE
In Graph mode, also apply highlighting to different sizes of the same register

### DIFF
--- a/src/gui/Src/Disassembler/ZydisTokenizer.cpp
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.cpp
@@ -21,6 +21,11 @@ void ZydisTokenizer::addColorName(TokenType type, QString color, QString backgro
     colorNamesMap[int(type)] = TokenColor(color, backgroundColor);
 }
 
+ZydisTokenizer::TokenColor ZydisTokenizer::getTokenColor(TokenType type)
+{
+    return colorNamesMap[(size_t)type];
+}
+
 void ZydisTokenizer::addStringsToPool(const QString & strings)
 {
     QStringList stringList = strings.split(' ', QString::SkipEmptyParts);

--- a/src/gui/Src/Disassembler/ZydisTokenizer.h
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.h
@@ -169,6 +169,7 @@ public:
     static void addColorName(TokenType type, QString color, QString backgroundColor);
     static void addStringsToPool(const QString & regs);
     static bool tokenTextPoolEquals(const QString & a, const QString & b);
+    static TokenColor getTokenColor(TokenType type);
 
     static void TokenizeTraceRegister(const char* reg, duint oldValue, duint newValue, std::vector<SingleToken> & tokens);
     static void TokenizeTraceMemory(duint address, duint oldValue, duint newValue, std::vector<SingleToken> & tokens);

--- a/src/gui/Src/Gui/DisassemblerGraphView.cpp
+++ b/src/gui/Src/Gui/DisassemblerGraphView.cpp
@@ -1043,7 +1043,7 @@ bool DisassemblerGraphView::getTokenForMouseEvent(QMouseEvent* event, ZydisToken
                 if(instrRow < instr.text.lineTokens.size())
                 {
                     auto & instrToken = instr.text.lineTokens.at(instrRow);
-                    int x = instrToken.x; // skip the breakpoint/CIP mark and RVA prefix
+                    int x = 1 + instrToken.x; // skip the breakpoint/CIP mark and potential RVA prefix
 
                     for(auto & token : instrToken.tokens)
                     {
@@ -1134,7 +1134,8 @@ void DisassemblerGraphView::mousePressEvent(QMouseEvent* event)
 
                 if(isHighlightable && (mPermanentHighlightingMode || mHighlightingModeEnabled))
                 {
-                    if(oldHighlightToken == currentToken && event->button() == Qt::LeftButton)
+                    bool isEqual = ZydisTokenizer::TokenEquals(&oldHighlightToken, &currentToken);
+                    if(isEqual && event->button() == Qt::LeftButton)
                         // on LMB, deselect an already highlighted token
                         mHighlightToken = ZydisTokenizer::SingleToken();
                     else
@@ -2099,7 +2100,6 @@ void DisassemblerGraphView::loadCurrentGraph()
                         RichTextPainter::List richText;
                         auto zydisTokens = instrTok.tokens;
                         ZydisTokenizer::TokenToRichText(zydisTokens, richText, nullptr);
-                        zydisTokens.x += 1; // account for the breakpoint/CIP mark
 
                         // add rva to node instruction text
                         if(showGraphRva)


### PR DESCRIPTION
Last time I forgot that different sub-registers (like rax, eax, ax, al) should be highlighted as well.

Unfortunately, it gets a bit awkward because we have to compare Zydis tokens and then apply changes to rich text. And these rich texts and tokens are not synced (rich text additionally has RVA and comments). Maybe the cleanest solution would be to store RVA and comments separately, and then, when needed, regenerate rich text from the token array and prepend/append the rest. But that would cause a lot of unnecessary object creation on every highlight change.
I've removed the duplicate rich text since the colors can be extracted directly from the tokens. At least the way they are used now.