### PR TITLE
commandparser handle UNC paths

### DIFF
--- a/src/dbg/commandparser.cpp
+++ b/src/dbg/commandparser.cpp
@@ -78,9 +78,6 @@ Command::Command(const String & command)
             case '{':
                 dataAppend(ch);
                 break;
-            case '\\':
-                dataAppend(ch);
-                break;
             default:
                 dataAppend('\\');
                 dataAppend(ch);


### PR DESCRIPTION
Solves #3210 .

I'm not sure if this is actually an optimal fix. It had seemed that the issue was being caused by escaped double quotes:

`init \\desktop-name\Network\test.exe`

This worked fine.

`init "\\desktop-name\Network\test.exe"`

Would result in the first backslash being parsed out.

Despite that, the double quotes parsing code looks fine. Maybe I'm missing something here though.
