### PR TITLE
#3280: Selection shifts when MemoryMap is updated

### DIFF
--- a/src/gui/Src/BasicView/AbstractStdTable.cpp
+++ b/src/gui/Src/BasicView/AbstractStdTable.cpp
@@ -1040,6 +1040,8 @@ void AbstractStdTable::headerButtonPressedSlot(duint col)
     else
         mSort.ascending = !mSort.ascending;
     reloadData();
+
+    emit sortHappenedSignal();
 }
 
 void AbstractStdTable::reloadData()

--- a/src/gui/Src/BasicView/AbstractStdTable.cpp
+++ b/src/gui/Src/BasicView/AbstractStdTable.cpp
@@ -1032,7 +1032,13 @@ void AbstractStdTable::headerButtonPressedSlot(duint col)
 {
     if(!mIsColumnSortingAllowed)
         return;
-    if(mSort.column != col)
+
+    if(mSort.column == -1 && col == mAddressColumn)
+    {
+        mSort.column = col;
+        mSort.ascending = false;
+    }
+    else if(mSort.column != col)
     {
         mSort.column = col;
         mSort.ascending = true;
@@ -1041,7 +1047,7 @@ void AbstractStdTable::headerButtonPressedSlot(duint col)
         mSort.ascending = !mSort.ascending;
     reloadData();
 
-    emit sortHappenedSignal();
+    emit sortChangedSignal();
 }
 
 void AbstractStdTable::reloadData()

--- a/src/gui/Src/BasicView/AbstractStdTable.h
+++ b/src/gui/Src/BasicView/AbstractStdTable.h
@@ -76,6 +76,7 @@ signals:
     void keyPressedSignal(QKeyEvent* event);
     void doubleClickedSignal();
     void contextMenuSignal(const QPoint & pos);
+    void sortHappenedSignal();
 
 public slots:
     void copyLineSlot();

--- a/src/gui/Src/BasicView/AbstractStdTable.h
+++ b/src/gui/Src/BasicView/AbstractStdTable.h
@@ -76,7 +76,7 @@ signals:
     void keyPressedSignal(QKeyEvent* event);
     void doubleClickedSignal();
     void contextMenuSignal(const QPoint & pos);
-    void sortHappenedSignal();
+    void sortChangedSignal();
 
 public slots:
     void copyLineSlot();

--- a/src/gui/Src/Gui/MemoryMapView.h
+++ b/src/gui/Src/Gui/MemoryMapView.h
@@ -17,6 +17,7 @@ signals:
 
 public slots:
     void selectionChangedSlot(duint index);
+    void fixSelectionRangeSlot();
     void refreshShortcutsSlot();
     void stateChangedSlot(DBGSTATE state);
     void followDumpSlot();
@@ -42,13 +43,9 @@ public slots:
     void selectionGetSlot(SELECTIONDATA* selection);
     void selectionSetSlot(const SELECTIONDATA* selection);
     void disassembleAtSlot(duint va, duint cip);
-    void sortHappenedSlot();
-private:
 
+private:
     void setSwitchViewName();
-    std::pair<duint, duint> getAddressRangeFromSelection(QList<duint> & selection);
-    void tryEmitAddressSelectionChange(const SelectionData & newSelection, const std::pair<duint, duint> & newAddressRange);
-    void selectAddressRange(const std::pair<duint, duint> & addressRange);
 
     enum
     {
@@ -72,7 +69,6 @@ private:
         return getCellContent(getInitialSelection(), ColAddress);
     }
 
-    std::pair<duint, duint> mSelectedAddressRange;
     QAction* makeCommandAction(QAction* action, const QString & command);
 
     GotoDialog* mGoto = nullptr;
@@ -111,5 +107,9 @@ private:
     QAction* mReferences;
     QMenu* mPluginMenu;
 
-    duint mCipBase;
+    duint mCipBase = 0;
+    duint mSelectionStart = 0;
+    duint mSelectionEnd = 0;
+    duint mSelectionCount = 0;
+    duint mSelectionSort = -1;
 };

--- a/src/gui/Src/Gui/MemoryMapView.h
+++ b/src/gui/Src/Gui/MemoryMapView.h
@@ -16,6 +16,7 @@ signals:
     void showReferences();
 
 public slots:
+    void selectionChangedSlot(duint index);
     void refreshShortcutsSlot();
     void stateChangedSlot(DBGSTATE state);
     void followDumpSlot();
@@ -41,9 +42,13 @@ public slots:
     void selectionGetSlot(SELECTIONDATA* selection);
     void selectionSetSlot(const SELECTIONDATA* selection);
     void disassembleAtSlot(duint va, duint cip);
-
+    void sortHappenedSlot();
 private:
+
     void setSwitchViewName();
+    std::pair<duint, duint> getAddressRangeFromSelection(QList<duint> & selection);
+    void tryEmitAddressSelectionChange(const SelectionData & newSelection, const std::pair<duint, duint> & newAddressRange);
+    void selectAddressRange(const std::pair<duint, duint> & addressRange);
 
     enum
     {
@@ -67,6 +72,7 @@ private:
         return getCellContent(getInitialSelection(), ColAddress);
     }
 
+    std::pair<duint, duint> mSelectedAddressRange;
     QAction* makeCommandAction(QAction* action, const QString & command);
 
     GotoDialog* mGoto = nullptr;


### PR DESCRIPTION
Restoring the selection after the MMap is updated by holding the no. of row which was selected earlier.

https://github.com/x64dbg/x64dbg/assets/28221162/13551567-2e9b-45c5-bd9f-a71b3c78d072

Closes #3280 .