### PR TITLE
Fixed get count threads for multi-cpu system with NUMA architecture

### DIFF
--- a/src/dbg/_global.cpp
+++ b/src/dbg/_global.cpp
@@ -3,10 +3,12 @@
 \brief Implements the global class.
 */
 
+#include <windows.h>
 #include "_global.h"
 #include <objbase.h>
 #include <shlobj.h>
 #include <psapi.h>
+#include <thread>
 #include "DeviceNameResolver/DeviceNameResolver.h"
 
 /**
@@ -392,4 +394,54 @@ void WaitForMultipleThreadsTermination(const HANDLE* hThread, int count, DWORD t
     WaitForMultipleObjects(count, hThread, TRUE, timeout);
     for(int i = 0; i < count; i++)
         CloseHandle(hThread[i]);
+}
+
+// This implementation supports both conventional single-cpu PC configurations
+// and multi-cpu system on NUMA (Non-uniform_memory_access) architecture
+// Original code from here: https://developercommunity.visualstudio.com/t/hardware-concurrency-returns-an-incorrect-result/350854
+// Modified by GermanAizek
+duint GetThreadCount() noexcept
+{
+    DWORD length = 0;
+    duint concurrency = 0;
+    const auto validConcurrency = [&concurrency]() noexcept -> duint
+    {
+        return (concurrency == 0) ? std::thread::hardware_concurrency() : concurrency;
+    };
+    if(GetLogicalProcessorInformationEx(RelationAll, nullptr, &length) != FALSE)
+    {
+        return validConcurrency();
+    }
+    if(GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    {
+        return validConcurrency();
+    }
+    std::unique_ptr<void, void (*)(void*)> buffer(std::malloc(length), std::free);
+    if(!buffer)
+    {
+        return validConcurrency();
+    }
+    auto* mem = reinterpret_cast<unsigned char*>(buffer.get());
+    if(GetLogicalProcessorInformationEx(
+                RelationAll, reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(mem), &length) == false)
+    {
+        return validConcurrency();
+    }
+    DWORD i = 0;
+    while(i < length)
+    {
+        const auto* proc = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(mem + i);
+        if(proc->Relationship == RelationProcessorCore)
+        {
+            for(WORD group = 0; group < proc->Processor.GroupCount; ++group)
+            {
+                for(KAFFINITY mask = proc->Processor.GroupMask[group].Mask; mask != 0; mask >>= 1)
+                {
+                    concurrency += mask & 1;
+                }
+            }
+        }
+        i += proc->Size;
+    }
+    return validConcurrency();
 }

--- a/src/dbg/_global.h
+++ b/src/dbg/_global.h
@@ -65,6 +65,7 @@ bool IsWow64();
 bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, std::wstring & executable, std::wstring & arguments, std::wstring & workingDir);
 void WaitForThreadTermination(HANDLE hThread, DWORD timeout = INFINITE);
 void WaitForMultipleThreadsTermination(const HANDLE* hThread, int count, DWORD timeout = INFINITE);
+duint GetThreadCount() noexcept;
 
 #ifdef _WIN64
 #define ArchValue(x32value, x64value) x64value

--- a/src/dbg/_global.h
+++ b/src/dbg/_global.h
@@ -65,7 +65,7 @@ bool IsWow64();
 bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, std::wstring & executable, std::wstring & arguments, std::wstring & workingDir);
 void WaitForThreadTermination(HANDLE hThread, DWORD timeout = INFINITE);
 void WaitForMultipleThreadsTermination(const HANDLE* hThread, int count, DWORD timeout = INFINITE);
-duint GetThreadCount() noexcept;
+duint GetThreadCount();
 
 #ifdef _WIN64
 #define ArchValue(x32value, x64value) x64value

--- a/src/dbg/analysis/AnalysisPass.cpp
+++ b/src/dbg/analysis/AnalysisPass.cpp
@@ -77,7 +77,7 @@ duint AnalysisPass::IdealThreadCount()
     if(m_InternalMaxThreads == 0)
     {
         // Determine the maximum hardware thread count at once
-        duint maximumThreads = max(std::thread::hardware_concurrency(), 1);
+        duint maximumThreads = max(GetThreadCount(), 1);
 
         // Don't consume 100% of the CPU, adjust accordingly
         if(maximumThreads > 1)


### PR DESCRIPTION
Fixed very old problem on any Windows NT and modern Windows Server 😆 

https://developercommunity.visualstudio.com/t/hardware-concurrency-returns-an-incorrect-result/350854

https://stackoverflow.com/questions/31209256/reliable-way-to-programmatically-get-the-number-of-hardware-threads-on-windows

Why this commit is useful not only for server configurations, now a very cheap PC configuration is building from Xeon E54xx, X34xx, E3-xxxx, E5-xxxx, E7-xxx, any Silver, any Gold, any Platinum series, cheapest on LGA 2011v3 socket two-socket board with NUMA support is cheap on Alibaba, Baidu or Aliexpress and Amazon.

Examples:
https://www.alibaba.com/product-detail/DDR4-x99-dual-cpu-Lga2011-V3_1600443686429.html
https://www.amazon.com/Desktop-Motherboard-Gigabit-LGA2011-SATA3-0/dp/B0CC6KSTXC