### PR TITLE
Add support for plugins in sub directories

### DIFF
--- a/src/dbg/plugin_loader.cpp
+++ b/src/dbg/plugin_loader.cpp
@@ -499,6 +499,14 @@ void pluginloadall(const char* pluginDir)
 
     for(const std::wstring & pluginName : availablePlugins)
     {
+        // Check if the plugin is a sub-directory and also add it to the search paths.
+        std::wstring pluginPath = pluginDirectory + L"\\" + pluginName;
+
+        if(PathIsDirectoryW(pluginPath.c_str()))
+        {
+            pAddDllDirectory(pluginPath.c_str());
+        }
+
         pluginload(StringUtils::Utf16ToUtf8(pluginName).c_str(), true);
     }
 

--- a/src/dbg/plugin_loader.cpp
+++ b/src/dbg/plugin_loader.cpp
@@ -94,7 +94,7 @@ static std::string pluginGetFullPath(std::string pluginName)
 
     // Check if the plugin is in a sub-directory.
     std::string pluginPathSubdir = pluginPath + "\\" + pluginName + pluginExtension;
-    if(PathIsDirectoryW(StringUtils::Utf8ToUtf16(pluginPathSubdir).c_str()))
+    if(PathFileExistsW(StringUtils::Utf8ToUtf16(pluginPathSubdir).c_str()))
     {
         // Plugin resides in sub directory.
         return pluginPathSubdir;

--- a/src/dbg/plugin_loader.cpp
+++ b/src/dbg/plugin_loader.cpp
@@ -138,7 +138,7 @@ bool pluginload(const char* pluginName, bool loadall)
         EXCLUSIVE_ACQUIRE(LockPluginList);
         for(auto it = pluginList.begin(); it != pluginList.end(); ++it)
         {
-            if(_stricmp(it->plugname, name.c_str()) == 0 && it->isLoaded)
+            if(_stricmp(it->plugname, name.c_str()) == 0)
             {
                 dprintf(QT_TRANSLATE_NOOP("DBG", "[PLUGIN] %s already loaded\n"), name);
                 SetCurrentDirectoryW(currentDir);
@@ -300,7 +300,6 @@ bool pluginload(const char* pluginName, bool loadall)
         setupStruct.hMenuSymmod = pluginData.hMenuSymmod;
         pluginData.plugsetup(&setupStruct);
     }
-    pluginData.isLoaded = true;
     curPluginHandle++;
 
     if(!loadall)

--- a/src/dbg/plugin_loader.cpp
+++ b/src/dbg/plugin_loader.cpp
@@ -143,9 +143,9 @@ bool pluginload(const char* pluginName, bool loadall)
     {
         if(_stricmp(it->plugname, name.c_str()) == 0)
         {
-            dprintf(QT_TRANSLATE_NOOP("DBG", "[PLUGIN] %s already loaded\n"), it->plugname);
             if(!loadall)
             {
+                dprintf(QT_TRANSLATE_NOOP("DBG", "[PLUGIN] %s already loaded\n"), it->plugname);
                 SetCurrentDirectoryW(currentDir);
             }
             return false;
@@ -456,6 +456,10 @@ static std::vector<std::wstring> enumerateAvailablePlugins(const std::wstring & 
     while(FindNextFileW(hSearch, &foundData));
 
     FindClose(hSearch);
+
+    // Sort the list of plugins.
+    std::sort(result.begin(), result.end());
+
     return result;
 }
 
@@ -480,6 +484,15 @@ void pluginloadall(const char* pluginDir)
 
     // Enumerate all plugins from plugins directory.
     const auto availablePlugins = enumerateAvailablePlugins(StringUtils::Utf8ToUtf16(pluginDir));
+
+    // Check the sorted list for duplicate names.
+    for(size_t i = 1; i < availablePlugins.size(); ++i)
+    {
+        if(availablePlugins[i] == availablePlugins[i - 1])
+        {
+            dprintf(QT_TRANSLATE_NOOP("DBG", "[PLUGIN] Plugin with same name found: %s, will only load plugin using sub-directory.\n"), StringUtils::Utf16ToUtf8(availablePlugins[i]).c_str());
+        }
+    }
 
     GetCurrentDirectoryW(deflen, currentDir);
     SetCurrentDirectoryW(pluginDirectory.c_str());

--- a/src/dbg/plugin_loader.h
+++ b/src/dbg/plugin_loader.h
@@ -26,7 +26,6 @@ struct PLUG_DATA
 {
     char plugpath[MAX_PATH];
     char plugname[MAX_PATH];
-    bool isLoaded;
     HINSTANCE hPlugin;
     PLUGINIT pluginit;
     PLUGSTOP plugstop;

--- a/src/dbg/plugin_loader.h
+++ b/src/dbg/plugin_loader.h
@@ -66,7 +66,7 @@ struct PLUG_FORMATFUNCTION
 };
 
 //plugin management functions
-bool pluginload(const char* pluginname, bool loadall = false);
+bool pluginload(const char* pluginname);
 bool pluginunload(const char* pluginname, bool unloadall = false);
 void pluginloadall(const char* pluginDir);
 void pluginunloadall();

--- a/src/exe/signaturecheck.cpp
+++ b/src/exe/signaturecheck.cpp
@@ -319,7 +319,7 @@ static VOID CALLBACK MyLdrDllNotification(
 
 typedef BOOL(WINAPI* pfnSetDefaultDllDirectories)(DWORD DirectoryFlags);
 typedef BOOL(WINAPI* pfnSetDllDirectoryW)(LPCWSTR lpPathName);
-typedef BOOL(WINAPI* pfnAddDllDirectory)(LPCWSTR lpPathName);
+typedef PVOID(WINAPI* pfnAddDllDirectory)(LPCWSTR lpPathName);
 
 static pfnSetDefaultDllDirectories pSetDefaultDllDirectories;
 static pfnSetDllDirectoryW pSetDllDirectoryW;


### PR DESCRIPTION
Some plugins may contain multiple other libraries so the plugin folder becomes quite messy over time. This adds support to load plugins from a sub directory, ex.: `x64/plugins/myplugin/myplugin.dp64`.

The directory name MUST match the plugin name in order to work. I also refactored the way how pluginload and pluginunload works, one does not have to use `pluginload myplugin/myplugin.dp64` for it to work, providing just the plugin name is now the preferred way, plugins will also load when `pluginload myplugin.dp64` is used even when its from a sub directory. I personally think that the requirement of having the same name is sensible, having that not a requirement would add way more complexity and the command pluginload would have to always specify the relative path.

This PR also fixes x64dbg being able to load the same plugin multiple times due to `isLoaded` never being copied to the plugin list. Another thing this PR fixes is pluginunloadall not clearing the actual plugin list and only unloading the dll, probably not an actual issue as this happens only when x64dbg closes, however now one could add a command to unload them all and it would work.

In case the requirement for the folder name is too strict I'm open for suggestions, this also means only one plugin can be loaded from the directory, this is just a means to better organize plugins with lots of dependencies. All existing plugins will also not be affected by this PR.