### PR TITLE
#3238: Escaping { from any command argument

### DIFF
--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -1248,7 +1248,7 @@ void MainWindow::openFileSlot()
 
 void MainWindow::openRecentFileSlot(QString filename)
 {
-    DbgCmdExec(QString().sprintf("init \"%s\"", filename.toUtf8().constData()));
+    DbgCmdExec(QString().sprintf("init \"%s\"", DbgCmdEscape(filename).toUtf8().constData()));
 }
 
 void MainWindow::runSlot()
@@ -1263,7 +1263,7 @@ void MainWindow::restartDebugging()
 {
     auto last = mMRUList->getEntry(0);
     if(!last.isEmpty())
-        DbgCmdExec(QString("init \"%1\"").arg(last));
+        DbgCmdExec(QString("init \"%1\"").arg(DbgCmdEscape(last)));
 }
 
 void MainWindow::displayBreakpointWidget()
@@ -1281,10 +1281,11 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* pEvent)
 
 void MainWindow::dropEvent(QDropEvent* pEvent)
 {
+
     if(pEvent->mimeData()->hasUrls())
     {
         QString filename = QDir::toNativeSeparators(pEvent->mimeData()->urls()[0].toLocalFile());
-        DbgCmdExec(QString().sprintf("init \"%s\"", filename.toUtf8().constData()));
+        DbgCmdExec(QString().sprintf("init \"%s\"", DbgCmdEscape(filename).toUtf8().constData()));
         pEvent->acceptProposedAction();
     }
 }

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -295,6 +295,7 @@ QString DbgCmdEscape(QString argument)
 {
     // TODO: implement this properly
     argument.replace("\"", "\\\"");
+    argument.replace("{", "\\{");
 
     return argument;
 }


### PR DESCRIPTION
Escaping the `{` from file path for initalization of the debugger by pressing Open File or Drag&Drop or restarting.

Also, it allows for providing `{` as a normal character for any cmd argument that is needed to be escaped (`setthreadname`, `loadlib`, `BreakpointEdit`).

plz test :<

Closes #3238