### PR TITLE
Using reserve and unordered_map for optimize inserts

### DIFF
--- a/src/dbg/analysis/advancedanalysis.cpp
+++ b/src/dbg/analysis/advancedanalysis.cpp
@@ -79,6 +79,7 @@ void AdvancedAnalysis::analyzeFunction(duint entryPoint, bool writedata)
     CFGraph graph(entryPoint);
     UintSet visited;
     std::queue<duint> queue;
+    visited.reserve(queue.size());
     mEntryPoints.insert(entryPoint);
     queue.push(graph.entryPoint);
     while(!queue.empty())
@@ -344,6 +345,7 @@ void AdvancedAnalysis::writeDataXrefs()
 
 void AdvancedAnalysis::findFuzzyEntryPoints()
 {
+    mCandidateEPs.reserve(mFuzzyEPs.size());
     for(const auto & entryPoint : mFuzzyEPs)
     {
         mCandidateEPs.insert(entryPoint);
@@ -392,6 +394,7 @@ void AdvancedAnalysis::analyzeCandidateFunctions(bool writedata)
         pendingEPs.clear();
         if(mCandidateEPs.size() == 0)
             return;
+        pendingEPs.reserve(mCandidateEPs.size());
         for(const auto & entryPoint : mCandidateEPs)
         {
             pendingEPs.insert(entryPoint);

--- a/src/dbg/analysis/recursiveanalysis.cpp
+++ b/src/dbg/analysis/recursiveanalysis.cpp
@@ -149,6 +149,7 @@ void RecursiveAnalysis::analyzeFunction(duint entryPoint)
     CFGraph graph(entryPoint);
     UintSet visited;
     std::queue<duint> queue;
+    visited.reserve(queue.size());
     queue.push(graph.entryPoint);
     while(!queue.empty())
     {
@@ -228,6 +229,8 @@ void RecursiveAnalysis::analyzeFunction(duint entryPoint)
                         {
                             node.brtrue = 0;
                             node.brfalse = 0;
+                            node.exits.reserve(actualSize);
+                            mXrefs.reserve(actualSize);
                             for(index = 0; index < actualSize; index++)
                             {
                                 node.exits.push_back(switchTable()[index]);

--- a/src/dbg/exception.cpp
+++ b/src/dbg/exception.cpp
@@ -57,6 +57,7 @@ bool ConstantCodeInit(const String & constantFile)
     std::unordered_map<unsigned int, String> names;
     if(!UniversalCodeInit(constantFile, names, 0))
         return false;
+    Constants.reserve(names.size());
     for(const auto & it : names)
         Constants.insert({ it.second, it.first });
     return true;
@@ -244,6 +245,7 @@ bool SyscallInit()
     }
     else
     {
+        SyscallIndices.reserve(sizeof(Win32kSyscalls) / sizeof(Win32kSyscalls[0]));
         for(auto & syscall : Win32kSyscalls)
         {
             auto index = syscall.GetSyscallIndex((USHORT)versionInfo.dwBuildNumber, ArchValue(true, false));

--- a/src/dbg/handles.cpp
+++ b/src/dbg/handles.cpp
@@ -24,6 +24,7 @@ static void HandleTypesEnum()
         return;
 
     auto TypeInfo = TypesInformation()->TypeInformation;
+    HandleTypeNames.reserve(TypesInformation()->NumberOfTypes);
     for(ULONG i = 0; i < TypesInformation()->NumberOfTypes; i++)
     {
         auto wtypeName = WString(TypeInfo->TypeName.Buffer, TypeInfo->TypeName.Buffer + TypeInfo->TypeName.Length / 2);

--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -312,6 +312,7 @@ static void ProcessSystemPages(std::vector<MEMPAGE> & pageVector)
     auto HeapCount = min(_countof(ProcessHeaps), NumberOfHeaps);
     MemRead(ProcessHeapsPtr, ProcessHeaps, sizeof(duint) * HeapCount);
     std::unordered_map<duint, uint32_t> processHeapIds;
+    processHeapIds.reserve(HeapCount);
     for(uint32_t i = 0; i < HeapCount; i++)
         processHeapIds.emplace(ProcessHeaps[i], i);
 

--- a/src/dbg/stackinfo.cpp
+++ b/src/dbg/stackinfo.cpp
@@ -30,6 +30,7 @@ void stackupdateseh()
         STACK_COMMENT comment;
         strcpy_s(comment.color, "!sehclr"); // Special token for SEH chain color.
         auto count = SEHList.size();
+        newcache.reserve(count);
         for(duint i = 0; i < count; i++)
         {
             if(i + 1 != count)

--- a/src/dbg/types.cpp
+++ b/src/dbg/types.cpp
@@ -502,6 +502,7 @@ static void loadTypes(const JSON troot, std::vector<Member> & types)
     size_t i;
     JSON vali;
     Member curType;
+    types.reserve(json_array_size(troot));
     json_array_foreach(troot, i, vali)
     {
         auto type = json_string_value(json_object_get(vali, "type"));
@@ -556,6 +557,7 @@ static void loadFunctions(const JSON froot, std::vector<Function> & functions)
     size_t i;
     JSON vali;
     Function curFunction;
+    functions.reserve(json_array_size(froot));
     json_array_foreach(froot, i, vali)
     {
         auto rettype = json_string_value(json_object_get(vali, "rettype"));
@@ -581,6 +583,7 @@ static void loadFunctions(const JSON froot, std::vector<Function> & functions)
         size_t j;
         JSON valj;
         Member curArg;
+        curFunction.args.reserve(json_array_size(args));
         json_array_foreach(args, j, valj)
         {
             auto type = json_string_value(json_object_get(valj, "type"));

--- a/src/dbg/xrefs.cpp
+++ b/src/dbg/xrefs.cpp
@@ -34,6 +34,7 @@ struct XrefSerializer : AddrInfoSerializer<XREFSINFO>
         value.type = XREF_DATA;
         size_t i;
         JSON reference;
+        value.references.reserve(json_array_size(references));
         json_array_foreach(references, i, reference)
         {
             XREF_RECORD record;


### PR DESCRIPTION
I am sure, that not all fixes will be needed, because there are cases when count elements does not exceed 3 for avg user x64dbg.