### PR TITLE
Set trace register value as current value

### DIFF
--- a/src/gui/Src/Tracer/TraceRegisters.cpp
+++ b/src/gui/Src/Tracer/TraceRegisters.cpp
@@ -125,11 +125,7 @@ void TraceRegisters::onSetCurrentRegister()
         regName = mRegisterMapping.constFind(reg).value();
 
     // flags and MFPU need to '_' infront
-    if(mFlags.contains(reg))
-        regName = "_" + regName;
-    \
-
-    if(mFPU.contains(reg))
+    if(mFlags.contains(reg) || mFPU.contains(reg))
         regName = "_" + regName;
 
     if(mUINTDISPLAY.contains(reg))

--- a/src/gui/Src/Tracer/TraceRegisters.cpp
+++ b/src/gui/Src/Tracer/TraceRegisters.cpp
@@ -68,7 +68,13 @@ void TraceRegisters::displayCustomContextMenuSlot(QPoint pos)
                 menu.addAction(mDisplayMMX);
         }
 
-        menu.addAction(wCM_SetRegister);
+        if((!mNoChange.contains(mSelected)) ||
+                mSelected == LastError ||
+                mSelected == LastStatus ||
+                mSelected == CIP)
+        {
+            menu.addAction(wCM_SetRegister);
+        }
 
         menu.exec(this->mapToGlobal(pos));
     }
@@ -140,7 +146,7 @@ void TraceRegisters::onSetRegister()
     }
 
     // we change the value (so highlight it)
-    mRegisterUpdates.insert(reg);
+    //    mRegisterUpdates.insert(reg);
 
     qDebug() << "This is the value " << value;
     qDebug() << "This is the string " << regName.toUtf8().constData();
@@ -148,7 +154,7 @@ void TraceRegisters::onSetRegister()
     DbgValToString(regName.toUtf8().constData(), value);
 
     // force repaint
-    emit refresh();
+    //    emit refresh();
 }
 
 void TraceRegisters::mouseDoubleClickEvent(QMouseEvent* event)

--- a/src/gui/Src/Tracer/TraceRegisters.cpp
+++ b/src/gui/Src/Tracer/TraceRegisters.cpp
@@ -118,7 +118,8 @@ void TraceRegisters::onSetRegister()
     // map x87st0 to x87r0
     REGISTER_NAME reg = mSelected;
     QString regName;
-    duint value = *((duint*)registerValue(&mRegDumpStruct, mSelected));
+    //    duint value = *((duint*)registerValue(&mRegDumpStruct, mSelected));
+    duint value;
     if(reg >= x87st0 && reg <= x87st7)
         regName = QString().sprintf("st%d", reg - x87st0);
     else
@@ -129,25 +130,37 @@ void TraceRegisters::onSetRegister()
     if(mFlags.contains(reg))
     {
         regName = "_" + regName;
-        value = (int)(* (bool*) registerValue(&mRegDumpStruct, mSelected));
+        //        value = (int)(* (bool*) registerValue(&mRegDumpStruct, mSelected));
     }
-
-
-    // tell everything the compiler
     if(mFPU.contains(reg))
-    {
         regName = "_" + regName;
-        value = (duint)registerValue(&mRegDumpStruct, mSelected);
-    }
-
-    if(mTAGWORD.contains(reg) || reg == MxCsr_RC || reg == x87CW_RC || reg == x87CW_PC || reg == x87SW_TOP)
-    {
-        value = (* ((const unsigned short*)registerValue(&mRegDumpStruct, mSelected)));
-    }
+    //    else if(mFPUXMM.contains(reg) || mFPUYMM.contains(reg) || mFPUMMX.contains(reg))
+    //    {
+    //        regName = "_" + regName;
+    ////        value = (duint)((const char *)registerValue(&mRegDumpStruct, mSelected));
+    //    }
+    //    else if(mFPUx87.contains(reg) || mFPU.contains(reg))
+    //    {
+    //        value = (* ((const unsigned short*)registerValue(&mRegDumpStruct, mSelected)));
+    //    }
 
     // we change the value (so highlight it)
     //    mRegisterUpdates.insert(reg);
 
+    if(mUINTDISPLAY.contains(reg) || reg == LastError || reg == LastStatus)
+        value = *((const duint*)registerValue(&mRegDumpStruct, mSelected));
+    else if(mBOOLDISPLAY.contains(reg))
+        value = (duint)(*(const bool*)registerValue(&mRegDumpStruct, mSelected));
+    else if(mUSHORTDISPLAY.contains(reg) || mFIELDVALUE.contains(reg))
+        value = (duint)(*(const unsigned short*)registerValue(&mRegDumpStruct, mSelected));
+    else if(mDWORDDISPLAY.contains(reg))
+        value = (duint)(*(const DWORD*)registerValue(&mRegDumpStruct, mSelected));
+    else if(mFPUXMM.contains(reg) || mFPUYMM.contains(reg) || mFPUMMX.contains(reg) || mFPUx87_80BITSDISPLAY.contains(reg))
+        value = (duint)((const char*)registerValue(&mRegDumpStruct, mSelected));
+    else
+        qDebug() << "What do I do with " << reg;
+
+    qDebug() << "Trace Registers";
     qDebug() << "This is the value " << value;
     qDebug() << "This is the string " << regName.toUtf8().constData();
 

--- a/src/gui/Src/Tracer/TraceRegisters.h
+++ b/src/gui/Src/Tracer/TraceRegisters.h
@@ -14,12 +14,12 @@ public:
 public slots:
     virtual void displayCustomContextMenuSlot(QPoint pos);
     void onCopySIMDRegister();
-    void onSetRegister();
+    void onSetCurrentRegister();
 
 protected:
     virtual void mouseDoubleClickEvent(QMouseEvent* event);
 
 private:
     QAction* wCM_CopySIMDRegister;
-    QAction* wCM_SetRegister;
+    QAction* wCM_SetCurrentRegister;
 };

--- a/src/gui/Src/Tracer/TraceRegisters.h
+++ b/src/gui/Src/Tracer/TraceRegisters.h
@@ -14,10 +14,12 @@ public:
 public slots:
     virtual void displayCustomContextMenuSlot(QPoint pos);
     void onCopySIMDRegister();
+    void onSetRegister();
 
 protected:
     virtual void mouseDoubleClickEvent(QMouseEvent* event);
 
 private:
     QAction* wCM_CopySIMDRegister;
+    QAction* wCM_SetRegister;
 };


### PR DESCRIPTION
Fixes #3050 
From the 'Trace' window, select a register value and set it as the current value. To do so, right click on the trace register value and select 'Set as current value'. This option would be available for any register that can be modified in the CPU registers window. 