### PR TITLE
Update image memory region processing to support 24H2 changes

### DIFF
--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -258,6 +258,17 @@ static void ProcessFileSections(std::vector<MEMPAGE> & pageVector, std::vector<S
             for(const auto & page : newPages)
                 totalSize += page.mbi.RegionSize;
 
+            if(totalSize < pageSize)
+            {
+                // On Windows 11 24H2+, modules that support hotpatching contain an extra page mapped into their image region
+                MEMPAGE imageExtensionPage = {};
+                imageExtensionPage.mbi.BaseAddress = (PVOID)(pageBase + totalSize);
+                imageExtensionPage.mbi.RegionSize = pageSize - totalSize;
+                sprintf_s(imageExtensionPage.info, "ImageExtension");
+                newPages.push_back(imageExtensionPage);
+                totalSize = pageSize;
+            }
+
             // Replace the single module page with the sections
             // newPages should never be empty, but try to avoid data loss if it is
             if(!newPages.empty() && totalSize == pageSize)

--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -258,9 +258,11 @@ static void ProcessFileSections(std::vector<MEMPAGE> & pageVector, std::vector<S
             for(const auto & page : newPages)
                 totalSize += page.mbi.RegionSize;
 
-            if(totalSize < pageSize)
+            // On Windows 11 24H2+, modules that support hotpatching contain an extra page mapped into their image region
+            // Reference: https://ynwarcs.github.io/Win11-24H2-CFG
+            static auto buildNumber = BridgeGetNtBuildNumber();
+            if(buildNumber >= 26100 && totalSize + 0x1000 == pageSize)
             {
-                // On Windows 11 24H2+, modules that support hotpatching contain an extra page mapped into their image region
                 MEMPAGE imageExtensionPage = {};
                 imageExtensionPage.mbi.BaseAddress = (PVOID)(pageBase + totalSize);
                 imageExtensionPage.mbi.RegionSize = pageSize - totalSize;


### PR DESCRIPTION
24H2 adds hotpatching, with hotpatchable modules having an extra page mapped at the end of their image region. We previously assumed that the image region will only contain the header and executable sections, that's no longer the case.

Fixes #3338