### PR TITLE
Save graph as WEBP and TIFF and fix crash

### DIFF
--- a/src/gui/Src/Gui/DisassemblerGraphView.cpp
+++ b/src/gui/Src/Gui/DisassemblerGraphView.cpp
@@ -2567,8 +2567,10 @@ void DisassemblerGraphView::saveImageSlot()
     }
 
     //save viewport to image
-    QRect completeRenderRect = QRect(0, 0, this->renderWidth, this->renderHeight);
+    auto scaleFactor = this->devicePixelRatioF();
+    QRect completeRenderRect = QRect(0, 0, this->renderWidth * scaleFactor, this->renderHeight * scaleFactor);
     QImage img(completeRenderRect.size(), QImage::Format_ARGB32);
+    img.setDevicePixelRatio(scaleFactor);
     QPainter painter(&img);
     this->viewport()->render(&painter);
     if(!path.toLower().endsWith(".webp"))

--- a/src/gui/Src/Gui/DisassemblerGraphView.h
+++ b/src/gui/Src/Gui/DisassemblerGraphView.h
@@ -342,7 +342,6 @@ private:
     qreal overviewScale;
     duint mCip = 0;
     bool forceCenter = false;
-    bool saveGraph;
     bool mHistoryLock = false; //Don't add a history while going to previous/next
     LayoutType layoutType;
 


### PR DESCRIPTION
It seems there's a crash when saving graph image. Qt Creator outputs the log message:
```
QPaintDevice: Cannot destroy paint device that is being painted
QWidget::repaint: Recursive repaint detected
```
The newly downloaded snapshot also crashes when saving graph image.
Also the image formats WEBP and TIFF are added. The required file format plugins are already shipped, and WEBP image is smaller and lossless, so why not.