### PR TITLE
Find Pattern searches now begin at start of current region

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -1217,7 +1217,6 @@ void CPUDisassembly::findCallsSlot()
 void CPUDisassembly::findPatternSlot()
 {
     HexEditDialog hexEdit(this);
-    hexEdit.showEntireBlock(true);
     hexEdit.isDataCopiable(false);
     hexEdit.mHexEdit->setOverwriteMode(false);
     hexEdit.setWindowTitle(tr("Find Pattern..."));
@@ -1225,12 +1224,11 @@ void CPUDisassembly::findPatternSlot()
         return;
 
     dsint addr = rvaToVa(getSelectionStart());
-    if(hexEdit.entireBlock())
-        addr = DbgMemFindBaseAddr(addr, 0);
 
     QString command;
     if(sender() == mFindPatternRegion)
     {
+        addr = DbgMemFindBaseAddr(addr, 0);
         command = QString("findall %1, %2").arg(ToHexString(addr), hexEdit.mHexEdit->pattern());
     }
     else if(sender() == mFindPatternModule)

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -1444,12 +1444,16 @@ void CPUDump::findPattern()
 {
     HexEditDialog hexEdit(this);
     hexEdit.isDataCopiable(false);
+    hexEdit.showStartFromSelection(true, ConfigBool("Gui", "CPUDumpStartFromSelect"));
     hexEdit.mHexEdit->setOverwriteMode(false);
     hexEdit.setWindowTitle(tr("Find Pattern..."));
     if(hexEdit.exec() != QDialog::Accepted)
         return;
+    bool startFromSelection = hexEdit.startFromSelection();
+    Config()->setBool("Gui", "CPUDumpStartFromSelect", startFromSelection);
     dsint addr = rvaToVa(getSelectionStart());
-    addr = DbgMemFindBaseAddr(addr, 0);
+    if(!startFromSelection)
+        addr = DbgMemFindBaseAddr(addr, 0);
     QString addrText = ToPtrString(addr);
     DbgCmdExec(QString("findall " + addrText + ", " + hexEdit.mHexEdit->pattern() + ", &data&"));
     emit displayReferencesWidget();

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -1443,15 +1443,13 @@ void CPUDump::binarySaveToFileSlot()
 void CPUDump::findPattern()
 {
     HexEditDialog hexEdit(this);
-    hexEdit.showEntireBlock(true);
     hexEdit.isDataCopiable(false);
     hexEdit.mHexEdit->setOverwriteMode(false);
     hexEdit.setWindowTitle(tr("Find Pattern..."));
     if(hexEdit.exec() != QDialog::Accepted)
         return;
     dsint addr = rvaToVa(getSelectionStart());
-    if(hexEdit.entireBlock())
-        addr = DbgMemFindBaseAddr(addr, 0);
+    addr = DbgMemFindBaseAddr(addr, 0);
     QString addrText = ToPtrString(addr);
     DbgCmdExec(QString("findall " + addrText + ", " + hexEdit.mHexEdit->pattern() + ", &data&"));
     emit displayReferencesWidget();

--- a/src/gui/Src/Gui/CPUStack.cpp
+++ b/src/gui/Src/Gui/CPUStack.cpp
@@ -865,15 +865,15 @@ void CPUStack::binaryPasteIgnoreSizeSlot()
 void CPUStack::findPattern()
 {
     HexEditDialog hexEdit(this);
-    hexEdit.showEntireBlock(true);
     hexEdit.isDataCopiable(false);
     hexEdit.mHexEdit->setOverwriteMode(false);
     hexEdit.setWindowTitle(tr("Find Pattern..."));
     if(hexEdit.exec() != QDialog::Accepted)
         return;
+
     dsint addr = rvaToVa(getSelectionStart());
-    if(hexEdit.entireBlock())
-        addr = DbgMemFindBaseAddr(addr, 0);
+    addr = DbgMemFindBaseAddr(addr, 0);
+
     QString addrText = ToPtrString(addr);
     DbgCmdExec(QString("findall " + addrText + ", " + hexEdit.mHexEdit->pattern() + ", &data&"));
     emit displayReferencesWidget();

--- a/src/gui/Src/Gui/CPUStack.cpp
+++ b/src/gui/Src/Gui/CPUStack.cpp
@@ -866,13 +866,17 @@ void CPUStack::findPattern()
 {
     HexEditDialog hexEdit(this);
     hexEdit.isDataCopiable(false);
+    hexEdit.showStartFromSelection(true, ConfigBool("Gui", "CPUStackStartFromSelect"));
     hexEdit.mHexEdit->setOverwriteMode(false);
     hexEdit.setWindowTitle(tr("Find Pattern..."));
     if(hexEdit.exec() != QDialog::Accepted)
         return;
 
     dsint addr = rvaToVa(getSelectionStart());
-    addr = DbgMemFindBaseAddr(addr, 0);
+    bool startFromSelection = hexEdit.startFromSelection();
+    Config()->setBool("Gui", "CPUStackStartFromSelect", startFromSelection);
+    if(!startFromSelection)
+        addr = DbgMemFindBaseAddr(addr, 0);
 
     QString addrText = ToPtrString(addr);
     DbgCmdExec(QString("findall " + addrText + ", " + hexEdit.mHexEdit->pattern() + ", &data&"));

--- a/src/gui/Src/Gui/HexEditDialog.cpp
+++ b/src/gui/Src/Gui/HexEditDialog.cpp
@@ -28,6 +28,7 @@ HexEditDialog::HexEditDialog(QWidget* parent) : QDialog(parent), ui(new Ui::HexE
     ui->chkKeepSize->setChecked(ConfigBool("HexDump", "KeepSize"));
     ui->chkKeepSize->hide();
     ui->chkEntireBlock->hide();
+    ui->chkFromSelection->hide();
 
     mDataInitialized = false;
     stringEditorLock = false;
@@ -112,6 +113,12 @@ void HexEditDialog::showKeepSize(bool show)
     ui->chkKeepSize->setVisible(show);
 }
 
+void HexEditDialog::showStartFromSelection(bool show, bool checked)
+{
+    ui->chkFromSelection->setVisible(show);
+    ui->chkFromSelection->setChecked(checked);
+}
+
 void HexEditDialog::isDataCopiable(bool copyDataEnabled)
 {
     if(copyDataEnabled == false)
@@ -148,6 +155,11 @@ void HexEditDialog::updateCodepage(const QByteArray & name)
 bool HexEditDialog::entireBlock()
 {
     return ui->chkEntireBlock->isChecked();
+}
+
+bool HexEditDialog::startFromSelection()
+{
+    return ui->chkFromSelection->isChecked();
 }
 
 void HexEditDialog::updateStyle()

--- a/src/gui/Src/Gui/HexEditDialog.h
+++ b/src/gui/Src/Gui/HexEditDialog.h
@@ -18,10 +18,12 @@ public:
 
     void showEntireBlock(bool show, bool checked = false);
     void showKeepSize(bool show);
+    void showStartFromSelection(bool show, bool checked = false);
     void isDataCopiable(bool copyDataEnabled);
     void updateCodepage();
 
     bool entireBlock();
+    bool startFromSelection();
 
     QHexEdit* mHexEdit;
 

--- a/src/gui/Src/Gui/HexEditDialog.ui
+++ b/src/gui/Src/Gui/HexEditDialog.ui
@@ -446,6 +446,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="chkFromSelection">
+       <property name="text">
+        <string>Start from &amp;Selection</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/gui/Src/Gui/MemoryMapView.cpp
+++ b/src/gui/Src/Gui/MemoryMapView.cpp
@@ -612,12 +612,23 @@ void MemoryMapView::findPatternSlot()
     hexEdit.setWindowTitle(tr("Find Pattern..."));
     if(hexEdit.exec() != QDialog::Accepted)
         return;
-    duint addr = getSelectionAddr();
+
     entireBlockEnabled = hexEdit.entireBlock();
     BridgeSettingSetUint("Gui", "MemoryMapEntireBlock", entireBlockEnabled);
     if(entireBlockEnabled)
-        addr = 0;
-    DbgCmdExec(QString("findallmem %1, %2, &data&").arg(ToPtrString(addr)).arg(hexEdit.mHexEdit->pattern()));
+    {
+        DbgCmdExec(QString("findallmem 0, %2").arg(hexEdit.mHexEdit->pattern()));
+    }
+    else
+    {
+        QList<duint> selection = getSelection();
+        if(selection.isEmpty())
+            return;
+        duint addrFirst = getCellUserdata(selection.first(), ColAddress);
+        duint addrLast = getCellUserdata(selection.last(), ColAddress);
+        duint size = getCellUserdata(selection.last(), ColSize);
+        DbgCmdExec(QString("findallmem %1, %2, %3").arg(ToPtrString(addrFirst)).arg(hexEdit.mHexEdit->pattern()).arg(ToHexString(addrLast - addrFirst + size)));
+    }
     emit showReferences();
 }
 

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -254,7 +254,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     disassemblyBool.insert("KeepSize", false);
     disassemblyBool.insert("FillNOPs", false);
     disassemblyBool.insert("Uppercase", false);
-    disassemblyBool.insert("FindCommandEntireBlock", false);
+    disassemblyBool.insert("FindCommandFromSelection", true);
+    disassemblyBool.insert("FindPatternFromSelection", true);
     disassemblyBool.insert("OnlyCipAutoComments", false);
     disassemblyBool.insert("TabbedMnemonic", false);
     disassemblyBool.insert("LongDataInstruction", false);
@@ -292,6 +293,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     guiBool.insert("AutoFollowInStack", true);
     guiBool.insert("EnableQtHighDpiScaling", true);
     guiBool.insert("Topmost", false);
+    guiBool.insert("CPUDumpStartFromSelect", true);
+    guiBool.insert("CPUStackStartFromSelect", true);
     //Named menu settings
     insertMenuBuilderBools(&guiBool, "CPUDisassembly", 50); //CPUDisassembly
     insertMenuBuilderBools(&guiBool, "CPUDump", 50); //CPUDump


### PR DESCRIPTION
It didn't make sense for searches to begin from the current selection, nor was this obvious from the UI, maybe this was a bug.
The start/end of the search ranges are dependant on the users Memory Map view (Section or Region view), perhaps this should be made clear to the user somehow.

Disassembler: Search for -> Current Region -> Pattern (Ctrl + B)
Previous range: Selection -> End of Region
New range: Start of Region -> End of Region
Removed "Entire Block" checkbox

Dump: Find Pattern... (Ctrl + B)
Previous range: Selection -> End of Region
New range: Start of Region -> End of Region
Removed "Entire Block" checkbox

Stack: Find Pattern... (Ctrl + B)
Previous range: Selection -> End of Region
New range: Start of Region -> End of Region
Removed "Entire Block" checkbox

Memory Map: Find Pattern... (Ctrl + B)
Search through all selected regions (if more than one is selected)