### PR TITLE
Removing PidTidInHex, keeping PID/TID in dec

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1145,7 +1145,6 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
         bNoWow64SingleStepWorkaround = settingboolget("Engine", "NoWow64SingleStepWorkaround");
         bQueryWorkingSet = settingboolget("Misc", "QueryWorkingSet");
         bForceLoadSymbols = settingboolget("Misc", "ForceLoadSymbols");
-        bPidTidInHex = settingboolget("Gui", "PidTidInHex");
         bTruncateBreakpointLogs = settingboolget("Engine", "TruncateBreakpointLogs");
         stackupdatesettings();
 

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -3044,10 +3044,7 @@ void dbgcreatedebugthread(INIT_STRUCT* init)
 
 String formatpidtid(DWORD pidtid)
 {
-    if(bPidTidInHex)
-        return StringUtils::sprintf("%X", pidtid);
-    else
-        return StringUtils::sprintf("%u", pidtid);
+    return StringUtils::sprintf("%u", pidtid);
 }
 
 void dbgsetcontinuestatus(DWORD status)

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -157,7 +157,6 @@ extern bool bVerboseExceptionLogging;
 extern bool bNoWow64SingleStepWorkaround;
 extern bool bForceLoadSymbols;
 extern bool bNewStringAlgorithm;
-extern bool bPidTidInHex;
 extern bool bWindowLongPath;
 extern duint maxSkipExceptionCount;
 extern HANDLE mProcHandle;

--- a/src/gui/Src/Gui/AttachDialog.cpp
+++ b/src/gui/Src/Gui/AttachDialog.cpp
@@ -33,7 +33,7 @@ AttachDialog::AttachDialog(QWidget* parent) : QDialog(parent), ui(new Ui::Attach
 
     //setup process list
     int charwidth = mSearchListView->getCharWidth();
-    mSearchListView->addColumnAt(charwidth * sizeof(int) * 2 + 8, tr("PID"), true, QString(), ConfigBool("Gui", "PidTidInHex") ? StdTable::SortBy::AsHex : StdTable::SortBy::AsInt);
+    mSearchListView->addColumnAt(charwidth * sizeof(int) * 2 + 8, tr("PID"), true, QString(), StdTable::SortBy::AsInt);
     mSearchListView->addColumnAt(150, tr("Name"), true);
     mSearchListView->addColumnAt(300, tr("Title"), true);
     mSearchListView->addColumnAt(500, tr("Path"), true);
@@ -70,7 +70,7 @@ void AttachDialog::refresh()
     for(int i = 0; i < count; i++)
     {
         QFileInfo fi(entries[i].szExeFile);
-        mSearchListView->setCellContent(i, ColPid, QString().sprintf(ConfigBool("Gui", "PidTidInHex") ? "%.8X" : "%u", entries[i].dwProcessId));
+        mSearchListView->setCellContent(i, ColPid, QString().sprintf("%u", entries[i].dwProcessId));
         mSearchListView->setCellContent(i, ColName, fi.baseName());
         mSearchListView->setCellContent(i, ColTitle, QString(entries[i].szExeMainWindowTitle));
         mSearchListView->setCellContent(i, ColPath, QString(entries[i].szExeFile));
@@ -84,7 +84,7 @@ void AttachDialog::refresh()
 void AttachDialog::on_btnAttach_clicked()
 {
     QString pid = mSearchListView->mCurList->getCellContent(mSearchListView->mCurList->getInitialSelection(), ColPid);
-    DbgCmdExec(QString("attach %1%2").arg(ConfigBool("Gui", "PidTidInHex") ? "" : ".").arg(pid));
+    DbgCmdExec(QString("attach %1%2").arg(".").arg(pid));
     accept();
 }
 
@@ -110,7 +110,7 @@ retryFindWindow:
         if(tid = GetWindowThreadProcessId(hWndFound, &pid))
         {
             refresh();
-            QString pidText = QString().sprintf(ConfigBool("Gui", "PidTidInHex") ? "%.8X" : "%u", pid);
+            QString pidText = QString().sprintf("%u", pid);
             bool found = false;
             for(duint i = 0; i < mSearchListView->mCurList->getRowCount(); i++)
             {

--- a/src/gui/Src/Gui/HandlesView.cpp
+++ b/src/gui/Src/Gui/HandlesView.cpp
@@ -444,7 +444,7 @@ void HandlesView::enumWindows()
             mWindowsTable->setCellContent(i, 1, ToHexString(windows[i].handle));
             mWindowsTable->setCellContent(i, 2, QString(windows[i].windowTitle));
             mWindowsTable->setCellContent(i, 3, QString(windows[i].windowClass));
-            auto tidStr = QString().sprintf(Config()->getBool("Gui", "PidTidInHex") ? "%X" : "%u", windows[i].threadId);
+            auto tidStr = QString().sprintf("%u", windows[i].threadId);
             char threadName[MAX_THREAD_NAME_SIZE];
             if(DbgFunctions()->ThreadGetName(windows[i].threadId, threadName) && *threadName != '\0')
                 mWindowsTable->setCellContent(i, 4, QString::fromUtf8(threadName) + QString(" (%1)").arg(tidStr));

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -261,7 +261,6 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Gui", "FpuRegistersLittleEndian", &settings.guiFpuRegistersLittleEndian);
     GetSettingBool("Gui", "SaveColumnOrder", &settings.guiSaveColumnOrder);
     GetSettingBool("Gui", "NoCloseDialog", &settings.guiNoCloseDialog);
-    GetSettingBool("Gui", "PidTidInHex", &settings.guiPidTidInHex);
     GetSettingBool("Gui", "SidebarWatchLabels", &settings.guiSidebarWatchLabels);
     GetSettingBool("Gui", "NoForegroundWindow", &settings.guiNoForegroundWindow);
     GetSettingBool("Gui", "LoadSaveTabOrder", &settings.guiLoadSaveTabOrder);
@@ -278,7 +277,6 @@ void SettingsDialog::LoadSettings()
     ui->chkFpuRegistersLittleEndian->setChecked(settings.guiFpuRegistersLittleEndian);
     ui->chkSaveColumnOrder->setChecked(settings.guiSaveColumnOrder);
     ui->chkNoCloseDialog->setChecked(settings.guiNoCloseDialog);
-    ui->chkPidTidInHex->setChecked(settings.guiPidTidInHex);
     ui->chkSidebarWatchLabels->setChecked(settings.guiSidebarWatchLabels);
     ui->chkNoForegroundWindow->setChecked(settings.guiNoForegroundWindow);
     ui->chkSaveLoadTabOrder->setChecked(settings.guiLoadSaveTabOrder);
@@ -431,8 +429,7 @@ void SettingsDialog::SaveSettings()
     //Gui tab
     BridgeSettingSetUint("Gui", "FpuRegistersLittleEndian", settings.guiFpuRegistersLittleEndian);
     BridgeSettingSetUint("Gui", "SaveColumnOrder", settings.guiSaveColumnOrder);
-    BridgeSettingSetUint("Gui", "NoCloseDialog", settings.guiNoCloseDialog);
-    BridgeSettingSetUint("Gui", "PidTidInHex", settings.guiPidTidInHex);
+    BridgeSettingSetUint("Gui", "NoCloseDialog", settings.guiNoCloseDialog);;
     BridgeSettingSetUint("Gui", "SidebarWatchLabels", settings.guiSidebarWatchLabels);
     BridgeSettingSetUint("Gui", "NoForegroundWindow", settings.guiNoForegroundWindow);
     BridgeSettingSetUint("Gui", "LoadSaveTabOrder", settings.guiLoadSaveTabOrder);
@@ -1007,11 +1004,6 @@ void SettingsDialog::on_chkAutoFollowInStack_toggled(bool checked)
 void SettingsDialog::on_chkSkipInt3Stepping_toggled(bool checked)
 {
     settings.engineSkipInt3Stepping = checked;
-}
-
-void SettingsDialog::on_chkPidTidInHex_clicked(bool checked)
-{
-    settings.guiPidTidInHex = checked;
 }
 
 void SettingsDialog::on_chkNoScriptTimeout_stateChanged(int arg1)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -100,7 +100,6 @@ private slots:
     void on_chkSaveColumnOrder_stateChanged(int arg1);
     void on_chkSaveLoadTabOrder_stateChanged(int arg1);
     void on_chkNoCloseDialog_toggled(bool checked);
-    void on_chkPidTidInHex_clicked(bool checked);
     void on_chkSidebarWatchLabels_stateChanged(int arg1);
     void on_chkNoForegroundWindow_toggled(bool checked);
     void on_chkShowExitConfirmation_toggled(bool checked);
@@ -236,7 +235,6 @@ private:
         bool guiFpuRegistersLittleEndian = false;
         bool guiSaveColumnOrder = false;
         bool guiNoCloseDialog = false;
-        bool guiPidTidInHex = false;
         bool guiSidebarWatchLabels = false;
         bool guiNoForegroundWindow = true;
         bool guiLoadSaveTabOrder = true;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -868,13 +868,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="chkPidTidInHex">
-         <property name="text">
-          <string>Show PID/TID in HEX</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="chkSaveLoadTabOrder">
          <property name="text">
           <string>Enable Load/Save Tab Order</string>

--- a/src/gui/Src/Gui/ThreadView.cpp
+++ b/src/gui/Src/Gui/ThreadView.cpp
@@ -150,7 +150,7 @@ ThreadView::ThreadView(StdTable* parent) : StdTable(parent)
     enableMultiSelection(true);
     int charwidth = getCharWidth();
     addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("Number"), true, "", SortBy::AsInt);
-    addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("ID"), true, "", ConfigBool("Gui", "PidTidInHex") ? SortBy::AsHex : SortBy::AsInt);
+    addColumnAt(8 + charwidth * sizeof(unsigned int) * 2, tr("ID"), true, "", SortBy::AsInt);
     addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("Entry"), true, "", SortBy::AsHex);
     addColumnAt(8 + charwidth * sizeof(duint) * 2, tr("TEB"), true, "", SortBy::AsHex);
     addColumnAt(8 + charwidth * sizeof(duint) * 2, ArchValue(tr("EIP"), tr("RIP")), true, "", SortBy::AsHex);
@@ -208,7 +208,7 @@ void ThreadView::updateThreadListSlot()
     memset(&threadList, 0, sizeof(THREADLIST));
     DbgGetThreadList(&threadList);
     setRowCount(threadList.count);
-    auto tidFormat = ConfigBool("Gui", "PidTidInHex") ? "%X" : "%d";
+    auto tidFormat = "%d";
     for(int i = 0; i < threadList.count; i++)
     {
         if(!threadList.list[i].BasicInfo.ThreadNumber)

--- a/src/gui/Src/Tracer/TraceInfoBox.cpp
+++ b/src/gui/Src/Tracer/TraceInfoBox.cpp
@@ -208,7 +208,7 @@ void TraceInfoBox::update(TRACEINDEX selection, TraceFileReader* traceFile, cons
         }
         DWORD tid;
         tid = traceFile->ThreadId(selection);
-        line = QString("ThreadID: %1").arg(ConfigBool("Gui", "PidTidInHex") ? ToHexString(tid) : QString::number(tid));
+        line = QString("ThreadID: %1").arg(QString::number(tid));
         setCellContent(3, 0, line);
     }
     reloadData();

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -281,7 +281,6 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     guiBool.insert("FpuRegistersLittleEndian", false);
     guiBool.insert("SaveColumnOrder", true);
     guiBool.insert("NoCloseDialog", false);
-    guiBool.insert("PidTidInHex", false);
     guiBool.insert("SidebarWatchLabels", true);
     guiBool.insert("LoadSaveTabOrder", true);
     guiBool.insert("ShowGraphRva", false);


### PR DESCRIPTION
This PR removes `PidInHex` settings from Configuration and its uses. All of the TIDs/PIDs are being stored in decimal format.

Issue #3142.