### PR TITLE
Use 32-bit trace index to save memory

### DIFF
--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -857,6 +857,12 @@ void TraceBrowser::setupRightClickContextMenu()
 
     mMenuBuilder->addMenu(makeMenu(DIcon("copy"), tr("&Copy")), copyMenu);
 
+    mMenuBuilder->addMenu(makeMenu(DIcon("dump"), tr("&Follow in Dump")), [this](QMenu * menu)
+    {
+        mParent->setupFollowMenu(menu);
+        return true;
+    });
+
     mCommonActions->build(mMenuBuilder, CommonActions::ActionDisasm | CommonActions::ActionBreakpoint | CommonActions::ActionLabel | CommonActions::ActionComment | CommonActions::ActionBookmark);
     mMenuBuilder->addAction(makeShortcutAction(DIcon("highlight"), tr("&Highlighting mode"), SLOT(enableHighlightingModeSlot()), "ActionHighlightingMode"), mTraceFileNotNull);
     mMenuBuilder->addAction(makeShortcutAction(DIcon("helpmnemonic"), tr("Help on mnemonic"), SLOT(mnemonicHelpSlot()), "ActionHelpOnMnemonic"), mTraceFileNotNull);

--- a/src/gui/Src/Tracer/TraceBrowser.h
+++ b/src/gui/Src/Tracer/TraceBrowser.h
@@ -3,8 +3,8 @@
 #include "AbstractTableView.h"
 #include "VaHistory.h"
 #include "QZydis.h"
+#include "TraceFileReader.h"
 
-class TraceFileReader;
 class TraceWidget;
 class BreakpointMenu;
 class CommonActions;
@@ -59,8 +59,8 @@ private:
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
 
-    ZydisTokenizer::InstructionToken memoryTokens(unsigned long long atIndex);
-    ZydisTokenizer::InstructionToken registersTokens(unsigned long long atIndex);
+    ZydisTokenizer::InstructionToken memoryTokens(TRACEINDEX atIndex);
+    ZydisTokenizer::InstructionToken registersTokens(TRACEINDEX atIndex);
     VaHistory mHistory;
     MenuBuilder* mMenuBuilder;
     CommonActions* mCommonActions;
@@ -146,7 +146,7 @@ private:
 
 signals:
     void displayLogWidget();
-    void selectionChanged(unsigned long long selection);
+    void selectionChanged(TRACEINDEX selection);
     void xrefSignal(duint addr);
     void closeFile();
 
@@ -159,7 +159,7 @@ public slots:
     void closeDeleteSlot();
     void parseFinishedSlot();
     void tokenizerConfigUpdatedSlot();
-    void selectionChangedSlot(unsigned long long selection);
+    void selectionChangedSlot(TRACEINDEX selection);
 
     void gotoSlot();
     void gotoIndexSlot();
@@ -192,7 +192,7 @@ public slots:
 
 private:
     // Go to by index
-    void disasm(unsigned long long index, bool history = true);
+    void disasm(TRACEINDEX index, bool history = true);
     // Go to by address, display the Xref dialog if multiple indicies are found
     void disasmByAddress(duint address, bool history = true);
     TraceWidget* mParent;

--- a/src/gui/Src/Tracer/TraceDump.cpp
+++ b/src/gui/Src/Tracer/TraceDump.cpp
@@ -1,11 +1,9 @@
-#include "TraceDump.h"
-#include "TraceWidget.h"
-#include "TraceFileReader.h"
-#include "TraceFileDump.h"
 #include <QMessageBox>
 #include <QClipboard>
 #include <QFileDialog>
 #include <QToolTip>
+#include "TraceDump.h"
+#include "TraceWidget.h"
 #include "Configuration.h"
 #include "Bridge.h"
 #include "HexEditDialog.h"

--- a/src/gui/Src/Tracer/TraceFileDump.cpp
+++ b/src/gui/Src/Tracer/TraceFileDump.cpp
@@ -7,7 +7,7 @@
 
 TraceFileDump::TraceFileDump()
 {
-    maxIndex = 0ull;
+    maxIndex = static_cast<TRACEINDEX>(0);
     enabled = false;
 }
 
@@ -27,7 +27,7 @@ TraceFileDump::~TraceFileDump()
 
 void TraceFileDump::clear()
 {
-    maxIndex = 0ull;
+    maxIndex = static_cast<TRACEINDEX>(0);
     dump.clear();
 }
 
@@ -48,7 +48,7 @@ bool TraceFileDump::isValidReadPtr(duint address) const
     return false;
 }
 
-void TraceFileDump::getBytes(duint addr, duint size, unsigned long long index, void* buffer) const
+void TraceFileDump::getBytes(duint addr, duint size, TRACEINDEX index, void* buffer) const
 {
     if(!isEnabled())
         return;
@@ -135,12 +135,12 @@ void TraceFileDump::getBytes(duint addr, duint size, unsigned long long index, v
 }
 
 // find references to the memory address
-std::vector<unsigned long long> TraceFileDump::getReferences(duint startAddr, duint endAddr) const
+std::vector<TRACEINDEX> TraceFileDump::getReferences(duint startAddr, duint endAddr) const
 {
     if(!isEnabled())
         return {};
 
-    std::vector<unsigned long long> index;
+    std::vector<TRACEINDEX> index;
     if(endAddr < startAddr)
         std::swap(endAddr, startAddr);
     // find references to the memory address
@@ -154,7 +154,7 @@ std::vector<unsigned long long> TraceFileDump::getReferences(duint startAddr, du
         return index;
     // rearrange the array and remove duplicates
     std::sort(index.begin(), index.end());
-    std::vector<unsigned long long> result;
+    std::vector<TRACEINDEX> result;
     result.push_back(index[0]);
     for(size_t i = 1; i < index.size(); i++)
     {
@@ -236,12 +236,12 @@ TraceFileDumpMemoryPage::TraceFileDumpMemoryPage(TraceFileDump* dump, QObject* p
     this->dump = dump;
 }
 
-void TraceFileDumpMemoryPage::setSelectedIndex(unsigned long long index)
+void TraceFileDumpMemoryPage::setSelectedIndex(TRACEINDEX index)
 {
     if(dump)
         selectedIndex = std::min(index, dump->getMaxIndex());
     else
-        selectedIndex = 0ull;
+        selectedIndex = static_cast<TRACEINDEX>(0);
 }
 
 bool TraceFileDumpMemoryPage::isAvailable() const
@@ -249,7 +249,7 @@ bool TraceFileDumpMemoryPage::isAvailable() const
     return !!this->dump;
 }
 
-unsigned long long TraceFileDumpMemoryPage::getSelectedIndex() const
+TRACEINDEX TraceFileDumpMemoryPage::getSelectedIndex() const
 {
     return selectedIndex;
 }

--- a/src/gui/Src/Tracer/TraceFileDump.h
+++ b/src/gui/Src/Tracer/TraceFileDump.h
@@ -5,13 +5,15 @@
 #include <QMutex>
 #include "MemoryPage.h"
 
+typedef DWORD TRACEINDEX;
+
 class TraceFileDump
 {
 public:
     struct Key
     {
         duint addr;
-        unsigned long long index;
+        TRACEINDEX index;
         friend bool operator <(const Key & a, const Key & b)
         {
             // order is inverted, highest address is less! We want to use lower_bound() to find last memory access index.
@@ -39,8 +41,8 @@ public:
     }
     // Read a byte at "addr" at the moment given in "index"
     bool isValidReadPtr(duint addr) const;
-    void getBytes(duint addr, duint size, unsigned long long index, void* buffer) const;
-    std::vector<unsigned long long> getReferences(duint startAddr, duint endAddr) const;
+    void getBytes(duint addr, duint size, TRACEINDEX index, void* buffer) const;
+    std::vector<TRACEINDEX> getReferences(duint startAddr, duint endAddr) const;
     // Insert a memory access record
     //void addMemAccess(duint addr, DumpRecord record);
     void addMemAccess(duint addr, const void* oldData, const void* newData, size_t size);
@@ -48,7 +50,7 @@ public:
     {
         maxIndex++;
     }
-    inline unsigned long long getMaxIndex()
+    inline TRACEINDEX getMaxIndex()
     {
         return maxIndex;
     }
@@ -58,7 +60,7 @@ public:
 private:
     std::map<Key, DumpRecord> dump;
     // maxIndex is the last index included here. As the debuggee steps there will be new data coming.
-    unsigned long long maxIndex;
+    TRACEINDEX maxIndex;
     bool enabled;
 };
 
@@ -69,10 +71,10 @@ public:
     TraceFileDumpMemoryPage(TraceFileDump* dump, QObject* parent = nullptr);
     virtual bool read(void* parDest, dsint parRVA, duint parSize) const override;
     virtual bool write(const void* parDest, dsint parRVA, duint parSize) override;
-    void setSelectedIndex(unsigned long long index);
-    unsigned long long getSelectedIndex() const;
+    void setSelectedIndex(TRACEINDEX index);
+    TRACEINDEX getSelectedIndex() const;
     bool isAvailable() const;
 private:
     TraceFileDump* dump;
-    unsigned long long selectedIndex = 0ull;
+    TRACEINDEX selectedIndex = static_cast<TRACEINDEX>(0);
 };

--- a/src/gui/Src/Tracer/TraceFileReader.h
+++ b/src/gui/Src/Tracer/TraceFileReader.h
@@ -25,20 +25,20 @@ public:
     bool isError(QString & reason) const;
     //int Progress() const; // TODO: Trace view should start showing its first instructions as soon as they are loaded
 
-    QString getIndexText(unsigned long long index) const;
+    QString getIndexText(TRACEINDEX index) const;
 
-    unsigned long long Length() const;
+    TRACEINDEX Length() const;
     uint64_t FileSize() const;
 
-    REGDUMP Registers(unsigned long long index);
-    void OpCode(unsigned long long index, unsigned char* buffer, int* opcodeSize);
-    const Instruction_t & Instruction(unsigned long long index);
+    REGDUMP Registers(TRACEINDEX index);
+    void OpCode(TRACEINDEX index, unsigned char* buffer, int* opcodeSize);
+    const Instruction_t & Instruction(TRACEINDEX index);
     // Get thread ID
-    DWORD ThreadId(unsigned long long index);
+    DWORD ThreadId(TRACEINDEX index);
     // Get number of memory accesses
-    int MemoryAccessCount(unsigned long long index);
+    int MemoryAccessCount(TRACEINDEX index);
     // Get memory access information. Size of these buffers are MAX_MEMORY_OPERANDS.
-    void MemoryAccessInfo(unsigned long long index, duint* address, duint* oldMemory, duint* newMemory, bool* isValid);
+    void MemoryAccessInfo(TRACEINDEX index, duint* address, duint* oldMemory, duint* newMemory, bool* isValid);
     // Get hash of EXE
     duint HashValue() const;
     const QString & ExePath() const;
@@ -46,8 +46,8 @@ public:
 
     void purgeLastPage();
 
-    void buildDumpTo(unsigned long long index);
-    std::vector<unsigned long long> getReferences(duint startAddr, duint endAddr) const;
+    void buildDumpTo(TRACEINDEX index);
+    std::vector<TRACEINDEX> getReferences(duint startAddr, duint endAddr) const;
     TraceFileDump* getDump();
 
 signals:
@@ -60,7 +60,7 @@ private slots:
     void tokenizerUpdatedSlot();
 
 private:
-    typedef std::pair<unsigned long long, unsigned long long> Range;
+    typedef std::pair<TRACEINDEX, TRACEINDEX> Range;
     struct RangeCompare //from addrinfo.h
     {
         bool operator()(const Range & a, const Range & b) const //a before b?
@@ -71,7 +71,7 @@ private:
 
     QFile traceFile;
     qint64 fileSize = 0;
-    unsigned long long length = 0;
+    TRACEINDEX length = 0;
     duint hashValue = 0;
     QString EXEPath;
     std::vector<std::pair<unsigned long long, Range>> fileIndex; //index;<file offset;length>
@@ -79,15 +79,15 @@ private:
     bool error = true;
     QString errorMessage;
     TraceFilePage* lastAccessedPage = nullptr;
-    unsigned long long lastAccessedIndexOffset = 0;
+    TRACEINDEX lastAccessedIndexOffset = 0;
     friend class TraceFileParser;
     friend class TraceFilePage;
 
     TraceFileParser* parser = nullptr;
     std::map<Range, TraceFilePage, RangeCompare> pages;
-    TraceFilePage* getPage(unsigned long long index, unsigned long long* base);
+    TraceFilePage* getPage(TRACEINDEX index, TRACEINDEX* base);
     TraceFileDump dump;
-    void buildDump(unsigned long long index);
+    void buildDump(TRACEINDEX index);
 
     QZydis* mDisasm;
 };

--- a/src/gui/Src/Tracer/TraceFileReaderInternal.h
+++ b/src/gui/Src/Tracer/TraceFileReaderInternal.h
@@ -16,14 +16,14 @@ class TraceFileParser : public QThread
 class TraceFilePage
 {
 public:
-    TraceFilePage(TraceFileReader* parent, unsigned long long fileOffset, unsigned long long maxLength);
-    unsigned long long Length() const;
-    const REGDUMP & Registers(unsigned long long index) const;
-    void OpCode(unsigned long long index, unsigned char* buffer, int* opcodeSize) const;
-    const Instruction_t & Instruction(unsigned long long index, QZydis & mDisasm);
-    DWORD ThreadId(unsigned long long index) const;
-    int MemoryAccessCount(unsigned long long index) const;
-    void MemoryAccessInfo(unsigned long long index, duint* address, duint* oldMemory, duint* newMemory, bool* isValid) const;
+    TraceFilePage(TraceFileReader* parent, unsigned long long fileOffset, TRACEINDEX maxLength);
+    TRACEINDEX Length() const;
+    const REGDUMP & Registers(TRACEINDEX index) const;
+    void OpCode(TRACEINDEX index, unsigned char* buffer, int* opcodeSize) const;
+    const Instruction_t & Instruction(TRACEINDEX index, QZydis & mDisasm);
+    DWORD ThreadId(TRACEINDEX index) const;
+    int MemoryAccessCount(TRACEINDEX index) const;
+    void MemoryAccessInfo(TRACEINDEX index, duint* address, duint* oldMemory, duint* newMemory, bool* isValid) const;
 
     FILETIME lastAccessed; //system user time
 
@@ -43,5 +43,5 @@ private:
     std::vector<duint> oldMemory;
     std::vector<duint> newMemory;
     std::vector<DWORD> threadId;
-    unsigned long long length;
+    TRACEINDEX length;
 };

--- a/src/gui/Src/Tracer/TraceInfoBox.cpp
+++ b/src/gui/Src/Tracer/TraceInfoBox.cpp
@@ -2,7 +2,6 @@
 #include "TraceWidget.h"
 #include "TraceDump.h"
 #include "TraceBrowser.h"
-#include "TraceFileReader.h"
 #include "CPUInfoBox.h"
 #include "zydis_wrapper.h"
 
@@ -36,7 +35,7 @@ TraceInfoBox::~TraceInfoBox()
 
 }
 
-void TraceInfoBox::update(unsigned long long selection, TraceFileReader* traceFile, const REGDUMP & registers)
+void TraceInfoBox::update(TRACEINDEX selection, TraceFileReader* traceFile, const REGDUMP & registers)
 {
     duint infoline = 0;
     Zydis zydis;

--- a/src/gui/Src/Tracer/TraceInfoBox.h
+++ b/src/gui/Src/Tracer/TraceInfoBox.h
@@ -11,8 +11,6 @@ class TraceInfoBox : public StdTable
 public:
     TraceInfoBox(TraceWidget* parent);
     int getHeight();
-    void setupFollowMenu(QMenu* menu, duint va);
-    void addFollowMenuItem(QMenu* menu, QString name, duint value);
     ~TraceInfoBox();
 
     void update(TRACEINDEX selection, TraceFileReader* traceFile, const REGDUMP & registers);
@@ -20,7 +18,6 @@ public:
 
 public slots:
     void contextMenuSlot(QPoint pos);
-    void followActionSlot();
 
 private:
     void setupContextMenu();

--- a/src/gui/Src/Tracer/TraceInfoBox.h
+++ b/src/gui/Src/Tracer/TraceInfoBox.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "StdTable.h"
+#include "TraceFileReader.h"
 
 class TraceWidget;
-class TraceFileReader;
 
 class TraceInfoBox : public StdTable
 {
@@ -15,7 +15,7 @@ public:
     void addFollowMenuItem(QMenu* menu, QString name, duint value);
     ~TraceInfoBox();
 
-    void update(unsigned long long selection, TraceFileReader* traceFile, const REGDUMP & registers);
+    void update(TRACEINDEX selection, TraceFileReader* traceFile, const REGDUMP & registers);
     void clear();
 
 public slots:

--- a/src/gui/Src/Tracer/TraceRegisters.h
+++ b/src/gui/Src/Tracer/TraceRegisters.h
@@ -2,11 +2,13 @@
 
 #include "RegistersView.h"
 
+class TraceWidget;
+
 class TraceRegisters : public RegistersView
 {
     Q_OBJECT
 public:
-    TraceRegisters(QWidget* parent = nullptr);
+    TraceRegisters(TraceWidget* parent = nullptr);
 
     void setRegisters(REGDUMP* registers);
     void setActive(bool isActive);
@@ -15,11 +17,14 @@ public slots:
     virtual void displayCustomContextMenuSlot(QPoint pos);
     void onCopySIMDRegister();
     void onSetCurrentRegister();
+    void onFollowInDump();
 
 protected:
     virtual void mouseDoubleClickEvent(QMouseEvent* event);
 
 private:
+    TraceWidget* mParent;
     QAction* wCM_CopySIMDRegister;
     QAction* wCM_SetCurrentRegister;
+    QAction* wCM_FollowInDump;
 };

--- a/src/gui/Src/Tracer/TraceStack.cpp
+++ b/src/gui/Src/Tracer/TraceStack.cpp
@@ -1,8 +1,6 @@
 #include "TraceWidget.h"
 #include "TraceStack.h"
 #include "TraceDump.h"
-#include "TraceFileReader.h"
-#include "TraceFileDump.h"
 #include "TraceBrowser.h"
 #include "CPUDump.h"
 #include <QClipboard>

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -60,7 +60,7 @@ TraceWidget::TraceWidget(Architecture* architecture, const QString & fileName, Q
     QPushButton* button_changeview = new QPushButton("", this);
     button_changeview->setStyleSheet("Text-align:left;padding: 4px;padding-left: 10px;");
     connect(button_changeview, SIGNAL(clicked()), mGeneralRegs, SLOT(onChangeFPUViewAction()));
-    connect(mTraceBrowser, SIGNAL(selectionChanged(unsigned long long)), this, SLOT(traceSelectionChanged(unsigned long long)));
+    connect(mTraceBrowser, SIGNAL(selectionChanged(TRACEINDEX)), this, SLOT(traceSelectionChanged(TRACEINDEX)));
     connect(mTraceBrowser, SIGNAL(displayLogWidget()), this, SLOT(displayLogWidgetSlot()));
     connect(mTraceFile, SIGNAL(parseFinished()), this, SLOT(parseFinishedSlot()));
     connect(mTraceBrowser, SIGNAL(closeFile()), this, SLOT(closeFileSlot()));
@@ -116,7 +116,7 @@ TraceWidget::~TraceWidget()
     delete ui;
 }
 
-void TraceWidget::traceSelectionChanged(unsigned long long selection)
+void TraceWidget::traceSelectionChanged(TRACEINDEX selection)
 {
     REGDUMP registers;
     if(mTraceFile != nullptr)
@@ -253,7 +253,7 @@ bool TraceWidget::loadDumpFully()
     return true;
 }
 
-void TraceWidget::setupDumpInitialAddresses(unsigned long long selection)
+void TraceWidget::setupDumpInitialAddresses(TRACEINDEX selection)
 {
     // Setting the initial address of dump view
     duint initialAddress;

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -277,3 +277,123 @@ void TraceWidget::setupDumpInitialAddresses(TRACEINDEX selection)
     // Setting the initial address of stack view
     mStack->printDumpAt(mTraceFile->Registers(selection).regcontext.csp, false, true, true);
 }
+
+/**
+ * @brief TraceWidget::addFollowMenuItem Add a follow action to the menu
+ * @param menu The menu to which the follow action adds
+ * @param name The user-friendly name of the action
+ * @param value The VA of the address
+ */
+void TraceWidget::addFollowMenuItem(QMenu* menu, QString name, duint value)
+{
+    foreach(QAction* action, menu->actions()) //check for duplicate action
+        if(action->text() == name)
+            return;
+    QAction* newAction = new QAction(name, menu);
+    menu->addAction(newAction);
+    newAction->setObjectName(ToPtrString(value));
+    connect(newAction, SIGNAL(triggered()), this, SLOT(followActionSlot()));
+}
+
+/**
+ * @brief TraceWidget::setupFollowMenu Set up a follow menu.
+ * @param menu The menu to create
+ * @param va The selected VA
+ */
+void TraceWidget::setupFollowMenu(QMenu* menu)
+{
+    const TraceFileDump* traceDump = mTraceFile->getDump();
+    if(!traceDump->isEnabled())
+    {
+        QAction* newAction = new QAction(tr("Load dump"), menu);
+        connect(newAction, SIGNAL(triggered()), this, SLOT(loadDump()));
+        menu->addAction(newAction);
+        return;
+    }
+
+    //add follow actions
+    TRACEINDEX selection = getTraceBrowser()->getInitialSelection();
+    REGDUMP registers = mTraceFile->Registers(selection);
+    duint va = registers.regcontext.cip;
+    Zydis zydis;
+    unsigned char opcode[16];
+    int opsize;
+    mTraceFile->OpCode(selection, opcode, &opsize);
+    duint MemoryAddress[MAX_MEMORY_OPERANDS];
+    duint MemoryOldContent[MAX_MEMORY_OPERANDS];
+    duint MemoryNewContent[MAX_MEMORY_OPERANDS];
+    bool MemoryIsValid[MAX_MEMORY_OPERANDS];
+    int MemoryOperandsCount;
+    MemoryOperandsCount = mTraceFile->MemoryAccessCount(selection);
+    if(MemoryOperandsCount > 0)
+        mTraceFile->MemoryAccessInfo(selection, MemoryAddress, MemoryOldContent, MemoryNewContent, MemoryIsValid);
+
+    //most basic follow action
+    addFollowMenuItem(menu, tr("&Selected Address"), va);
+    if(zydis.Disassemble(va, opcode, opsize))
+    {
+        for(uint8_t opindex = 0; opindex < zydis.OpCount(); opindex++)
+        {
+            size_t value = zydis.ResolveOpValue(opindex, [&registers](ZydisRegister reg)
+            {
+                return resolveZydisRegister(registers, reg);
+            });
+
+            if(zydis[opindex].type == ZYDIS_OPERAND_TYPE_MEMORY)
+            {
+                if(zydis[opindex].size == sizeof(void*) * 8)
+                {
+                    if(traceDump->isValidReadPtr(value))
+                    {
+                        addFollowMenuItem(menu, tr("&Address: ") + QString::fromStdString(zydis.OperandText(opindex)), value);
+                    }
+                    for(uint8_t memaccessindex = 0; memaccessindex < MemoryOperandsCount; memaccessindex++)
+                    {
+                        if(MemoryAddress[memaccessindex] == value)
+                        {
+                            if(traceDump->isValidReadPtr(MemoryOldContent[memaccessindex]))
+                            {
+                                if(MemoryOldContent[memaccessindex] != MemoryNewContent[memaccessindex])
+                                {
+                                    addFollowMenuItem(menu, tr("&Old value: ") + ToPtrString(MemoryOldContent[memaccessindex]), MemoryOldContent[memaccessindex]);
+                                }
+                                else
+                                {
+                                    addFollowMenuItem(menu, tr("&Value: ") + ToPtrString(MemoryOldContent[memaccessindex]), MemoryOldContent[memaccessindex]);
+                                    break;
+                                }
+                            }
+                            if(traceDump->isValidReadPtr(MemoryNewContent[memaccessindex]))
+                            {
+                                addFollowMenuItem(menu, tr("&New value: ") + ToPtrString(MemoryNewContent[memaccessindex]), MemoryNewContent[memaccessindex]);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            else if(zydis[opindex].type == ZYDIS_OPERAND_TYPE_IMMEDIATE)
+            {
+                if(traceDump->isValidReadPtr(value))
+                {
+                    addFollowMenuItem(menu, tr("&Constant: ") + QString::fromStdString(zydis.OperandText(opindex)), value);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief TraceWidget::followActionSlot Called when follow action is clicked
+ */
+void TraceWidget::followActionSlot()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    duint data;
+#ifdef _WIN64
+    data = action->objectName().toULongLong(nullptr, 16);
+#else
+    data = action->objectName().toULong(nullptr, 16);
+#endif //_WIN64
+    mDump->printDumpAt(data, true, true, true);
+}

--- a/src/gui/Src/Tracer/TraceWidget.h
+++ b/src/gui/Src/Tracer/TraceWidget.h
@@ -46,6 +46,7 @@ public:
     };
     // Enable trace dump and load it fully before searching. Return false if the user cancels.
     bool loadDumpFully();
+    void setupFollowMenu(QMenu* menu);
 public slots:
     // Enable trace dump in order to use these features. Return false if the user cancels.
     bool loadDump();
@@ -60,6 +61,7 @@ protected slots:
     void parseFinishedSlot();
     void closeFileSlot();
     void xrefSlot(duint addr);
+    void followActionSlot();
 
 protected:
     TraceFileReader* mTraceFile;
@@ -77,4 +79,5 @@ protected:
 private:
     Ui::TraceWidget* ui;
     void setupDumpInitialAddresses(TRACEINDEX selection);
+    void addFollowMenuItem(QMenu* menu, QString name, duint value);
 };

--- a/src/gui/Src/Tracer/TraceWidget.h
+++ b/src/gui/Src/Tracer/TraceWidget.h
@@ -2,18 +2,17 @@
 
 #include <QWidget>
 #include "Bridge.h"
+#include "TraceFileReader.h"
 
 class QVBoxLayout;
 class QPushButton;
 class CPUWidget;
 class TraceRegisters;
 class TraceBrowser;
-class TraceFileReader;
 class TraceFileDumpMemoryPage;
 class TraceInfoBox;
 class TraceDump;
 class TraceStack;
-class TraceFileReader;
 class TraceXrefBrowseDialog;
 
 namespace Ui
@@ -57,7 +56,7 @@ signals:
 
 protected slots:
     void displayLogWidgetSlot();
-    void traceSelectionChanged(unsigned long long selection);
+    void traceSelectionChanged(TRACEINDEX selection);
     void parseFinishedSlot();
     void closeFileSlot();
     void xrefSlot(duint addr);
@@ -77,5 +76,5 @@ protected:
 
 private:
     Ui::TraceWidget* ui;
-    void setupDumpInitialAddresses(unsigned long long selection);
+    void setupDumpInitialAddresses(TRACEINDEX selection);
 };

--- a/src/gui/Src/Tracer/TraceXrefBrowseDialog.cpp
+++ b/src/gui/Src/Tracer/TraceXrefBrowseDialog.cpp
@@ -55,7 +55,7 @@ void TraceXrefBrowseDialog::setup(duint index, duint address, TraceFileReader* t
     }
 
     setWindowTitle(QString(tr("xrefs at <%1>")).arg(GetFunctionSymbol(address)));
-    for(duint i = 0; i < mXrefInfo.size(); i++)
+    for(size_t i = 0; i < mXrefInfo.size(); i++)
     {
         Zydis zydis;
         QString disasm;

--- a/src/gui/Src/Tracer/TraceXrefBrowseDialog.h
+++ b/src/gui/Src/Tracer/TraceXrefBrowseDialog.h
@@ -4,14 +4,12 @@
 #include "ActionHelpers.h"
 #include <QDialog>
 #include <QListWidgetItem>
+#include "TraceFileReader.h"
 
 namespace Ui
 {
     class XrefBrowseDialog;
 }
-
-class TraceFileReader;
-class TraceFileDump;
 
 class TraceXrefBrowseDialog : public QDialog, public ActionHelper<TraceXrefBrowseDialog>
 {
@@ -43,7 +41,7 @@ private:
 
     typedef struct
     {
-        unsigned long long index;
+        TRACEINDEX index;
         duint addr;
     } TRACE_XREF_RECORD;
     std::vector<TRACE_XREF_RECORD> mXrefInfo;


### PR DESCRIPTION
Memory usage is reduced from 1.1GB to 999MB for a test trace.