### PR TITLE
Fixed catch exception std::bad_alloc and close handle hFile if downslib::inetopen

### DIFF
--- a/src/dbg/WinInet-Downloader/downslib.cpp
+++ b/src/dbg/WinInet-Downloader/downslib.cpp
@@ -67,7 +67,10 @@ downslib_error downslib_download(const char* url,
                               0);
 
     if(!hInternet)
+    {
+        CloseHandle(hFile);
         return downslib_error::inetopen;
+    }
 
     // Set a time-out value in milliseconds
     InternetSetOptionA(hInternet,

--- a/src/dbg/disasm_helper.cpp
+++ b/src/dbg/disasm_helper.cpp
@@ -311,9 +311,16 @@ extern "C" __declspec(dllexport) bool isasciistring(const unsigned char* data, i
     if(bNewStringAlgorithm)
     {
         int len = 0;
-        char* safebuffer = new char[maxlen];
-        if(!safebuffer)
+        char* safebuffer;
+        try
+        {
+            safebuffer = new char[maxlen];
+        }
+        catch(const std::bad_alloc &)
+        {
             return false;
+        }
+
         for(const char* p = (const char*)data; *p && len < maxlen - 1; len++, p++)
         {
             safebuffer[p - (const char*)data] = *p;
@@ -366,9 +373,16 @@ extern "C" __declspec(dllexport) bool isasciistring(const unsigned char* data, i
 extern "C" __declspec(dllexport) bool isunicodestring(const unsigned char* data, int maxlen)
 {
     int len = 0;
-    wchar_t* safebuffer = new wchar_t[maxlen];
-    if(!safebuffer)
+    wchar_t* safebuffer;
+    try
+    {
+        safebuffer = new wchar_t[maxlen];
+    }
+    catch(const std::bad_alloc &)
+    {
         return false;
+    }
+
     for(const wchar_t* p = (const wchar_t*)data; *p && len < maxlen - 1; len += sizeof(wchar_t), p++)
     {
         safebuffer[p - (const wchar_t*)data] = *p;

--- a/src/dbg/pdbdiafile.cpp
+++ b/src/dbg/pdbdiafile.cpp
@@ -41,10 +41,14 @@ public:
         if(hFile == INVALID_HANDLE_VALUE)
             return HRESULT_FROM_WIN32(GetLastError());
 
-        *ppStream = new FileStream(hFile);
-
-        if(*ppStream == NULL)
+        try
+        {
+            *ppStream = new FileStream(hFile);
+        }
+        catch(const std::bad_alloc &)
+        {
             CloseHandle(hFile);
+        }
 
         return S_OK;
     }


### PR DESCRIPTION
@mrexodia hi
`new` operator has failed to alloc memory, exception `std::bad_alloc()` is thrown, following to C++ standard (not C).
Сhecking for zero is pointless.