### PR TITLE
#3232: Providing Rename Thread and etc. for CallStack View

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -1779,6 +1779,12 @@ BRIDGE_IMPEXP void GuiMenuSetEntryHotkey(int hEntry, const char* hack)
     _gui_sendmessage(GUI_MENU_SET_ENTRY_HOTKEY, (void*)hEntry, (void*)hack);
 }
 
+
+BRIDGE_IMPEXP void GuiShowThreads()
+{
+    _gui_sendmessage(GUI_SHOW_THREADS, 0, 0);
+}
+
 BRIDGE_IMPEXP void GuiShowCpu()
 {
     _gui_sendmessage(GUI_SHOW_CPU, 0, 0);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1152,6 +1152,7 @@ typedef enum
     GUI_GRAPH,
     GUI_MEMMAP,
     GUI_SYMMOD,
+    GUI_THREADS,
 } GUISELECTIONTYPE;
 
 #define GUI_MAX_LINE_SIZE 65536
@@ -1281,6 +1282,7 @@ typedef enum
     GUI_SAVE_LOG,                   // param1=const char* file name,param2=unused
     GUI_REDIRECT_LOG,               // param1=const char* file name,param2=unused
     GUI_STOP_REDIRECT_LOG,          // param1=unused,               param2=unused
+    GUI_SHOW_THREADS,               // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
@@ -1423,6 +1425,7 @@ BRIDGE_IMPEXP void GuiMenuSetName(int hMenu, const char* name);
 BRIDGE_IMPEXP void GuiMenuSetEntryName(int hEntry, const char* name);
 BRIDGE_IMPEXP void GuiMenuSetEntryHotkey(int hEntry, const char* hack);
 BRIDGE_IMPEXP void GuiShowCpu();
+BRIDGE_IMPEXP void GuiShowThreads();
 BRIDGE_IMPEXP void GuiAddQWidgetTab(void* qWidget);
 BRIDGE_IMPEXP void GuiShowQWidgetTab(void* qWidget);
 BRIDGE_IMPEXP void GuiCloseQWidgetTab(void* qWidget);

--- a/src/dbg/commands/cmd-gui.h
+++ b/src/dbg/commands/cmd-gui.h
@@ -2,6 +2,7 @@
 
 #include "command.h"
 
+bool cbShowThreadId(int argc, char* argv[]);
 bool cbDebugDisasm(int argc, char* argv[]);
 bool cbDebugDump(int argc, char* argv[]);
 bool cbDebugStackDump(int argc, char* argv[]);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -415,6 +415,7 @@ static void registercommands()
     dbgcmdnew("scriptcmd", cbScriptCmd, false); // execute a script command TODO: undocumented
 
     //gui
+    dbgcmdnew("showthreadid", cbShowThreadId, false); // show given thread in threads
     dbgcmdnew("disasm,dis,d", cbDebugDisasm, true); //doDisasm
     dbgcmdnew("dump", cbDebugDump, true); //dump at address
     dbgcmdnew("sdump", cbDebugStackDump, true); //dump at stack address

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -579,6 +579,9 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
         case GUI_MEMMAP:
             emit selectionMemmapSet(selection);
             break;
+        case GUI_THREADS:
+            emit selectionThreadsSet(selection);
+            break;
         default:
             return (void*)false;
         }
@@ -642,6 +645,10 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
 
     case GUI_LOAD_SOURCE_FILE:
         emit loadSourceFile(QString((const char*)param1), (duint)param2);
+        break;
+
+    case GUI_SHOW_THREADS:
+        emit showThreads();
         break;
 
     case GUI_SHOW_CPU:

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -125,6 +125,7 @@ signals:
     void selectionMemmapGet(SELECTIONDATA* selection);
     void selectionMemmapSet(const SELECTIONDATA* selection);
     void selectionSymmodGet(SELECTIONDATA* selection);
+    void selectionThreadsSet(const SELECTIONDATA* selection);
     void getStrWindow(const QString title, QString* text);
     void autoCompleteAddCmd(const QString cmd);
     void autoCompleteDelCmd(const QString cmd);
@@ -139,6 +140,7 @@ signals:
     void symbolRefreshCurrent();
     void loadSourceFile(const QString path, duint addr);
     void showCpu();
+    void showThreads();
     void addQWidgetTab(QWidget* qWidget);
     void showQWidgetTab(QWidget* qWidget);
     void closeQWidgetTab(QWidget* qWidget);

--- a/src/gui/Src/Gui/BreakpointsView.cpp
+++ b/src/gui/Src/Gui/BreakpointsView.cpp
@@ -813,9 +813,7 @@ void BreakpointsView::addExceptionBreakpointSlot()
 
 static QString escape(QString data)
 {
-    //data = data.replace("\\", "\\\\");
-    data = data.replace("\"", "\\\"");
-    return data;
+    return DbgCmdEscape(std::move(data));
 }
 
 void BreakpointsView::copyConditionalBreakpointSlot()

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -739,11 +739,11 @@ void CPUDisassembly::setLabelSlot()
     duint va = rvaToVa(getInitialSelection());
     LineEditDialog mLineEdit(this);
     mLineEdit.setTextMaxLength(MAX_LABEL_SIZE - 2);
-    QString addr_text = ToPtrString(va);
+    QString addrText = ToPtrString(va);
     char label_text[MAX_COMMENT_SIZE] = "";
     if(DbgGetLabelAt((duint)va, SEG_DEFAULT, label_text))
         mLineEdit.setText(QString(label_text));
-    mLineEdit.setWindowTitle(tr("Add label at ") + addr_text);
+    mLineEdit.setWindowTitle(tr("Add label at ") + addrText);
 restart:
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
@@ -785,11 +785,11 @@ void CPUDisassembly::setLabelAddressSlot()
         return;
     LineEditDialog mLineEdit(this);
     mLineEdit.setTextMaxLength(MAX_LABEL_SIZE - 2);
-    QString addr_text = ToPtrString(addr);
+    QString addrText = ToPtrString(addr);
     char label_text[MAX_LABEL_SIZE] = "";
     if(DbgGetLabelAt(addr, SEG_DEFAULT, label_text))
         mLineEdit.setText(QString(label_text));
-    mLineEdit.setWindowTitle(tr("Add label at ") + addr_text);
+    mLineEdit.setWindowTitle(tr("Add label at ") + addrText);
 restart:
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
@@ -902,7 +902,7 @@ void CPUDisassembly::assembleSlot()
         dsint rva = getInitialSelection();
         duint va = rvaToVa(rva);
         unfold(rva);
-        QString addr_text = ToPtrString(va);
+        QString addrText = ToPtrString(va);
 
         Instruction_t instr = this->DisassembleAt(rva);
 
@@ -919,7 +919,7 @@ void CPUDisassembly::assembleSlot()
             if(ConfigBool("Disassembler", "Uppercase"))
                 actual_inst = actual_inst.toUpper().replace(QRegularExpression("0X([0-9A-F]+)"), "0x\\1");
             assembleDialog.setTextEditValue(actual_inst);
-            assembleDialog.setWindowTitle(tr("Assemble at %1").arg(addr_text));
+            assembleDialog.setWindowTitle(tr("Assemble at %1").arg(addrText));
             assembleDialog.setFillWithNopsChecked(ConfigBool("Disassembler", "FillNOPs"));
             assembleDialog.setKeepSizeChecked(ConfigBool("Disassembler", "KeepSize"));
 
@@ -1798,11 +1798,11 @@ void CPUDisassembly::findCommandSlot()
         return;
     }
 
-    QString addr_text = ToPtrString(va);
+    QString addrText = ToPtrString(va);
 
     dsint size = mMemPage->getSize();
     if(refFindType != -1)
-        DbgCmdExec(QString("findasm \"%1\", %2, .%3, %4").arg(mLineEdit.editText).arg(addr_text).arg(size).arg(refFindType));
+        DbgCmdExec(QString("findasm \"%1\", %2, .%3, %4").arg(mLineEdit.editText).arg(addrText).arg(size).arg(refFindType));
     else
     {
         duint start, end;

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -21,6 +21,8 @@ protected slots:
     void followTo();
     void followFrom();
     void showSuspectedCallStack();
+    void followInThreads();
+    void renameThread();
 
 private:
     enum
@@ -37,4 +39,5 @@ private:
     MenuBuilder* mMenuBuilder;
     CommonActions* mCommonActions;
     bool isSelectionValid();
+    bool CallStackView::isThreadHeaderSelected();
 };

--- a/src/gui/Src/Gui/CallStackView.h
+++ b/src/gui/Src/Gui/CallStackView.h
@@ -15,14 +15,14 @@ protected:
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
 
 protected slots:
-    void updateCallStack();
+    void updateCallStackSlot();
     void contextMenuSlot(const QPoint pos);
-    void followAddress();
-    void followTo();
-    void followFrom();
-    void showSuspectedCallStack();
-    void followInThreads();
-    void renameThread();
+    void followAddressSlot();
+    void followToSlot();
+    void followFromSlot();
+    void showSuspectedCallStackSlot();
+    void followInThreadsSlot();
+    void renameThreadSlot();
 
 private:
     enum

--- a/src/gui/Src/Gui/EditBreakpointDialog.cpp
+++ b/src/gui/Src/Gui/EditBreakpointDialog.cpp
@@ -65,13 +65,13 @@ void EditBreakpointDialog::loadFromBp()
 template<typename T>
 void copyTruncate(T & dest, QString src)
 {
-    src.replace(QChar('\\'), QString("\\\\"));
-    src.replace(QChar('"'), QString("\\\""));
+    src = DbgCmdEscape(std::move(src));
     strncpy_s(dest, src.toUtf8().constData(), _TRUNCATE);
 }
 
 void EditBreakpointDialog::on_editLogText_textEdited(const QString & arg1)
 {
+    Q_UNUSED(arg1);
     ui->checkBoxSilent->setChecked(true);
 }
 

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -91,6 +91,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(Bridge::getBridge(), SIGNAL(getStrWindow(QString, QString*)), this, SLOT(getStrWindow(QString, QString*)));
     connect(Bridge::getBridge(), SIGNAL(showCpu()), this, SLOT(displayCpuWidget()));
     connect(Bridge::getBridge(), SIGNAL(showReferences()), this, SLOT(displayReferencesWidget()));
+    connect(Bridge::getBridge(), SIGNAL(showThreads()), this, SLOT(displayThreadsWidget()));
     connect(Bridge::getBridge(), SIGNAL(addQWidgetTab(QWidget*)), this, SLOT(addQWidgetTab(QWidget*)));
     connect(Bridge::getBridge(), SIGNAL(showQWidgetTab(QWidget*)), this, SLOT(showQWidgetTab(QWidget*)));
     connect(Bridge::getBridge(), SIGNAL(closeQWidgetTab(QWidget*)), this, SLOT(closeQWidgetTab(QWidget*)));
@@ -368,6 +369,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displaySourceManagerWidget()), this, SLOT(displaySourceViewWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displayLogWidget()), this, SLOT(displayLogWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(displaySymbolsWidget()), this, SLOT(displaySymbolWidget()));
+    connect(mThreadView, SIGNAL(displayThreadsView()), this, SLOT(displayThreadsWidget()));
     connect(mCpuWidget->getDisasmWidget(), SIGNAL(showPatches()), this, SLOT(patchWindow()));
     connect(mCpuWidget->getGraphWidget(), SIGNAL(displayLogWidget()), this, SLOT(displayLogWidget()));
 
@@ -1363,6 +1365,11 @@ void MainWindow::displayCpuWidget()
     showQWidgetTab(mCpuWidget);
 }
 
+void MainWindow::displayThreadsWidget()
+{
+    showQWidgetTab(mThreadView);
+}
+
 void MainWindow::displaySymbolWidget()
 {
     showQWidgetTab(mSymbolView);
@@ -1376,11 +1383,6 @@ void MainWindow::displaySourceViewWidget()
 void MainWindow::displayReferencesWidget()
 {
     showQWidgetTab(mReferenceManager);
-}
-
-void MainWindow::displayThreadsWidget()
-{
-    showQWidgetTab(mThreadView);
 }
 
 void MainWindow::displayGraphWidget()

--- a/src/gui/Src/Gui/MainWindow.h
+++ b/src/gui/Src/Gui/MainWindow.h
@@ -80,12 +80,12 @@ public slots:
     void displayBreakpointWidget();
     void updateWindowTitleSlot(QString filename);
     void runSlot();
+    void displayThreadsWidget();
     void displayCpuWidget();
     void displayCpuWidgetShowCpu();
     void displaySymbolWidget();
     void displaySourceViewWidget();
     void displayReferencesWidget();
-    void displayThreadsWidget();
     void displayVariables();
     void displayGraphWidget();
     void displayTraceWidget();

--- a/src/gui/Src/Gui/MemoryMapView.cpp
+++ b/src/gui/Src/Gui/MemoryMapView.cpp
@@ -545,12 +545,12 @@ void MemoryMapView::memoryExecuteSingleshootToggleSlot()
 {
     for(int i : getSelection())
     {
-        QString addr_text = getCellContent(i, ColAddress);
+        QString addrText = getCellContent(i, ColAddress);
         duint selectedAddr = getSelectionAddr();
         if((DbgGetBpxTypeAt(selectedAddr) & bp_memory) == bp_memory) //memory breakpoint set
-            DbgCmdExec(QString("bpmc ") + addr_text);
+            DbgCmdExec(QString("bpmc ") + addrText);
         else
-            DbgCmdExec(QString("bpm %1, 0, x").arg(addr_text));
+            DbgCmdExec(QString("bpm %1, 0, x").arg(addrText));
     }
 }
 
@@ -799,7 +799,7 @@ void MemoryMapView::commentSlot()
 {
     duint va = getSelectionAddr();
     LineEditDialog mLineEdit(this);
-    QString addr_text = ToPtrString(va);
+    QString addrText = ToPtrString(va);
     char comment_text[MAX_COMMENT_SIZE] = "";
     if(DbgGetCommentAt((duint)va, comment_text))
     {
@@ -808,7 +808,7 @@ void MemoryMapView::commentSlot()
         else
             mLineEdit.setText(QString(comment_text));
     }
-    mLineEdit.setWindowTitle(tr("Add comment at ") + addr_text);
+    mLineEdit.setWindowTitle(tr("Add comment at ") + addrText);
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
     if(!DbgSetCommentAt(va, mLineEdit.editText.replace('\r', "").replace('\n', "").toUtf8().constData()))

--- a/src/gui/Src/Gui/SimpleTraceDialog.cpp
+++ b/src/gui/Src/Gui/SimpleTraceDialog.cpp
@@ -35,9 +35,7 @@ void SimpleTraceDialog::setTraceCommand(const QString & command)
 
 static QString escapeText(QString str)
 {
-    str.replace(QChar('\\'), QString("\\\\"));
-    str.replace(QChar('"'), QString("\\\""));
-    return str;
+    return DbgCmdEscape(std::move(str));
 }
 
 void SimpleTraceDialog::on_btnOk_clicked()

--- a/src/gui/Src/Gui/SymbolView.cpp
+++ b/src/gui/Src/Gui/SymbolView.cpp
@@ -701,7 +701,7 @@ void SymbolView::moduleLoad()
     if(browse.exec() != QDialog::Accepted && browse.path.length())
         return;
     auto fileName = browse.path;
-    DbgCmdExec(QString("loadlib \"%1\"").arg(fileName.replace("\\", "\\\\")));
+    DbgCmdExec(QString("loadlib \"%1\"").arg(DbgCmdEscape(fileName)));
 }
 
 void SymbolView::moduleFree()

--- a/src/gui/Src/Gui/ThreadView.cpp
+++ b/src/gui/Src/Gui/ThreadView.cpp
@@ -17,8 +17,8 @@ void ThreadView::contextMenuSlot(const QPoint & pos)
 
 void ThreadView::GoToThreadEntry()
 {
-    QString addr_text = getCellContent(getInitialSelection(), 2);
-    DbgCmdExecDirect(QString("disasm " + addr_text));
+    QString addrText = getCellContent(getInitialSelection(), 2);
+    DbgCmdExecDirect(QString("disasm " + addrText));
 }
 
 void ThreadView::setupContextMenu()
@@ -405,8 +405,8 @@ void ThreadView::doubleClickedSlot()
     duint threadId = getCellUserdata(getInitialSelection(), 1);
     DbgCmdExecDirect("switchthread " + ToHexString(threadId));
 
-    QString addr_text = getCellContent(getInitialSelection(), 4);
-    DbgCmdExec("disasm " + addr_text);
+    QString addrText = getCellContent(getInitialSelection(), 4);
+    DbgCmdExec("disasm " + addrText);
 }
 
 void ThreadView::SetNameSlot()

--- a/src/gui/Src/Gui/ThreadView.h
+++ b/src/gui/Src/Gui/ThreadView.h
@@ -15,12 +15,12 @@ signals:
 
 public slots:
     void selectionThreadsSet(const SELECTIONDATA* selection);
-    void updateThreadList();
+    void updateThreadListSlot();
     void doubleClickedSlot();
-    void ExecCommand();
-    void GoToThreadEntry();
+    void execCommandSlot();
+    void gotoThreadEntrySlot();
     void contextMenuSlot(const QPoint & pos);
-    void SetNameSlot();
+    void setNameSlot();
 
 private:
     QAction* makeCommandAction(QAction* action, const QString & command);

--- a/src/gui/Src/Gui/ThreadView.h
+++ b/src/gui/Src/Gui/ThreadView.h
@@ -10,8 +10,11 @@ public:
     explicit ThreadView(StdTable* parent = nullptr);
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
     void setupContextMenu();
+signals:
+    void displayThreadsView();
 
 public slots:
+    void selectionThreadsSet(const SELECTIONDATA* selection);
     void updateThreadList();
     void doubleClickedSlot();
     void ExecCommand();

--- a/src/gui/Src/Gui/XrefBrowseDialog.cpp
+++ b/src/gui/Src/Gui/XrefBrowseDialog.cpp
@@ -230,95 +230,95 @@ void XrefBrowseDialog::onDebuggerClose(DBGSTATE state)
 
 void XrefBrowseDialog::breakpointSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
     if(DbgGetBpxTypeAt(mXrefInfo.references[ui->listWidget->currentRow()].addr) & bp_normal)
-        DbgCmdExec(QString("bc " + addr_text));
+        DbgCmdExec(QString("bc " + addrText));
     else
-        DbgCmdExec(QString("bp " + addr_text));
+        DbgCmdExec(QString("bp " + addrText));
 }
 
 void XrefBrowseDialog::hardwareAccess1Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", r, 1"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", r, 1"));
 }
 
 void XrefBrowseDialog::hardwareAccess2Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", r, 2"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", r, 2"));
 }
 
 void XrefBrowseDialog::hardwareAccess4Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", r, 4"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", r, 4"));
 }
 
 void XrefBrowseDialog::hardwareAccess8Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", r, 8"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", r, 8"));
 }
 
 void XrefBrowseDialog::hardwareWrite1Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", w, 1"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", w, 1"));
 }
 
 void XrefBrowseDialog::hardwareWrite2Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", w, 2"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", w, 2"));
 }
 
 void XrefBrowseDialog::hardwareWrite4Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", w, 4"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", w, 4"));
 }
 
 void XrefBrowseDialog::hardwareWrite8Slot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphws " + addr_text + ", w, 8"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphws " + addrText + ", w, 8"));
 }
 
 void XrefBrowseDialog::hardwareRemoveSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bphwc " + addr_text));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bphwc " + addrText));
 }
 
 void XrefBrowseDialog::memoryAccessSingleshootSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bpm " + addr_text + ", 0, a"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bpm " + addrText + ", 0, a"));
 }
 
 void XrefBrowseDialog::memoryAccessRestoreSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bpm " + addr_text + ", 1, a"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bpm " + addrText + ", 1, a"));
 }
 
 void XrefBrowseDialog::memoryWriteSingleshootSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bpm " + addr_text + ", 0, w"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bpm " + addrText + ", 0, w"));
 }
 
 void XrefBrowseDialog::memoryWriteRestoreSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bpm " + addr_text + ", 1, w"));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bpm " + addrText + ", 1, w"));
 }
 
 void XrefBrowseDialog::memoryRemoveSlot()
 {
-    QString addr_text = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
-    DbgCmdExec(QString("bpmc " + addr_text));
+    QString addrText = ToPtrString(mXrefInfo.references[ui->listWidget->currentRow()].addr);
+    DbgCmdExec(QString("bpmc " + addrText));
 }
 
 void XrefBrowseDialog::copyThisSlot()
@@ -330,11 +330,11 @@ void XrefBrowseDialog::breakpointAllSlot()
 {
     for(int i = 0; i < ui->listWidget->count(); i++)
     {
-        QString addr_text = ToPtrString(mXrefInfo.references[i].addr);
+        QString addrText = ToPtrString(mXrefInfo.references[i].addr);
         if(DbgGetBpxTypeAt(mXrefInfo.references[i].addr) & bp_normal)
-            DbgCmdExec(QString("bc " + addr_text));
+            DbgCmdExec(QString("bc " + addrText));
         else
-            DbgCmdExec(QString("bp " + addr_text));
+            DbgCmdExec(QString("bp " + addrText));
     }
 }
 

--- a/src/gui/Src/Utils/CommonActions.cpp
+++ b/src/gui/Src/Utils/CommonActions.cpp
@@ -234,11 +234,11 @@ void CommonActions::setLabelSlot()
     duint va = mGetSelection();
     LineEditDialog mLineEdit(widgetparent());
     mLineEdit.setTextMaxLength(MAX_LABEL_SIZE - 2);
-    QString addr_text = ToPtrString(va);
+    QString addrText = ToPtrString(va);
     char label_text[MAX_COMMENT_SIZE] = "";
     if(DbgGetLabelAt((duint)va, SEG_DEFAULT, label_text))
         mLineEdit.setText(QString(label_text));
-    mLineEdit.setWindowTitle(tr("Add label at ") + addr_text);
+    mLineEdit.setWindowTitle(tr("Add label at ") + addrText);
 restart:
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
@@ -267,7 +267,7 @@ void CommonActions::setCommentSlot()
     duint va = mGetSelection();
     LineEditDialog mLineEdit(widgetparent());
     mLineEdit.setTextMaxLength(MAX_COMMENT_SIZE - 2);
-    QString addr_text = ToPtrString(va);
+    QString addrText = ToPtrString(va);
     char comment_text[MAX_COMMENT_SIZE] = "";
     if(DbgGetCommentAt((duint)va, comment_text))
     {
@@ -276,7 +276,7 @@ void CommonActions::setCommentSlot()
         else
             mLineEdit.setText(QString(comment_text));
     }
-    mLineEdit.setWindowTitle(tr("Add comment at ") + addr_text);
+    mLineEdit.setWindowTitle(tr("Add comment at ") + addrText);
     if(mLineEdit.exec() != QDialog::Accepted)
         return;
     QString comment = mLineEdit.editText.replace('\r', "").replace('\n', "");

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -290,3 +290,11 @@ bool GetCommentFormat(duint addr, QString & comment, bool* autoComment)
         comment = commentData + a;
     return true;
 }
+
+QString DbgCmdEscape(QString argument)
+{
+    // TODO: implement this properly
+    argument.replace("\"", "\\\"");
+
+    return argument;
+}

--- a/src/gui/Src/Utils/StringUtil.h
+++ b/src/gui/Src/Utils/StringUtil.h
@@ -145,3 +145,5 @@ QString FILETIMEToDate(const FILETIME & date);
 bool GetCommentFormat(duint addr, QString & comment, bool* autoComment = nullptr);
 
 QString EscapeCh(QChar ch);
+
+QString DbgCmdEscape(QString argument);


### PR DESCRIPTION
Adding `Follow in Threads` and `Rename Thread` option to context menu.
![image](https://github.com/x64dbg/x64dbg/assets/28221162/c146003c-c70c-4ba0-ab18-73530010f1f1)

Solves #3232 