### PR TITLE
Optimize select/deselect all in Page Rights UI

### DIFF
--- a/src/gui/Src/Gui/PageMemoryRights.cpp
+++ b/src/gui/Src/Gui/PageMemoryRights.cpp
@@ -55,14 +55,14 @@ void PageMemoryRights::RunAddrSize(duint addrin, duint sizein, QString pagetypei
 
 void PageMemoryRights::on_btnSelectall_clicked()
 {
-    for(int i = 0; i < ui->pagetableWidget->rowCount(); i++)
-    {
-        for(int j = 0; j < ui->pagetableWidget->columnCount(); j++)
-        {
-            QModelIndex idx = (ui->pagetableWidget->model()->index(i, j));
-            ui->pagetableWidget->selectionModel()->select(idx, QItemSelectionModel::Select);
-        }
-    }
+    const auto rowCount = ui->pagetableWidget->rowCount();
+    const auto columnCount = ui->pagetableWidget->columnCount();
+
+    QModelIndex topLeft = ui->pagetableWidget->model()->index(0, 0);
+    QModelIndex bottomRight = ui->pagetableWidget->model()->index(rowCount - 1, columnCount - 1);
+
+    QItemSelection selection(topLeft, bottomRight);
+    ui->pagetableWidget->selectionModel()->select(selection, QItemSelectionModel::Select);
 }
 
 void PageMemoryRights::on_btnDeselectall_clicked()

--- a/src/gui/Src/Gui/PageMemoryRights.cpp
+++ b/src/gui/Src/Gui/PageMemoryRights.cpp
@@ -67,12 +67,15 @@ void PageMemoryRights::on_btnSelectall_clicked()
 
 void PageMemoryRights::on_btnDeselectall_clicked()
 {
-    QModelIndexList indexList = ui->pagetableWidget->selectionModel()->selectedIndexes();
-    foreach(QModelIndex index, indexList)
-    {
-        ui->pagetableWidget->selectionModel()->select(index, QItemSelectionModel::Deselect);
+    QModelIndexList selectedIndexes = ui->pagetableWidget->selectionModel()->selectedIndexes();
+    if(selectedIndexes.isEmpty())
+        return;
 
-    }
+    QModelIndex topLeft = selectedIndexes.first();
+    QModelIndex bottomRight = selectedIndexes.last();
+
+    QItemSelection selection(topLeft, bottomRight);
+    ui->pagetableWidget->selectionModel()->select(selection, QItemSelectionModel::Deselect);
 }
 
 void PageMemoryRights::on_btnSetrights_clicked()


### PR DESCRIPTION
It took ages for the dialog to show up when the section is large. The select all implementation was also very inefficient, now its all pretty much instant.

~~The change in MemGetPageRights is maybe not the most optimal thing, the change will cause it to prefer the cache if the debugger is paused which should be safe in like 99% unless something modifies it externally, in most cases the memory pages are updated when the user modifies anything from within x64dbg.~~

Can't use the cache as when bListAllPages is disabled its not allowed to split which would lead to having the wrong information in the page list, ideally the UI memory map builds its own view and the actual memory map reflects the actual pages.