### PR TITLE
SymbolView: Don't update fonts on each 'repaintTableView' event

### DIFF
--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -215,7 +215,7 @@ SymbolView::SymbolView(QWidget* parent) : QWidget(parent), ui(new Ui::SymbolView
     setupContextMenu();
 
     //Signals and slots
-    connect(Bridge::getBridge(), SIGNAL(repaintTableView()), this, SLOT(updateStyle()));
+    connect(Bridge::getBridge(), SIGNAL(repaintTableView()), this, SLOT(reloadDataSlot()));
     connect(Bridge::getBridge(), SIGNAL(addMsgToSymbolLog(QString)), this, SLOT(addMsgToSymbolLogSlot(QString)));
     connect(Bridge::getBridge(), SIGNAL(clearLog()), this, SLOT(clearSymbolLogSlot()));
     connect(Bridge::getBridge(), SIGNAL(clearSymbolLog()), this, SLOT(clearSymbolLogSlot()));
@@ -408,10 +408,14 @@ void SymbolView::refreshShortcutsSlot()
 
 void SymbolView::updateStyle()
 {
-    mModuleList->stdList()->reloadData();
-    mModuleList->stdSearchList()->reloadData();
     ui->symbolLogEdit->setFont(ConfigFont("Log"));
     ui->symbolLogEdit->setStyleSheet(QString("QTextEdit { color: %1; background-color: %2 }").arg(ConfigColor("AbstractTableViewTextColor").name(), ConfigColor("AbstractTableViewBackgroundColor").name()));
+}
+
+void SymbolView::reloadDataSlot()
+{
+    mModuleList->stdList()->reloadData();
+    mModuleList->stdSearchList()->reloadData();
 }
 
 void SymbolView::addMsgToSymbolLogSlot(QString msg)

--- a/src/gui/Src/Gui/SymbolView.h
+++ b/src/gui/Src/Gui/SymbolView.h
@@ -30,6 +30,7 @@ public:
 
 private slots:
     void updateStyle();
+    void reloadDataSlot();
     void addMsgToSymbolLogSlot(QString msg);
     void clearSymbolLogSlot();
     void moduleSelectionChanged(int index);


### PR DESCRIPTION
Many actions in the debugger (like toggling a breakpoint with F2) force all the views to update. That includes the Symbols log. On each update, its font and stylesheet settings are refreshed. Depending on how much text is in the log, that causes serious slowdown to the whole program (e.g. there may be several second delay just to put a single breakpoint).

I don't know precisely how, but it seems to be dependent on the currently selected fonts (maybe non-default ones cause this or something).

**Steps to reproduce**

1. Download the latest snapshot ([snapshot_2023-09-21_00-53.zip](https://github.com/x64dbg/x64dbg/releases/latest))
2. Start & exit `x64dbg.exe`
3. Open `x64dbg.ini` and replace `[Fonts]` with (set some other monospaced font if this one is not present):
```
[Fonts]
AbstractTableView=Courier New,12,-1,5,50,0,0,0,0,0
Application=Courier New,12,-1,5,50,0,0,0,0,0
Disassembly=Courier New,14,-1,5,50,0,0,0,0,0
HexDump=Courier New,12,-1,5,50,0,0,0,0,0
HexEdit=Courier New,12,-1,5,50,0,0,0,0,0
Log=Courier New,12,-1,5,50,0,0,0,0,0
Registers=Courier New,12,-1,5,50,0,0,0,0,0
Stack=Courier New,12,-1,5,50,0,0,0,0,0
```
4. Launch `x64dbg` and run/rerun a program that would generate a lot of input in the Symbols log (1000+ lines, or even better: 5000+). Or try this script (change the exe path):
```
i = 0
loop:
    init "C:\x96dbg\x64\x64dbg.exe"
    i++
    cmp i, 180
    jne loop
```
5. Make sure the Symbols tab was opened at least once
6. Try to do something like putting a breakpoint or pressing 'Restart' and see how everything got much slower