### PR TITLE
Add isdebuggeefocused, and optimized isdebuggerfocused

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -2015,11 +2015,6 @@ BRIDGE_IMPEXP DWORD GuiGetMainThreadId()
     return (DWORD)(duint)_gui_sendmessage(GUI_GET_MAIN_THREAD_ID, nullptr, nullptr);
 }
 
-BRIDGE_IMPEXP bool GuiIsDebuggerFocused()
-{
-    return !!(duint)_gui_sendmessage(GUI_IS_DEBUGGER_FOCUSED, nullptr, nullptr);
-}
-
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInst = hinstDLL;

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1126,7 +1126,6 @@ BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info
 BRIDGE_IMPEXP DEBUG_ENGINE DbgGetDebugEngine();
 BRIDGE_IMPEXP bool DbgGetSymbolInfoAt(duint addr, SYMBOLINFO* info);
 BRIDGE_IMPEXP duint DbgXrefAddMulti(const XREF_EDGE* edges, duint count);
-BRIDGE_IMPEXP bool GuiIsDebuggerFocused();
 
 //Gui defines
 typedef enum
@@ -1275,7 +1274,7 @@ typedef enum
     GUI_GET_MAIN_THREAD_ID,         // param1=unused,               param2=unused
     GUI_ADD_MSG_TO_LOG_HTML,        // param1=(const char*)msg,     param2=unused
     GUI_IS_LOG_ENABLED,             // param1=unused,               param2=unused
-    GUI_IS_DEBUGGER_FOCUSED,        // param1=unused,               param2=unused
+    GUI_IS_DEBUGGER_FOCUSED_UNUSED,        // This message is removed, could be used for future purposes
     GUI_SAVE_LOG,                   // param1=const char* file name,param2=unused
     GUI_REDIRECT_LOG,               // param1=const char* file name,param2=unused
     GUI_STOP_REDIRECT_LOG,          // param1=unused,               param2=unused

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -83,6 +83,7 @@ void ExpressionFunctions::Init()
     RegisterEasy("bswap", bswap);
     RegisterEasy("ternary,tern", ternary);
     RegisterEasy("GetTickCount,gettickcount", gettickcount);
+    RegisterEasy("rdtsc", rdtsc);
 
     //Memory
     RegisterEasy("mem.valid,mem.isvalid", memvalid);

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -154,6 +154,7 @@ void ExpressionFunctions::Init()
 
     //Other
     RegisterEasy("isdebuggerfocused", isdebuggerfocused);
+    RegisterEasy("isdebuggeefocused", isdebuggeefocused);
 
     // Strings
     ExpressionFunctions::Register("ansi", ValueTypeString, { ValueTypeNumber }, Exprfunc::ansi, nullptr);

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -453,6 +453,11 @@ namespace Exprfunc
         return GetTickCount();
     }
 
+    duint rdtsc()
+    {
+        return __rdtsc();
+    }
+
     static duint readMem(duint addr, duint size)
     {
         duint value = 0;

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -605,32 +605,29 @@ namespace Exprfunc
         return getLastExceptionInfo().ExceptionRecord.ExceptionInformation[index];
     }
 
-    duint isdebuggerfocused()
+    duint isprocessfocused(DWORD process)
     {
         HWND foreground = GetForegroundWindow();
         if(foreground)
         {
             DWORD pid;
             DWORD tid = GetWindowThreadProcessId(foreground, &pid);
-            return pid == GetCurrentProcessId();
+            return pid == process;
         }
         else
             return 0;
+    }
+
+    duint isdebuggerfocused()
+    {
+        return isprocessfocused(GetCurrentProcessId());
     }
 
     duint isdebuggeefocused()
     {
         if(!DbgIsDebugging())
             return 0;
-        HWND foreground = GetForegroundWindow();
-        if(foreground)
-        {
-            DWORD pid;
-            DWORD tid = GetWindowThreadProcessId(foreground, &pid);
-            return pid == fdProcessInfo->dwProcessId;
-        }
-        else
-            return 0;
+        return isprocessfocused(fdProcessInfo->dwProcessId);
     }
 
     bool streq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata)

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -602,7 +602,30 @@ namespace Exprfunc
 
     duint isdebuggerfocused()
     {
-        return GuiIsDebuggerFocused();
+        HWND foreground = GetForegroundWindow();
+        if(foreground)
+        {
+            DWORD pid;
+            DWORD tid = GetWindowThreadProcessId(foreground, &pid);
+            return pid == GetCurrentProcessId();
+        }
+        else
+            return 0;
+    }
+
+    duint isdebuggeefocused()
+    {
+        if(!DbgIsDebugging())
+            return 0;
+        HWND foreground = GetForegroundWindow();
+        if(foreground)
+        {
+            DWORD pid;
+            DWORD tid = GetWindowThreadProcessId(foreground, &pid);
+            return pid == fdProcessInfo->dwProcessId;
+        }
+        else
+            return 0;
     }
 
     bool streq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata)

--- a/src/dbg/exprfunc.h
+++ b/src/dbg/exprfunc.h
@@ -59,6 +59,7 @@ namespace Exprfunc
     duint trhitcount(duint addr);
     duint trisrecording();
     duint gettickcount();
+    duint rdtsc();
 
     duint readbyte(duint addr);
     duint readword(duint addr);

--- a/src/dbg/exprfunc.h
+++ b/src/dbg/exprfunc.h
@@ -87,6 +87,7 @@ namespace Exprfunc
     duint exinfo(duint index);
 
     duint isdebuggerfocused();
+    duint isdebuggeefocused();
 
     bool streq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);
     bool strieq(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -920,9 +920,6 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
 
     case GUI_GET_MAIN_THREAD_ID:
         return (void*)dwMainThreadId;
-
-    case GUI_IS_DEBUGGER_FOCUSED:
-        return (void*)!!QApplication::activeWindow();
     }
 
     return nullptr;


### PR DESCRIPTION
isdebuggeefocused() is added, in my opinion more useful.
It seems the best way to do it is just GetForegroundWindow().