### PR TITLE
#3163: Long symbol name

### DIFF
--- a/src/gui/Src/Gui/GotoDialog.cpp
+++ b/src/gui/Src/Gui/GotoDialog.cpp
@@ -87,16 +87,14 @@ void GotoDialog::setInitialExpression(const QString & expression)
 
 static QString breakWithLines(const unsigned int numberCharsPerLine, const QString & txt, const bool condBreakBefore)
 {
-
     const QString BRStr = QString("<br>");
     const unsigned int breakCount = txt.size() / numberCharsPerLine;
-    const unsigned int charactersToSkip = numberCharsPerLine + BRStr.size();
-
     QString result = txt;
-
+    
     for(unsigned int i = 1 ; i <= breakCount; i++)
     {
-        result = result.left(charactersToSkip * i) + BRStr + result.right(result.size() - charactersToSkip * i);
+        unsigned int charactersToSkip = (numberCharsPerLine + BRStr.size()) * i - BRStr.size();
+        result = result.left(charactersToSkip) + BRStr + result.right(result.size() - charactersToSkip);
     }
 
     if(condBreakBefore && breakCount >= 1)

--- a/src/gui/Src/Gui/GotoDialog.cpp
+++ b/src/gui/Src/Gui/GotoDialog.cpp
@@ -85,7 +85,8 @@ void GotoDialog::setInitialExpression(const QString & expression)
     emit ui->editExpression->textEdited(expression);
 }
 
-static QString breakWithLines(const unsigned int numberCharsPerLine, const QString &txt, const bool condBreakBefore){
+static QString breakWithLines(const unsigned int numberCharsPerLine, const QString & txt, const bool condBreakBefore)
+{
 
     const QString BRStr = QString("<br>");
     const unsigned int breakCount = txt.size() / numberCharsPerLine;
@@ -93,8 +94,9 @@ static QString breakWithLines(const unsigned int numberCharsPerLine, const QStri
 
     QString result = txt;
 
-    for(unsigned int i = 1 ; i <= breakCount; i++){
-        result = result.left(charactersToSkip * i) + BRStr + result.right( result.size() - charactersToSkip * i);
+    for(unsigned int i = 1 ; i <= breakCount; i++)
+    {
+        result = result.left(charactersToSkip * i) + BRStr + result.right(result.size() - charactersToSkip * i);
     }
 
     if(condBreakBefore && breakCount >= 1)

--- a/src/gui/Src/Gui/GotoDialog.cpp
+++ b/src/gui/Src/Gui/GotoDialog.cpp
@@ -85,6 +85,24 @@ void GotoDialog::setInitialExpression(const QString & expression)
     emit ui->editExpression->textEdited(expression);
 }
 
+static QString breakWithLines(const unsigned int numberCharsPerLine, const QString &txt, const bool condBreakBefore){
+
+    const QString BRStr = QString("<br>");
+    const unsigned int breakCount = txt.size() / numberCharsPerLine;
+    const unsigned int charactersToSkip = numberCharsPerLine + BRStr.size();
+
+    QString result = txt;
+
+    for(unsigned int i = 1 ; i <= breakCount; i++){
+        result = result.left(charactersToSkip * i) + BRStr + result.right( result.size() - charactersToSkip * i);
+    }
+
+    if(condBreakBefore && breakCount >= 1)
+        result = BRStr + result;
+
+    return result;
+}
+
 void GotoDialog::expressionChanged(bool validExpression, bool validPointer, dsint value)
 {
     QString expression = ui->editExpression->text();
@@ -167,6 +185,8 @@ void GotoDialog::expressionChanged(bool validExpression, bool validPointer, dsin
                 addrText = QString(module) + "." + ToPtrString(addr);
             else
                 addrText = ToPtrString(addr);
+
+            addrText = breakWithLines(ui->editExpression->size().width() / 11, addrText, true); // 11 is a good value for WWWWWWWs
             ui->labelError->setText(tr("<font color='#00DD00'><b>Correct expression! -&gt; </b></font>") + addrText);
             setOkEnabled(true);
             expressionText = expression;

--- a/src/gui/Src/Gui/GotoDialog.cpp
+++ b/src/gui/Src/Gui/GotoDialog.cpp
@@ -90,7 +90,7 @@ static QString breakWithLines(const unsigned int numberCharsPerLine, const QStri
     const QString BRStr = QString("<br>");
     const unsigned int breakCount = txt.size() / numberCharsPerLine;
     QString result = txt;
-    
+
     for(unsigned int i = 1 ; i <= breakCount; i++)
     {
         unsigned int charactersToSkip = (numberCharsPerLine + BRStr.size()) * i - BRStr.size();

--- a/src/gui/Src/Gui/GotoDialog.ui
+++ b/src/gui/Src/Gui/GotoDialog.ui
@@ -26,10 +26,23 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="HistoryLineEdit" name="editExpression"/>
+        <widget class="HistoryLineEdit" name="editExpression">
+         <property name="maximumSize">
+          <size>
+           <width>4132</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QLabel" name="labelError">
+         <property name="maximumSize">
+          <size>
+           <width>4132</width>
+           <height>16777215</height>
+          </size>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -58,7 +71,7 @@
        <item>
         <widget class="QPushButton" name="buttonOk">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -71,7 +84,7 @@
        <item>
         <widget class="QPushButton" name="buttonCancel">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>


### PR DESCRIPTION
Had a crash course regarding Qt GUI...

The window now does not want to increase in size (somehow?, maybe by reducing the label width it got force shortened?), I have added max values to prevent expanding too much if it would happen.

Added a functionality to split a long symbol name with break lines based on the width of the editExpression.

Solves #3163 .