### PR TITLE
Find pattern in trace dump

### DIFF
--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -449,7 +449,7 @@ namespace Exprfunc
     duint gettickcount()
     {
 #ifdef _WIN64
-        static auto GTC64 = (duint(*)())GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "GetTickCount64");
+        static auto GTC64 = (ULONGLONG(*)())GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "GetTickCount64");
         if(GTC64)
             return GTC64();
 #endif //_WIN64

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -1,8 +1,9 @@
+#include <QMessageBox>
+#include <QFileDialog>
 #include "TraceBrowser.h"
 #include "TraceWidget.h"
 #include "TraceFileSearch.h"
 #include "RichTextPainter.h"
-#include "main.h"
 #include "BrowseDialog.h"
 #include "QZydis.h"
 #include "GotoDialog.h"
@@ -11,7 +12,6 @@
 #include "WordEditDialog.h"
 #include "CachedFontMetrics.h"
 #include "MRUList.h"
-#include <QFileDialog>
 
 TraceBrowser::TraceBrowser(TraceFileReader* traceFile, TraceWidget* parent) : AbstractTableView(parent), mTraceFile(traceFile)
 {
@@ -1882,10 +1882,11 @@ void TraceBrowser::searchConstantSlot()
     constantDlg.setup(tr("Constant"), initialConstant, sizeof(duint));
     if(constantDlg.exec() == QDialog::Accepted)
     {
-        auto ticks = GetTickCount();
+        QTime ticks;
+        ticks.start();
         int count = TraceFileSearchConstantRange(getTraceFile(), constantDlg.getVal(), constantDlg.getVal());
         GuiShowReferences();
-        GuiAddLogMessage(tr("%1 result(s) in %2ms\n").arg(count).arg(GetTickCount() - ticks).toUtf8().constData());
+        GuiAddLogMessage(tr("%1 result(s) in %2ms\n").arg(count).arg(ticks.elapsed()).toUtf8().constData());
     }
 }
 
@@ -1895,12 +1896,13 @@ void TraceBrowser::searchMemRefSlot()
     memRefDlg.setup(tr("References"), 0, sizeof(duint));
     if(memRefDlg.exec() == QDialog::Accepted)
     {
-        auto ticks = GetTickCount();
+        QTime ticks;
+        ticks.start();
         if(!mParent->loadDumpFully())
             return;
         int count = TraceFileSearchMemReference(getTraceFile(), memRefDlg.getVal());
         GuiShowReferences();
-        GuiAddLogMessage(tr("%1 result(s) in %2ms\n").arg(count).arg(GetTickCount() - ticks).toUtf8().constData());
+        GuiAddLogMessage(tr("%1 result(s) in %2ms\n").arg(count).arg(ticks.elapsed()).toUtf8().constData());
     }
 }
 

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -831,7 +831,7 @@ void TraceBrowser::setupRightClickContextMenu()
     mMenuBuilder = new MenuBuilder(this);
     mCommonActions = new CommonActions(this, getActionHelperFuncs(), [this]()
     {
-        return getTraceFile()->Registers(getInitialSelection()).regcontext.cip;
+        return getTraceFile()->Address(getInitialSelection());
     });
 
     auto mTraceFileNotNull = [](QMenu*)
@@ -1059,12 +1059,12 @@ void TraceBrowser::mouseDoubleClickEvent(QMouseEvent* event)
             mCommonActions->followDisassemblySlot();
             break;
         case Address://Address: set RVA
-            if(mRvaDisplayEnabled && getTraceFile()->Registers(getInitialSelection()).regcontext.cip == mRvaDisplayBase)
+            if(mRvaDisplayEnabled && getTraceFile()->Address(getInitialSelection()) == mRvaDisplayBase)
                 mRvaDisplayEnabled = false;
             else
             {
                 mRvaDisplayEnabled = true;
-                mRvaDisplayBase = getTraceFile()->Registers(getInitialSelection()).regcontext.cip;
+                mRvaDisplayBase = getTraceFile()->Address(getInitialSelection());
             }
             reloadData();
             break;
@@ -1172,7 +1172,7 @@ void TraceBrowser::selectionChangedSlot(TRACEINDEX selection)
 {
     if(mTraceSyncCpu && isFileOpened())
     {
-        GuiDisasmAt(getTraceFile()->Registers(selection).regcontext.cip, 0);
+        GuiDisasmAt(getTraceFile()->Address(selection), 0);
     }
 }
 
@@ -1359,7 +1359,7 @@ void TraceBrowser::mnemonicHelpSlot()
     int size;
     getTraceFile()->OpCode(getInitialSelection(), data, &size);
     Zydis zydis;
-    zydis.Disassemble(getTraceFile()->Registers(getInitialSelection()).regcontext.cip, data);
+    zydis.Disassemble(getTraceFile()->Address(getInitialSelection()), data);
     DbgCmdExecDirect(QString("mnemonichelp %1").arg(zydis.Mnemonic().c_str()));
     emit displayLogWidget();
 }
@@ -1407,7 +1407,7 @@ void TraceBrowser::disasmByAddress(duint address, bool history)
     {
         for(auto i : references)
         {
-            if(getTraceFile()->Registers(i).regcontext.cip == address)
+            if(getTraceFile()->Address(i) == address)
             {
                 if(found == false)
                 {
@@ -1481,7 +1481,7 @@ void TraceBrowser::gotoPreviousSlot()
 
 void TraceBrowser::gotoXrefSlot()
 {
-    emit xrefSignal(getTraceFile()->Registers(getInitialSelection()).regcontext.cip);
+    emit xrefSignal(getTraceFile()->Address(getInitialSelection()));
 }
 
 void TraceBrowser::copyCipSlot()
@@ -1491,7 +1491,7 @@ void TraceBrowser::copyCipSlot()
     {
         if(i != getSelectionStart())
             clipboard += "\r\n";
-        clipboard += ToPtrString(getTraceFile()->Registers(i).regcontext.cip);
+        clipboard += ToPtrString(getTraceFile()->Address(i));
     }
     Bridge::CopyToClipboard(clipboard);
 }
@@ -1747,7 +1747,7 @@ void TraceBrowser::copyRvaSlot()
 
     for(TRACEINDEX i = getSelectionStart(); i <= getSelectionEnd(); i++)
     {
-        duint cip = getTraceFile()->Registers(i).regcontext.cip;
+        duint cip = getTraceFile()->Address(i);
         duint base = DbgFunctions()->ModBaseFromAddr(cip);
         if(base)
         {
@@ -1772,7 +1772,7 @@ void TraceBrowser::copyFileOffsetSlot()
 
     for(TRACEINDEX i = getSelectionStart(); i <= getSelectionEnd(); i++)
     {
-        duint cip = getTraceFile()->Registers(i).regcontext.cip;
+        duint cip = getTraceFile()->Address(i);
         cip = DbgFunctions()->VaToFileOffset(cip);
         if(cip)
         {
@@ -1807,10 +1807,11 @@ void TraceBrowser::exportSlot()
 
         case Address:
         {
+            duint cip = getTraceFile()->Address(row);
             if(!DbgIsDebugging())
-                return ToPtrString(getTraceFile()->Registers(row).regcontext.cip);
+                return ToPtrString(cip);
             else
-                return getAddrText(getTraceFile()->Registers(row).regcontext.cip, 0, true);
+                return getAddrText(cip, 0, true);
         }
 
         case Opcode:
@@ -1847,11 +1848,12 @@ void TraceBrowser::exportSlot()
                 QString comment;
                 bool autoComment = false;
                 char label[MAX_LABEL_SIZE] = "";
-                if(GetCommentFormat(getTraceFile()->Registers(row).regcontext.cip, comment, &autoComment))
+                duint cip = getTraceFile()->Address(row);
+                if(GetCommentFormat(cip, comment, &autoComment))
                 {
                     return QString(comment);
                 }
-                else if(DbgGetLabelAt(getTraceFile()->Registers(row).regcontext.cip, SEG_DEFAULT, label)) // label but no comment
+                else if(DbgGetLabelAt(cip, SEG_DEFAULT, label)) // label but no comment
                 {
                     return QString(label);
                 }
@@ -1878,7 +1880,7 @@ void TraceBrowser::searchConstantSlot()
     if(!isFileOpened())
         return;
     WordEditDialog constantDlg(this);
-    duint initialConstant = getTraceFile()->Registers(getInitialSelection()).regcontext.cip;
+    duint initialConstant = getTraceFile()->Address(getInitialSelection());
     constantDlg.setup(tr("Constant"), initialConstant, sizeof(duint));
     if(constantDlg.exec() == QDialog::Accepted)
     {

--- a/src/gui/Src/Tracer/TraceDump.cpp
+++ b/src/gui/Src/Tracer/TraceDump.cpp
@@ -1162,8 +1162,11 @@ void TraceDump::findPattern()
         return;
     if(mParent->loadDumpFully())
     {
-        TraceFileSearchMemPattern(mParent->getTraceFile(), hexEdit.mHexEdit->pattern());
+        QTime ticks;
+        ticks.start();
+        auto count = TraceFileSearchMemPattern(mParent->getTraceFile(), hexEdit.mHexEdit->pattern());
         GuiShowReferences();
+        GuiAddLogMessage(QCoreApplication::translate("DBG", "%1 occurrence(s) in %2ms\n").arg(count).arg(ticks.elapsed()).toUtf8().constData());
     }
 }
 

--- a/src/gui/Src/Tracer/TraceDump.cpp
+++ b/src/gui/Src/Tracer/TraceDump.cpp
@@ -12,7 +12,8 @@
 #include "CommonActions.h"
 #include "CodepageSelectionDialog.h"
 #include "MiscUtil.h"
-#include "BackgroundFlickerThread.h"
+//#include "BackgroundFlickerThread.h"
+#include "TraceFileSearch.h"
 
 TraceDump::TraceDump(Architecture* architecture, TraceWidget* parent, TraceFileDumpMemoryPage* memoryPage) : mMemoryPage(memoryPage), HexDump(architecture, parent, memoryPage)
 {
@@ -82,7 +83,7 @@ void TraceDump::setupContextMenu()
     //TODO: Is it necessary to set memory breakpoints here?
 
     //TODO: find in dump
-    //mMenuBuilder->addAction(makeShortcutAction(DIcon("search-for"), tr("&Find Pattern..."), SLOT(findPattern()), "ActionFindPattern"));
+    mMenuBuilder->addAction(makeShortcutAction(DIcon("search-for"), tr("&Find Pattern..."), SLOT(findPattern()), "ActionFindPattern"));
     //mMenuBuilder->addAction(makeShortcutAction(DIcon("find"), tr("Find &References"), SLOT(findReferencesSlot()), "ActionFindReferences"));
 
     //TODO: Do we really need to sync with expression here?
@@ -194,12 +195,12 @@ void TraceDump::mousePressEvent(QMouseEvent* event)
     HexDump::mousePressEvent(event);
 }
 
-void TraceDump::getAttention()
-{
-    BackgroundFlickerThread* thread = new BackgroundFlickerThread(this, mBackgroundColor, this);
-    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
-    thread->start();
-}
+//void TraceDump::getAttention()
+//{
+//    BackgroundFlickerThread* thread = new BackgroundFlickerThread(this, mBackgroundColor, this);
+//    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+//    thread->start();
+//}
 
 void TraceDump::printDumpAt(duint parVA, bool select, bool repaint, bool updateTableOffset)
 {
@@ -1150,23 +1151,21 @@ void TraceDump::binarySaveToFileSlot()
     }
 }
 
-//TODO
-//void TraceDump::findPattern()
-//{
-//HexEditDialog hexEdit(this);
-//hexEdit.showEntireBlock(true);
-//hexEdit.isDataCopiable(false);
-//hexEdit.mHexEdit->setOverwriteMode(false);
-//hexEdit.setWindowTitle(tr("Find Pattern..."));
-//if(hexEdit.exec() != QDialog::Accepted)
-//return;
-//dsint addr = rvaToVa(getSelectionStart());
-//if(hexEdit.entireBlock())
-//addr = DbgMemFindBaseAddr(addr, 0);
-//QString addrText = ToPtrString(addr);
-//DbgCmdExec(QString("findall " + addrText + ", " + hexEdit.mHexEdit->pattern() + ", &data&"));
-//emit displayReferencesWidget();
-//}
+void TraceDump::findPattern()
+{
+    HexEditDialog hexEdit(this);
+    hexEdit.showEntireBlock(true);
+    hexEdit.isDataCopiable(false);
+    hexEdit.mHexEdit->setOverwriteMode(false);
+    hexEdit.setWindowTitle(tr("Find Pattern..."));
+    if(hexEdit.exec() != QDialog::Accepted)
+        return;
+    if(mParent->loadDumpFully())
+    {
+        TraceFileSearchMemPattern(mParent->getTraceFile(), hexEdit.mHexEdit->pattern());
+        GuiShowReferences();
+    }
+}
 
 void TraceDump::copyFileOffsetSlot()
 {

--- a/src/gui/Src/Tracer/TraceDump.h
+++ b/src/gui/Src/Tracer/TraceDump.h
@@ -19,7 +19,7 @@ public:
     void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) override;
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
     void setupContextMenu();
-    void getAttention();
+    //void getAttention();
     void contextMenuEvent(QContextMenuEvent* event);
     void mouseDoubleClickEvent(QMouseEvent* event);
     void mouseMoveEvent(QMouseEvent* event);
@@ -27,7 +27,6 @@ public:
     void printDumpAt(duint parVA, bool select, bool repaint, bool updateTableOffset) override;
 
 signals:
-    void displayReferencesWidget();
     void showDisassemblyTab(duint selectionStart, duint selectionEnd, duint firstAddress);
     void xrefSignal(duint addr);
 
@@ -74,7 +73,7 @@ public slots:
 
     void binaryCopySlot();
     void binarySaveToFileSlot();
-    //void findPattern();
+    void findPattern();
     void copyFileOffsetSlot();
     //void findReferencesSlot();
 

--- a/src/gui/Src/Tracer/TraceFileDump.h
+++ b/src/gui/Src/Tracer/TraceFileDump.h
@@ -15,7 +15,7 @@ public:
     {
         duint addr;
         TRACEINDEX index;
-        friend bool operator <(const Key & a, const Key & b)
+        friend bool operator <(const Key & a, const Key & b) noexcept
         {
             // order is inverted, highest address is less! We want to use lower_bound() to find last memory access index.
             return a.addr > b.addr || a.addr == b.addr && a.index > b.index;
@@ -32,11 +32,11 @@ public:
     TraceFileDump();
     ~TraceFileDump();
     void clear();
-    inline void setEnabled()
+    inline void setEnabled() noexcept
     {
         enabled = true;
     }
-    inline bool isEnabled() const
+    inline bool isEnabled() const noexcept
     {
         return enabled;
     }
@@ -48,11 +48,11 @@ public:
     void addMemAccess(duint addr, const void* oldData, const void* newData, size_t size);
     // Find pattern
     void findAllMem(const unsigned char* data, const unsigned char* mask, size_t size, std::function<bool(duint, TRACEINDEX, TRACEINDEX)> matchFunction) const;
-    inline void increaseIndex()
+    inline void increaseIndex() noexcept
     {
         maxIndex++;
     }
-    inline TRACEINDEX getMaxIndex()
+    inline TRACEINDEX getMaxIndex() noexcept
     {
         return maxIndex;
     }

--- a/src/gui/Src/Tracer/TraceFileDump.h
+++ b/src/gui/Src/Tracer/TraceFileDump.h
@@ -2,6 +2,7 @@
 
 #include "Imports.h"
 #include <map>
+#include <functional>
 #include <QMutex>
 #include "MemoryPage.h"
 
@@ -44,8 +45,9 @@ public:
     void getBytes(duint addr, duint size, TRACEINDEX index, void* buffer) const;
     std::vector<TRACEINDEX> getReferences(duint startAddr, duint endAddr) const;
     // Insert a memory access record
-    //void addMemAccess(duint addr, DumpRecord record);
     void addMemAccess(duint addr, const void* oldData, const void* newData, size_t size);
+    // Find pattern
+    void findAllMem(const unsigned char* data, const unsigned char* mask, size_t size, std::function<bool(duint, TRACEINDEX, TRACEINDEX)> matchFunction) const;
     inline void increaseIndex()
     {
         maxIndex++;

--- a/src/gui/Src/Tracer/TraceFileDump.h
+++ b/src/gui/Src/Tracer/TraceFileDump.h
@@ -44,8 +44,8 @@ public:
     bool isValidReadPtr(duint addr) const;
     void getBytes(duint addr, duint size, TRACEINDEX index, void* buffer) const;
     std::vector<TRACEINDEX> getReferences(duint startAddr, duint endAddr) const;
-    // Insert a memory access record
-    void addMemAccess(duint addr, const void* oldData, const void* newData, size_t size);
+    // Insert memory access records
+    void addMemAccess(duint cip, unsigned char* opcode, int opcodeSize, duint* memAddr, const duint* oldMemory, const duint* newMemory, size_t count);
     // Find pattern
     void findAllMem(const unsigned char* data, const unsigned char* mask, size_t size, std::function<bool(duint, TRACEINDEX, TRACEINDEX)> matchFunction) const;
     inline void increaseIndex() noexcept

--- a/src/gui/Src/Tracer/TraceFileDump.h
+++ b/src/gui/Src/Tracer/TraceFileDump.h
@@ -15,7 +15,7 @@ public:
     {
         duint addr;
         TRACEINDEX index;
-        friend bool operator <(const Key & a, const Key & b) noexcept
+        friend bool operator <(const Key & a, const Key & b)
         {
             // order is inverted, highest address is less! We want to use lower_bound() to find last memory access index.
             return a.addr > b.addr || a.addr == b.addr && a.index > b.index;
@@ -32,11 +32,11 @@ public:
     TraceFileDump();
     ~TraceFileDump();
     void clear();
-    inline void setEnabled() noexcept
+    inline void setEnabled()
     {
         enabled = true;
     }
-    inline bool isEnabled() const noexcept
+    inline bool isEnabled() const
     {
         return enabled;
     }
@@ -48,11 +48,11 @@ public:
     void addMemAccess(duint cip, unsigned char* opcode, int opcodeSize, duint* memAddr, const duint* oldMemory, const duint* newMemory, size_t count);
     // Find pattern
     void findAllMem(const unsigned char* data, const unsigned char* mask, size_t size, std::function<bool(duint, TRACEINDEX, TRACEINDEX)> matchFunction) const;
-    inline void increaseIndex() noexcept
+    inline void increaseIndex()
     {
         maxIndex++;
     }
-    inline TRACEINDEX getMaxIndex() noexcept
+    inline TRACEINDEX getMaxIndex()
     {
         return maxIndex;
     }

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -121,12 +121,12 @@ bool TraceFileReader::isError(QString & reason) const
 //}
 
 // Return the count of instructions
-TRACEINDEX TraceFileReader::Length() const noexcept
+TRACEINDEX TraceFileReader::Length() const
 {
     return length;
 }
 
-uint64_t TraceFileReader::FileSize() const noexcept
+uint64_t TraceFileReader::FileSize() const
 {
     return fileSize;
 }
@@ -175,14 +175,14 @@ REGDUMP TraceFileReader::Registers(TRACEINDEX index)
 {
     TRACEINDEX base;
     TraceFilePage* page = getPage(index, &base);
-    if(page == nullptr)
+    if(page != nullptr)
+        return page->Registers(index - base);
+    else
     {
         REGDUMP registers;
         memset(&registers, 0, sizeof(registers));
         return registers;
     }
-    else
-        return page->Registers(index - base);
 }
 
 // Return the registers context at a given index
@@ -858,7 +858,7 @@ TraceFilePage::TraceFilePage(TraceFileReader* parent, unsigned long long fileOff
     }
 }
 
-TRACEINDEX TraceFilePage::Length() const noexcept
+TRACEINDEX TraceFilePage::Length() const
 {
     return length;
 }

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -121,12 +121,12 @@ bool TraceFileReader::isError(QString & reason) const
 //}
 
 // Return the count of instructions
-TRACEINDEX TraceFileReader::Length() const
+TRACEINDEX TraceFileReader::Length() const noexcept
 {
     return length;
 }
 
-uint64_t TraceFileReader::FileSize() const
+uint64_t TraceFileReader::FileSize() const noexcept
 {
     return fileSize;
 }
@@ -183,6 +183,17 @@ REGDUMP TraceFileReader::Registers(TRACEINDEX index)
     }
     else
         return page->Registers(index - base);
+}
+
+// Return the registers context at a given index
+duint TraceFileReader::Address(TRACEINDEX index)
+{
+    TRACEINDEX base;
+    TraceFilePage* page = getPage(index, &base);
+    if(page == nullptr)
+        return 0;
+    else
+        return page->Address(index - base);
 }
 
 // Return the opcode at a given index. buffer must be 16 bytes long.
@@ -455,12 +466,11 @@ static bool readBlock(QFile & traceFile)
         throw std::wstring(L"Read block type failed");
     if(blockType == 0)
     {
-
         if(traceFile.read((char*)&changedCountFlags, 3) != 3)
             throw std::wstring(L"Read flags failed");
         //skipping: thread id, registers
         if(traceFile.seek(traceFile.pos() + ((changedCountFlags[2] & 0x80) ? 4 : 0) + (changedCountFlags[2] & 0x0F) + changedCountFlags[0] * (1 + sizeof(duint))) == false)
-            throw std::wstring(L"Unspecified");
+            throw std::wstring(L"Seek failed");
         QByteArray memflags;
         memflags = traceFile.read(changedCountFlags[1]);
         if(memflags.length() < changedCountFlags[1])
@@ -469,7 +479,7 @@ static bool readBlock(QFile & traceFile)
         for(unsigned char i = 0; i < changedCountFlags[1]; i++)
             skipOffset += ((memflags[i] & 1) == 1) ? 2 : 3;
         if(traceFile.seek(traceFile.pos() + skipOffset * sizeof(duint)) == false)
-            throw std::wstring(L"Unspecified");
+            throw std::wstring(L"Seek failed");
         //Gathered information, build index
         if(changedCountFlags[0] == (FIELD_OFFSET(REGDUMP, lastError) + sizeof(DWORD)) / sizeof(duint))
             return true;
@@ -603,87 +613,44 @@ void TraceFileReader::purgeLastPage()
 // Extract memory access information of given index into dump object
 void TraceFileReader::buildDump(TRACEINDEX index)
 {
-    unsigned char opcode[MAX_DISASM_BUFFER];
-    int opcodeSize;
-    REGDUMP registers = Registers(index);;
-    OpCode(index, opcode, &opcodeSize);
-    // Always add opcode into dump
-    dump.addMemAccess(registers.regcontext.cip, opcode, opcode, opcodeSize);
-    int MemoryOperandsCount = MemoryAccessCount(index);
-    if(MemoryOperandsCount == 0) //LEA and NOP instructions are ignored here
-        return;
-    // Method 1
-    // TODO: This doesn't get correct memory operand size
-    duint oldMemory[32];
-    duint newMemory[32];
-    duint address[32];
-    bool isValid[32];
-    MemoryAccessInfo(index, address, oldMemory, newMemory, isValid);
-    for(int i = 0; i < MemoryOperandsCount; i++)
+    try
     {
-        dump.addMemAccess(address[i], &oldMemory[i], &newMemory[i], sizeof(duint));
-    }
-    // Method 2
-    /*
-    // TODO: This works poorly for edge cases, still doesn't work with PUSH DWORD PTR FS:[ESP+EAX]
-    Zydis zydis;
-    zydis.Disassemble(registers.regcontext.cip, opcode, opcodeSize);
-    //bool used[32];
-    //memset(used, 0, sizeof(used));
-    // fix PUSH DWORD PTR [ESP] uses different ESP values
-    if(zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSH) // fix PUSH instructions, add explicit memory operand
-    {
-        const auto & operand = zydis[0];
-        if(operand.type == ZYDIS_OPERAND_TYPE_MEMORY)
+        unsigned char opcode[MAX_DISASM_BUFFER];
+        int opcodeSize;
+        duint cip = Address(index);;
+        OpCode(index, opcode, &opcodeSize);
+        int MemoryOperandsCount = MemoryAccessCount(index);
+        // Method 1
+        // TODO: This doesn't get correct memory operand size
+        duint oldMemory[32];
+        duint newMemory[32];
+        duint address[32];
+        bool isValid[32];
+        if(MemoryOperandsCount > 0) //LEA and NOP instructions are ignored here
         {
-            int size;
-            size = ceil((float)operand.size / 8.0f);
-            size_t value = zydis.ResolveOpValue(0, [&registers](ZydisRegister reg)
-            {
-                return resolveZydisRegister(registers, reg);
-            });
-            bool found = false;
-            for(int i = 0; i < MemoryOperandsCount; i++)
-            {
-                // TODO: fix up FS/GS segment
-                if(address[i] != value)
-                    continue;
-                dump.addMemAccess(address[i], &oldMemory[i], &newMemory[i], size);
-                found = true;
-                break;
-            }
-            //if(!found)
-            //bug???
-            //GuiAddLogMessage(QString("buildDump bug %1???\n").arg(index).toUtf8().constData());
+            MemoryAccessInfo(index, address, oldMemory, newMemory, isValid);
         }
-    }
-    // fix PUSH instructions, add implicit memory operand
-    if(zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSH ||zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSHF || zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSHFD || zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSHFQ)
-    {
-        size_t new_csp = registers.regcontext.csp - sizeof(duint);
-        bool found = false;
-        for(int i = 0; i < MemoryOperandsCount; i++)
+        dump.addMemAccess(cip, opcode, opcodeSize, address, oldMemory, newMemory, MemoryOperandsCount);
+        //for(int i = 0; i < MemoryOperandsCount; i++)
+        //{
+        //    dump.addMemAccess(address[i], &oldMemory[i], &newMemory[i], sizeof(duint));
+        //}
+        // Method 2
+        /*
+        // TODO: This works poorly for edge cases, still doesn't work with PUSH DWORD PTR FS:[ESP+EAX]
+        Zydis zydis;
+        zydis.Disassemble(registers.regcontext.cip, opcode, opcodeSize);
+        //bool used[32];
+        //memset(used, 0, sizeof(used));
+        // fix PUSH DWORD PTR [ESP] uses different ESP values
+        if(zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSH) // fix PUSH instructions, add explicit memory operand
         {
-            if(address[i] != new_csp)
-                continue;
-            dump.addMemAccess(address[i], &oldMemory[i], &newMemory[i], sizeof(duint));
-            found = true;
-            break;
-        }
-        //if(!found)
-        //bug???
-        //GuiAddLogMessage(QString("buildDump bug %1???\n").arg(index).toUtf8().constData());
-    }
-    else
-    {
-        for(int opindex = 0; opindex < zydis.GetInstr()->operandCount; opindex++)
-        {
-            const auto & operand = zydis.GetInstr()->operands[opindex];
+            const auto & operand = zydis[0];
             if(operand.type == ZYDIS_OPERAND_TYPE_MEMORY)
             {
                 int size;
                 size = ceil((float)operand.size / 8.0f);
-                size_t value = zydis.ResolveOpValue(opindex, [&registers](ZydisRegister reg)
+                size_t value = zydis.ResolveOpValue(0, [&registers](ZydisRegister reg)
                 {
                     return resolveZydisRegister(registers, reg);
                 });
@@ -702,14 +669,68 @@ void TraceFileReader::buildDump(TRACEINDEX index)
                 //GuiAddLogMessage(QString("buildDump bug %1???\n").arg(index).toUtf8().constData());
             }
         }
+        // fix PUSH instructions, add implicit memory operand
+        if(zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSH ||zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSHF || zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSHFD || zydis.GetInstr()->mnemonic == ZYDIS_MNEMONIC_PUSHFQ)
+        {
+            size_t new_csp = registers.regcontext.csp - sizeof(duint);
+            bool found = false;
+            for(int i = 0; i < MemoryOperandsCount; i++)
+            {
+                if(address[i] != new_csp)
+                    continue;
+                dump.addMemAccess(address[i], &oldMemory[i], &newMemory[i], sizeof(duint));
+                found = true;
+                break;
+            }
+            //if(!found)
+            //bug???
+            //GuiAddLogMessage(QString("buildDump bug %1???\n").arg(index).toUtf8().constData());
+        }
+        else
+        {
+            for(int opindex = 0; opindex < zydis.GetInstr()->operandCount; opindex++)
+            {
+                const auto & operand = zydis.GetInstr()->operands[opindex];
+                if(operand.type == ZYDIS_OPERAND_TYPE_MEMORY)
+                {
+                    int size;
+                    size = ceil((float)operand.size / 8.0f);
+                    size_t value = zydis.ResolveOpValue(opindex, [&registers](ZydisRegister reg)
+                    {
+                        return resolveZydisRegister(registers, reg);
+                    });
+                    bool found = false;
+                    for(int i = 0; i < MemoryOperandsCount; i++)
+                    {
+                        // TODO: fix up FS/GS segment
+                        if(address[i] != value)
+                            continue;
+                        dump.addMemAccess(address[i], &oldMemory[i], &newMemory[i], size);
+                        found = true;
+                        break;
+                    }
+                    //if(!found)
+                    //bug???
+                    //GuiAddLogMessage(QString("buildDump bug %1???\n").arg(index).toUtf8().constData());
+                }
+            }
+        }
+        */
     }
-    */
+    catch(std::bad_alloc &)
+    {
+        error = true;
+        errorMessage = "[TraceFileReader::buildDump] std::bad_alloc";
+        dump.clear(); // There's no enough memory, so we free up some memory
+    }
 }
 
 // Build dump index to the given index
 void TraceFileReader::buildDumpTo(TRACEINDEX index)
 {
     auto start = dump.getMaxIndex(); // Don't re-add existing dump
+    if(start == 0) // maxIndex=0, trace dump is just enabled
+        buildDump(0);
     for(auto i = start + 1; i <= index; i++)
     {
         dump.increaseIndex();
@@ -837,7 +858,7 @@ TraceFilePage::TraceFilePage(TraceFileReader* parent, unsigned long long fileOff
     }
 }
 
-TRACEINDEX TraceFilePage::Length() const
+TRACEINDEX TraceFilePage::Length() const noexcept
 {
     return length;
 }
@@ -845,6 +866,11 @@ TRACEINDEX TraceFilePage::Length() const
 const REGDUMP & TraceFilePage::Registers(TRACEINDEX index) const
 {
     return mRegisters.at(index);
+}
+
+const duint TraceFilePage::Address(TRACEINDEX index) const
+{
+    return mRegisters.at(index).regcontext.cip;
 }
 
 void TraceFilePage::OpCode(TRACEINDEX index, unsigned char* buffer, int* opcodeSize) const

--- a/src/gui/Src/Tracer/TraceFileReader.h
+++ b/src/gui/Src/Tracer/TraceFileReader.h
@@ -27,10 +27,13 @@ public:
 
     QString getIndexText(TRACEINDEX index) const;
 
-    TRACEINDEX Length() const;
-    uint64_t FileSize() const;
+    TRACEINDEX Length() const noexcept;
+    uint64_t FileSize() const noexcept;
 
+    // Get register dump
     REGDUMP Registers(TRACEINDEX index);
+    // Just get value of EIP
+    duint Address(TRACEINDEX index);
     void OpCode(TRACEINDEX index, unsigned char* buffer, int* opcodeSize);
     const Instruction_t & Instruction(TRACEINDEX index);
     // Get thread ID

--- a/src/gui/Src/Tracer/TraceFileReader.h
+++ b/src/gui/Src/Tracer/TraceFileReader.h
@@ -27,8 +27,8 @@ public:
 
     QString getIndexText(TRACEINDEX index) const;
 
-    TRACEINDEX Length() const noexcept;
-    uint64_t FileSize() const noexcept;
+    TRACEINDEX Length() const;
+    uint64_t FileSize() const;
 
     // Get register dump
     REGDUMP Registers(TRACEINDEX index);

--- a/src/gui/Src/Tracer/TraceFileReaderInternal.h
+++ b/src/gui/Src/Tracer/TraceFileReaderInternal.h
@@ -17,8 +17,9 @@ class TraceFilePage
 {
 public:
     TraceFilePage(TraceFileReader* parent, unsigned long long fileOffset, TRACEINDEX maxLength);
-    TRACEINDEX Length() const;
+    TRACEINDEX Length() const noexcept;
     const REGDUMP & Registers(TRACEINDEX index) const;
+    const duint Address(TRACEINDEX index) const;
     void OpCode(TRACEINDEX index, unsigned char* buffer, int* opcodeSize) const;
     const Instruction_t & Instruction(TRACEINDEX index, QZydis & mDisasm);
     DWORD ThreadId(TRACEINDEX index) const;

--- a/src/gui/Src/Tracer/TraceFileReaderInternal.h
+++ b/src/gui/Src/Tracer/TraceFileReaderInternal.h
@@ -17,7 +17,7 @@ class TraceFilePage
 {
 public:
     TraceFilePage(TraceFileReader* parent, unsigned long long fileOffset, TRACEINDEX maxLength);
-    TRACEINDEX Length() const noexcept;
+    TRACEINDEX Length() const;
     const REGDUMP & Registers(TRACEINDEX index) const;
     const duint Address(TRACEINDEX index) const;
     void OpCode(TRACEINDEX index, unsigned char* buffer, int* opcodeSize) const;

--- a/src/gui/Src/Tracer/TraceFileSearch.cpp
+++ b/src/gui/Src/Tracer/TraceFileSearch.cpp
@@ -75,12 +75,12 @@ int TraceFileSearchConstantRange(TraceFileReader* file, duint start, duint end)
         if(found)
         {
             GuiReferenceSetRowCount(count + 1);
-            GuiReferenceSetCellContent(count, 0, ToPtrString(file->Registers(index).regcontext.cip).toUtf8().constData());
+            GuiReferenceSetCellContent(count, 0, ToPtrString(file->Address(index)).toUtf8().constData());
             GuiReferenceSetCellContent(count, 1, file->getIndexText(index).toUtf8().constData());
             unsigned char opcode[16];
             int opcodeSize = 0;
             file->OpCode(index, opcode, &opcodeSize);
-            zy.Disassemble(file->Registers(index).regcontext.cip, opcode, opcodeSize);
+            zy.Disassemble(file->Address(index), opcode, opcodeSize);
             GuiReferenceSetCellContent(count, 2, zy.InstructionText(true).c_str());
             //GuiReferenceSetCurrentTaskProgress; GuiReferenceSetProgress
             count++;
@@ -138,12 +138,12 @@ int TraceFileSearchMemReference(TraceFileReader* file, duint address)
             if(found)
             {
                 GuiReferenceSetRowCount(count + 1);
-                GuiReferenceSetCellContent(count, 0, ToPtrString(file->Registers(index).regcontext.cip).toUtf8().constData());
+                GuiReferenceSetCellContent(count, 0, ToPtrString(file->Address(index)).toUtf8().constData());
                 GuiReferenceSetCellContent(count, 1, file->getIndexText(index).toUtf8().constData());
                 unsigned char opcode[16];
                 int opcodeSize = 0;
                 file->OpCode(index, opcode, &opcodeSize);
-                zy.Disassemble(file->Registers(index).regcontext.cip, opcode, opcodeSize);
+                zy.Disassemble(file->Address(index), opcode, opcodeSize);
                 GuiReferenceSetCellContent(count, 2, zy.InstructionText(true).c_str());
                 //GuiReferenceSetCurrentTaskProgress; GuiReferenceSetProgress
                 count++;
@@ -160,7 +160,8 @@ TRACEINDEX TraceFileSearchFuncReturn(TraceFileReader* file, TRACEINDEX start)
     Zydis zy;
     for(TRACEINDEX index = start; index < file->Length(); index++)
     {
-        if(mCsp <= file->Registers(index).regcontext.csp && file->ThreadId(index) == TID) //"Run until return" should break only if RSP is bigger than or equal to current value
+        auto registers = file->Registers(index);
+        if(mCsp <= registers.regcontext.csp && file->ThreadId(index) == TID) //"Run until return" should break only if RSP is bigger than or equal to current value
         {
             unsigned char data[16];
             int opcodeSize = 0;
@@ -173,7 +174,7 @@ TRACEINDEX TraceFileSearchFuncReturn(TraceFileReader* file, TRACEINDEX start)
 #endif //_WIN64
                    )
             {
-                if(zy.Disassemble(file->Registers(index).regcontext.cip, data, opcodeSize) && zy.IsRet())
+                if(zy.Disassemble(registers.regcontext.cip, data, opcodeSize) && zy.IsRet())
                     return index;
             }
         }
@@ -287,7 +288,7 @@ int TraceFileSearchMemPattern(TraceFileReader* file, const QString & pattern)
         if(startIndex > 0)
         {
             duint cip;
-            cip = file->Registers(startIndex).regcontext.cip;
+            cip = file->Address(startIndex);
             GuiReferenceSetCellContent(count, 3, ToPtrString(cip).toUtf8().constData());
             unsigned char opcode[16];
             int opcodeSize = 0;

--- a/src/gui/Src/Tracer/TraceFileSearch.h
+++ b/src/gui/Src/Tracer/TraceFileSearch.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "Bridge.h"
-class TraceFileReader;
+#include "TraceFileReader.h"
 
 int TraceFileSearchConstantRange(TraceFileReader* file, duint start, duint end);
 int TraceFileSearchMemReference(TraceFileReader* file, duint address);
-unsigned long long TraceFileSearchFuncReturn(TraceFileReader* file, unsigned long long start);
+TRACEINDEX TraceFileSearchFuncReturn(TraceFileReader* file, TRACEINDEX start);
+int TraceFileSearchMemPattern(TraceFileReader* file, const QString & pattern);

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -347,12 +347,12 @@ void TraceWidget::setupFollowMenu(QMenu* menu)
 
             if(zydis[opindex].type == ZYDIS_OPERAND_TYPE_MEMORY)
             {
+                if(traceDump->isValidReadPtr(value))
+                {
+                    addFollowMenuItem(menu, tr("&Address: ") + QString::fromStdString(zydis.OperandText(opindex)), value);
+                }
                 if(zydis[opindex].size == sizeof(void*) * 8)
                 {
-                    if(traceDump->isValidReadPtr(value))
-                    {
-                        addFollowMenuItem(menu, tr("&Address: ") + QString::fromStdString(zydis.OperandText(opindex)), value);
-                    }
                     for(uint8_t memaccessindex = 0; memaccessindex < MemoryOperandsCount; memaccessindex++)
                     {
                         if(MemoryAddress[memaccessindex] == value)

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -277,7 +277,7 @@ void TraceWidget::setupDumpInitialAddresses(TRACEINDEX selection)
     else
     {
         // No memory operands, so display opcode instead
-        initialAddress = mTraceFile->Registers(selection).regcontext.cip;
+        initialAddress = mTraceFile->Address(selection);
     }
     mDump->printDumpAt(initialAddress, false, true, true);
     // Setting the initial address of stack view

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -145,9 +145,8 @@ void TraceWidget::traceSelectionChanged(TRACEINDEX selection)
 
 void TraceWidget::xrefSlot(duint addr)
 {
-    if(!mDump)
-        if(!loadDumpFully())
-            return;
+    if(!loadDumpFully())
+        return;
     if(!mXrefDlg)
         mXrefDlg = new TraceXrefBrowseDialog(this);
     mXrefDlg->setup(mTraceBrowser->getInitialSelection(), addr, mTraceFile, [this](duint addr)
@@ -248,8 +247,15 @@ bool TraceWidget::loadDumpFully()
         if(!loadDump())
             return false;
 
+    QTime ticks;
+    ticks.start();
     // Fully build dump index
     mTraceFile->buildDumpTo(mTraceFile->Length() - 1);
+    auto elapsed = ticks.elapsed();
+    if(elapsed >= 200)
+    {
+        GuiAddLogMessage(tr("Loaded trace dump in %1ms\n").arg(elapsed).toUtf8().constData());
+    }
     return true;
 }
 

--- a/src/gui/Src/Tracer/TraceXrefBrowseDialog.cpp
+++ b/src/gui/Src/Tracer/TraceXrefBrowseDialog.cpp
@@ -51,7 +51,7 @@ void TraceXrefBrowseDialog::setup(duint index, duint address, TraceFileReader* t
     mXrefInfo.reserve(xrefInfo.size());
     for(auto & i : xrefInfo)
     {
-        mXrefInfo.emplace_back(TRACE_XREF_RECORD({i, traceFile->Registers(i).regcontext.cip}));
+        mXrefInfo.emplace_back(TRACE_XREF_RECORD({i, traceFile->Address(i)}));
     }
 
     setWindowTitle(QString(tr("xrefs at <%1>")).arg(GetFunctionSymbol(address)));


### PR DESCRIPTION
Now you can find pattern in trace dump. The memory changes during the trace, and the match can be anywhere at anytime within the trace.
Since there is no unit test, please report incorrect results.