### PR TITLE
Make error messages clearer if x96dbg fails to open a file

### DIFF
--- a/src/launcher/x64dbg_launcher.cpp
+++ b/src/launcher/x64dbg_launcher.cpp
@@ -714,9 +714,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
             break;
         case PeArch::Invalid:
             if(FileExists(szPath))
-                MessageBox(nullptr, argv[1], LoadResString(IDS_INVDPE), MB_ICONERROR);
+                MessageBox(nullptr, LoadResString(IDS_INVDPE), argv[1], MB_ICONERROR);
             else
-                MessageBox(nullptr, argv[1], LoadResString(IDS_FILEERR), MB_ICONERROR);
+                MessageBox(nullptr, LoadResString(IDS_FILEERR), argv[1], MB_ICONERROR);
             break;
         default:
             __debugbreak();


### PR DESCRIPTION
When x96dbg failed to open a file, it displayed a message box with the path as the message and a reason string as the caption. This looks weird, as the caption conveys useful information but it can usually be truncated.

We should display the reason string as the message, and the path as the caption instead.