### PR TITLE
Optimize allocation virtual memory in NUMA topology (Intel X79 X99 C741 C622 C621AE C612 C602 i5xxx iE75xx nForce 3xxx 2xxx and AMD SP5 SP4 SP3 G34 and old)

### DIFF
--- a/src/dbg/_global.h
+++ b/src/dbg/_global.h
@@ -66,6 +66,9 @@ bool ResolveShortcut(HWND hwnd, const wchar_t* szShortcutPath, std::wstring & ex
 void WaitForThreadTermination(HANDLE hThread, DWORD timeout = INFINITE);
 void WaitForMultipleThreadsTermination(const HANDLE* hThread, int count, DWORD timeout = INFINITE);
 duint GetThreadCount();
+void x64dbgVirtualFree(unsigned char* data, PVOID* buffers);
+void x64dbgVirtualAllocEx(HANDLE proc, unsigned char* data, duint dataSize, PVOID* buffers);
+bool IsNUMA() noexcept;
 
 #ifdef _WIN64
 #define ArchValue(x32value, x64value) x64value

--- a/src/dbg/analysis/AnalysisPass.h
+++ b/src/dbg/analysis/AnalysisPass.h
@@ -18,6 +18,7 @@ protected:
     duint m_DataSize;
     unsigned char* m_Data;
     BBlockArray & m_MainBlocks;
+    PVOID* Buffers = NULL;
 
     unsigned char* TranslateAddress(duint Address)
     {


### PR DESCRIPTION
@mrexodia hi again,
I was interested in rewriting NUMA-aware management memory and saw that it was more important to use VirtualAllocExNuma instead VirtualAlloc.
I did this PR with replacement only one object analysis and in fact it really gave an increase on 35-40% on 2 cpu motherboard configuration.
In fact, measurements are not accurate, but if you spam analysis to rewrite output time on text file and calculate average, it will come out exactly.

After 3 runs:
![step1](https://github.com/x64dbg/x64dbg/assets/21138600/c45bc525-ebda-4429-ac09-6ed5279fd7c3)
![step2](https://github.com/x64dbg/x64dbg/assets/21138600/c4a37927-673a-4e33-831a-c697b926f327)
![step3](https://github.com/x64dbg/x64dbg/assets/21138600/e0d0bc50-4cc6-4e5d-9a52-52fb7ab45b74)

Before 3 runs:
![step5](https://github.com/x64dbg/x64dbg/assets/21138600/b1c51b73-f8d2-4c31-8b8b-3fcb8d13e7ad)
![step55](https://github.com/x64dbg/x64dbg/assets/21138600/429bab63-8ed0-490e-9384-075bc0adc7ac)
![step555](https://github.com/x64dbg/x64dbg/assets/21138600/966e85bd-e0c1-4636-b8db-23558be6c473)

Test subject app:
[Docker Desktop Installer.exe.gz](https://github.com/x64dbg/x64dbg/files/14064432/Docker.Desktop.Installer.exe.gz)

Steps to reproduce:
Open test app, right-click on first instruction `jmp ntdll.7FF98D4E0993` and analyze module.

![more](https://github.com/x64dbg/x64dbg/assets/21138600/6260f111-1306-4284-9ff6-efd9d4e8ca02)
