### PR TITLE
Fixed a bug in the Edit Breakpoint dialog that might erase double quotes

### DIFF
--- a/src/gui/Src/Gui/EditBreakpointDialog.cpp
+++ b/src/gui/Src/Gui/EditBreakpointDialog.cpp
@@ -35,6 +35,8 @@ EditBreakpointDialog::EditBreakpointDialog(QWidget* parent, const BRIDGEBP & bp)
     setWindowIcon(DIcon("breakpoint"));
     loadFromBp();
 
+    connect(this, SIGNAL(accepted()), this, SLOT(acceptedSlot()));
+
     Config()->loadWindowGeometry(this);
 }
 
@@ -66,53 +68,22 @@ void copyTruncate(T & dest, QString src)
     strncpy_s(dest, src.toUtf8().constData(), _TRUNCATE);
 }
 
-void EditBreakpointDialog::on_editName_textEdited(const QString & arg1)
-{
-    copyTruncate(mBp.name, arg1);
-}
-
-void EditBreakpointDialog::on_editBreakCondition_textEdited(const QString & arg1)
-{
-    copyTruncate(mBp.breakCondition, arg1);
-}
-
 void EditBreakpointDialog::on_editLogText_textEdited(const QString & arg1)
 {
     ui->checkBoxSilent->setChecked(true);
-    copyTruncate(mBp.logText, arg1);
 }
 
-void EditBreakpointDialog::on_editLogCondition_textEdited(const QString & arg1)
+void EditBreakpointDialog::acceptedSlot()
 {
-    copyTruncate(mBp.logCondition, arg1);
-}
+    copyTruncate(mBp.breakCondition, ui->editBreakCondition->text());
+    copyTruncate(mBp.logText, ui->editLogText->text());
+    copyTruncate(mBp.logCondition, ui->editLogCondition->text());
+    copyTruncate(mBp.commandText, ui->editCommandText->text());
+    copyTruncate(mBp.commandCondition, ui->editCommandCondition->text());
+    copyTruncate(mBp.name, ui->editName->text());
 
-void EditBreakpointDialog::on_editCommandText_textEdited(const QString & arg1)
-{
-    copyTruncate(mBp.commandText, arg1);
-}
-
-void EditBreakpointDialog::on_editCommandCondition_textEdited(const QString & arg1)
-{
-    copyTruncate(mBp.commandCondition, arg1);
-}
-
-void EditBreakpointDialog::on_checkBoxFastResume_toggled(bool checked)
-{
-    mBp.fastResume = checked;
-}
-
-void EditBreakpointDialog::on_spinHitCount_valueChanged(int arg1)
-{
-    mBp.hitCount = arg1;
-}
-
-void EditBreakpointDialog::on_checkBoxSilent_toggled(bool checked)
-{
-    mBp.silent = checked;
-}
-
-void EditBreakpointDialog::on_checkBoxSingleshoot_toggled(bool checked)
-{
-    mBp.singleshoot = checked;
+    mBp.singleshoot = ui->checkBoxSingleshoot->isChecked();
+    mBp.fastResume = ui->checkBoxFastResume->isChecked();
+    mBp.hitCount = ui->spinHitCount->value();
+    mBp.silent = ui->checkBoxSilent->isChecked();
 }

--- a/src/gui/Src/Gui/EditBreakpointDialog.cpp
+++ b/src/gui/Src/Gui/EditBreakpointDialog.cpp
@@ -10,7 +10,9 @@ EditBreakpointDialog::EditBreakpointDialog(QWidget* parent, const BRIDGEBP & bp)
       mBp(bp)
 {
     ui->setupUi(this);
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::MSWindowsFixedSizeDialogHint);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setFixedHeight(sizeHint().height()); // resizable only horizontally
+
     switch(bp.type)
     {
     case bp_dll:

--- a/src/gui/Src/Gui/EditBreakpointDialog.h
+++ b/src/gui/Src/Gui/EditBreakpointDialog.h
@@ -21,16 +21,8 @@ public:
     }
 
 private slots:
-    void on_editName_textEdited(const QString & arg1);
-    void on_editBreakCondition_textEdited(const QString & arg1);
     void on_editLogText_textEdited(const QString & arg1);
-    void on_editLogCondition_textEdited(const QString & arg1);
-    void on_editCommandText_textEdited(const QString & arg1);
-    void on_editCommandCondition_textEdited(const QString & arg1);
-    void on_checkBoxFastResume_toggled(bool checked);
-    void on_spinHitCount_valueChanged(int arg1);
-    void on_checkBoxSilent_toggled(bool checked);
-    void on_checkBoxSingleshoot_toggled(bool checked);
+    void acceptedSlot();
 
 private:
     Ui::EditBreakpointDialog* ui;


### PR DESCRIPTION
Should fix #3248

As I can see, one of the few things that this dialog does is escape double quotes. But it's done in the methods like `on_editLogText_textEdited`, which are obviously called only when something is actually updated. So if the user doesn't touch the text fields, they don't get escaped. The solution is to make this escaping mandatory as soon as the OK button is pressed.

Somewhat unrelated, I also made the window resizable horizontally. If I remember correctly, the maximum size of those text fields is 256 bytes, but the window has room only for ~42 characters by default.