### PR TITLE
Enable HiDPI for launcher

### DIFF
--- a/src/launcher/x64dbg_launcher.cpp
+++ b/src/launcher/x64dbg_launcher.cpp
@@ -421,8 +421,37 @@ static void deleteZoneData(const std::wstring & rootDir)
     }
 }
 
+typedef BOOL(WINAPI* LPFN_SetProcessDpiAwarenessContext)(int);
+typedef BOOL(WINAPI* LPFN_SetProcessDPIAware)();
+
+static void EnableHiDPI()
+{
+    // Windows 10 Build 1607
+    LPFN_SetProcessDpiAwarenessContext SetProcessDpiAwarenessContext = (LPFN_SetProcessDpiAwarenessContext)GetProcAddress(GetModuleHandle(TEXT("user32.dll")), "SetProcessDpiAwarenessContext");
+    if (SetProcessDpiAwarenessContext != nullptr)
+    {
+        // Windows 10 Build 1703
+        if (SetProcessDpiAwarenessContext(-4)) //DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+        {
+            return;
+        }
+        // Windows 10 Build 1607
+        if (SetProcessDpiAwarenessContext(-3)) //DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
+        {
+            return;
+        }
+    }
+    // Windows Vista
+    LPFN_SetProcessDPIAware SetProcessDPIAware = (LPFN_SetProcessDPIAware)GetProcAddress(GetModuleHandle(TEXT("user32.dll")), "SetProcessDPIAware");
+    if (SetProcessDPIAware != nullptr)
+    {
+        SetProcessDPIAware();
+    }
+}
+
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
+    EnableHiDPI();
     InitCommonControls();
 
     //Initialize COM

--- a/src/launcher/x64dbg_launcher.cpp
+++ b/src/launcher/x64dbg_launcher.cpp
@@ -428,22 +428,22 @@ static void EnableHiDPI()
 {
     // Windows 10 Build 1607
     LPFN_SetProcessDpiAwarenessContext SetProcessDpiAwarenessContext = (LPFN_SetProcessDpiAwarenessContext)GetProcAddress(GetModuleHandle(TEXT("user32.dll")), "SetProcessDpiAwarenessContext");
-    if (SetProcessDpiAwarenessContext != nullptr)
+    if(SetProcessDpiAwarenessContext != nullptr)
     {
         // Windows 10 Build 1703
-        if (SetProcessDpiAwarenessContext(-4)) //DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+        if(SetProcessDpiAwarenessContext(-4))  //DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
         {
             return;
         }
         // Windows 10 Build 1607
-        if (SetProcessDpiAwarenessContext(-3)) //DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
+        if(SetProcessDpiAwarenessContext(-3))  //DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
         {
             return;
         }
     }
     // Windows Vista
     LPFN_SetProcessDPIAware SetProcessDPIAware = (LPFN_SetProcessDPIAware)GetProcAddress(GetModuleHandle(TEXT("user32.dll")), "SetProcessDPIAware");
-    if (SetProcessDPIAware != nullptr)
+    if(SetProcessDPIAware != nullptr)
     {
         SetProcessDPIAware();
     }


### PR DESCRIPTION
Windows supports HiDPI for dialog based application. It just needs to be enabled. And we can't use the manifest because it's shared with x32dbg.exe that has its own HiDPI policy.