### PR TITLE
#3134: Avoiding having space in MnemonicNop instruction

### DIFF
--- a/src/gui/Src/Disassembler/ZydisTokenizer.cpp
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.cpp
@@ -351,21 +351,31 @@ bool ZydisTokenizer::TokenEquals(const SingleToken* a, const SingleToken* b, boo
     return tokenTextPoolEquals(a->text, b->text);
 }
 
+
+static bool tokenIsSpace(ZydisTokenizer::TokenType type)
+{
+    return type == ZydisTokenizer::TokenType::Space || type == ZydisTokenizer::TokenType::ArgumentSpace || type == ZydisTokenizer::TokenType::MemoryOperatorSpace;
+}
+
 void ZydisTokenizer::addToken(TokenType type, QString text, const TokenValue & value)
 {
-    switch(type)
+    bool isItSpaceType = tokenIsSpace(type);
+    if(!isItSpaceType)
     {
-    case TokenType::Space:
-    case TokenType::ArgumentSpace:
-    case TokenType::MemoryOperatorSpace:
-        break;
-    default:
         text = text.trimmed();
-        break;
     }
+
     if(mUppercase && !value.size)
         text = text.toUpper();
-    mInst.tokens.push_back(SingleToken(mIsNop ? TokenType::MnemonicNop : type, text, value));
+
+    if(isItSpaceType)
+    {
+        mInst.tokens.push_back(SingleToken(type, text, value));
+    }
+    else
+    {
+        mInst.tokens.push_back(SingleToken(mIsNop ? TokenType::MnemonicNop : type, text, value));
+    }
 }
 
 void ZydisTokenizer::addToken(TokenType type, const QString & text)


### PR DESCRIPTION
`mInst.tokens.push_back(SingleToken(mIsNop ? TokenType::MnemonicNop : type, text, value));` 

This above line would make the additional space from `addToken(TokenType::Space, " ");` to be also `TokenType::MnemonicNop`.
 (called from `bool ZydisTokenizer::tokenizeMnemonic(TokenType type, const QString & mnemonic)` [here](https://github.com/x64dbg/x64dbg/blob/009bff18c93da2f268fa52f0ceee2eea756fdb38/src/gui/Src/Disassembler/ZydisTokenizer.cpp#L501C4-L501C37) in the same file, making it highlightable later in the debugger.


https://github.com/x64dbg/x64dbg/assets/28221162/13dfda4e-7689-4e27-9310-e1f69ed31e38


https://github.com/x64dbg/x64dbg/assets/28221162/aafe217b-4a8d-4f2a-a061-74ca3eff07fd


https://github.com/x64dbg/x64dbg/assets/28221162/16f965ab-e2c7-405b-b67b-2efa11bb6ec1

Closes #3134 .