### PR TITLE
Fixed cycling through filtered references without clearing filter.

### DIFF
--- a/src/gui/Src/BasicView/ReferenceView.cpp
+++ b/src/gui/Src/BasicView/ReferenceView.cpp
@@ -187,10 +187,14 @@ void ReferenceView::setRowCount(dsint count)
 
 void ReferenceView::setSingleSelection(int index, bool scroll)
 {
-    clearFilter();
+    //clearFilter();
     stdList()->setSingleSelection(index);
+    stdSearchList()->setSingleSelection(index);
     if(scroll) //TODO: better scrolling
+    {
         stdList()->setTableOffset(index);
+        stdSearchList()->setTableOffset(index);
+    }
 }
 
 void ReferenceView::addCommand(QString title, QString command)


### PR DESCRIPTION
Allow "Actions -> Go to Next/Previous Reference" to cycle through a filtered reference list.  Was previously clearing the filter on the first "Next/Previous" action.