### PR TITLE
Pass Escape key event if search text is empty

### DIFF
--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -355,7 +355,12 @@ bool SearchListView::eventFilter(QObject* obj, QEvent* event)
             return true;
         }
         if(key == Qt::Key_Escape)
-            clearFilter();
+        {
+            if(mFilterText.isEmpty())
+                return QWidget::eventFilter(obj, event);
+            else
+                clearFilter();
+        }
         if(!mSearchBox->text().isEmpty())
         {
             switch(key)


### PR DESCRIPTION
Was blocking Esc from closing Attach window.

Bug I introduced in #3183.