### PR TITLE
Added mnemonic brief column and keeps mnemonic brief configuration

### DIFF
--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -161,6 +161,7 @@ private:
         ColAddress,
         ColBytes,
         ColDisassembly,
+        ColMnemonicBrief,
         ColComment,
     };
 

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -45,6 +45,9 @@ CPUDisassembly::CPUDisassembly(QWidget* parent, bool isMain) : Disassembly(paren
     // Connect some internal signals
     connect(this, SIGNAL(selectionExpanded()), this, SLOT(selectionUpdatedSlot()));
 
+    // Load configuration
+    mShowMnemonicBrief = ConfigBool("Disassembler", "ShowMnemonicBrief");
+
     Initialize();
 }
 
@@ -1956,6 +1959,7 @@ void CPUDisassembly::traceCoverageDisableSlot()
 void CPUDisassembly::mnemonicBriefSlot()
 {
     mShowMnemonicBrief = !mShowMnemonicBrief;
+    Config()->setBool("Disassembler", "ShowMnemonicBrief", mShowMnemonicBrief);
     reloadData();
 }
 

--- a/src/gui/Src/Gui/CustomizeMenuDialog.cpp
+++ b/src/gui/Src/Gui/CustomizeMenuDialog.cpp
@@ -60,6 +60,8 @@ CustomizeMenuDialog::CustomizeMenuDialog(QWidget* parent) :
             viewName = tr("Help");
         else if(id == "View")
             viewName = tr("View");
+        else if(id == "TraceBrowser")
+            viewName = tr("Trace disassembler");
         else
             continue;
         // Add Parent Node

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -973,6 +973,8 @@ void TraceBrowser::setupRightClickContextMenu()
     synchronizeCpuAction->setCheckable(true);
     synchronizeCpuAction->setChecked(mTraceSyncCpu);
     mMenuBuilder->addAction(synchronizeCpuAction);
+
+    mMenuBuilder->loadFromConfig();
 }
 
 void TraceBrowser::contextMenuEvent(QContextMenuEvent* event)

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -308,6 +308,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     //"Favourites" menu cannot be customized for item hiding.
     insertMenuBuilderBools(&guiBool, "Help", 50); //Main Menu : Help
     insertMenuBuilderBools(&guiBool, "View", 50); //Main Menu : View
+    insertMenuBuilderBools(&guiBool, "TraceBrowser", 50); //TraceBrowser
     defaultBools.insert("Gui", guiBool);
 
     QMap<QString, duint> guiUint;

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -262,6 +262,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     disassemblyBool.insert("0xPrefixValues", false);
     disassemblyBool.insert("NoBranchDisasmPreview", false);
     disassemblyBool.insert("NoCurrentModuleText", false);
+    disassemblyBool.insert("ShowMnemonicBrief", false);
     defaultBools.insert("Disassembler", disassemblyBool);
 
     QMap<QString, bool> engineBool;
@@ -310,7 +311,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultBools.insert("Gui", guiBool);
 
     QMap<QString, duint> guiUint;
-    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUDisassembly", 4);
+    AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUDisassembly", 5);
     AbstractTableView::setupColumnConfigDefaultValue(guiUint, "CPUStack", 3);
     for(int i = 1; i <= 5; i++)
         AbstractTableView::setupColumnConfigDefaultValue(guiUint, QString("CPUDump%1").arg(i), 4);


### PR DESCRIPTION
The hidden by default mnemonic brief column helps keep comments column clean while showing mnemonic brief. It also remembers mnemonic brief settings.