### PR TITLE
fix crash and free dump in another thread

### DIFF
--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -1372,7 +1372,8 @@ void TraceBrowser::disasm(unsigned long long index, bool history)
 
 void TraceBrowser::disasmByAddress(duint address, bool history)
 {
-    mParent->loadDumpFully();
+    if(!mParent->loadDumpFully())
+        return;
     auto references = getTraceFile()->getDump()->getReferences(address, address);
     unsigned long long index;
     bool found = false;
@@ -1891,7 +1892,8 @@ void TraceBrowser::searchMemRefSlot()
     if(memRefDlg.exec() == QDialog::Accepted)
     {
         auto ticks = GetTickCount();
-        mParent->loadDumpFully();
+        if(!mParent->loadDumpFully())
+            return;
         int count = TraceFileSearchMemReference(getTraceFile(), memRefDlg.getVal());
         GuiShowReferences();
         GuiAddLogMessage(tr("%1 result(s) in %2ms\n").arg(count).arg(GetTickCount() - ticks).toUtf8().constData());

--- a/src/gui/Src/Tracer/TraceInfoBox.cpp
+++ b/src/gui/Src/Tracer/TraceInfoBox.cpp
@@ -258,13 +258,14 @@ void TraceInfoBox::addFollowMenuItem(QMenu* menu, QString name, duint value)
  */
 void TraceInfoBox::setupFollowMenu(QMenu* menu, duint va)
 {
+    TraceFileReader* traceFile = mParent->getTraceFile();
+    const TraceFileDump* traceDump = traceFile->getDump();
+    if(!traceDump->isEnabled())
+        return;
     //most basic follow action
     addFollowMenuItem(menu, tr("&Selected Address"), va);
 
     //add follow actions
-    mParent->loadDumpFully();
-    TraceFileReader* traceFile = mParent->getTraceFile();
-    TraceFileDump* traceDump = traceFile->getDump();
     duint selection = mParent->getTraceBrowser()->getInitialSelection();
     Zydis zydis;
     unsigned char opcode[16];
@@ -337,11 +338,7 @@ void TraceInfoBox::contextMenuSlot(QPoint pos)
     QMenu menu(this); //create context menu
     QMenu followMenu(tr("&Follow in Dump"), this);
     followMenu.setIcon(DIcon("dump"));
-    connect(&followMenu, &QMenu::aboutToShow, [&followMenu, this]()
-    {
-        // The following method will load dump, so we postpone until the mouse hovers it.
-        setupFollowMenu(&followMenu, mCurAddr);
-    });
+    setupFollowMenu(&followMenu, mCurAddr);
     menu.addMenu(&followMenu);
     QMenu copyMenu(tr("&Copy"), this);
     setupCopyMenu(&copyMenu);

--- a/src/gui/Src/Tracer/TraceWidget.h
+++ b/src/gui/Src/Tracer/TraceWidget.h
@@ -45,11 +45,11 @@ public:
     {
         return mStack;
     };
-    // Enable trace dump and load it fully before searching
-    void loadDumpFully();
+    // Enable trace dump and load it fully before searching. Return false if the user cancels.
+    bool loadDumpFully();
 public slots:
-    // Enable trace dump in order to use these features
-    void loadDump();
+    // Enable trace dump in order to use these features. Return false if the user cancels.
+    bool loadDump();
 
 signals:
     void closeFile();


### PR DESCRIPTION
The ability to cancel loading dump also makes x64dbg crashes if the user cancels loading while x64dbg expects it to be loaded. So a return value check is now added.
The trace dump is freed in another thread so the trace can be closed fast.