### PR TITLE
Fix "scriptcmd call label" when script is not running

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1014,7 +1014,7 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
 
     case DBG_SCRIPT_RUN:
     {
-        scriptrun((int)(duint)param1);
+        scriptrun((int)(duint)param1, param2 != nullptr);
     }
     break;
 

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -971,7 +971,11 @@ static void cbGenericBreakpoint(BP_TYPE bptype, const void* ExceptionAddress = n
             {
                 formattedText += "\n";
                 DWORD written = 0;
-                WriteFile(logFile, formattedText.c_str(), (DWORD)formattedText.length(), &written, nullptr);
+                if(WriteFile(logFile, formattedText.c_str(), (DWORD)formattedText.length(), &written, nullptr) == FALSE)
+                {
+                    // WriteFile failed
+                    logFileError = GetLastError();
+                };
             }
         }
         else

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -615,19 +615,22 @@ void scriptunload()
     bAbort = false;
 }
 
-void scriptrun(int destline)
+void scriptrun(int destline, bool silentRet)
 {
     if(DbgIsDebugging() && dbgisrunning())
     {
-        GuiScriptError(0, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Debugger must be paused to run a script!")));
+        if(!silentRet)
+            GuiScriptError(0, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Debugger must be paused to run a script!")));
+        else
+            dputs(QT_TRANSLATE_NOOP("DBG", "Debugger must be paused to run a script!"));
         return;
     }
     if(bIsRunning) //already running
         return;
     bIsRunning = true;
-    std::thread t([destline]
+    std::thread t([destline, silentRet]
     {
-        scriptRunSync(destline, false);
+        scriptRunSync(destline, silentRet);
     });
     t.detach();
 }
@@ -697,7 +700,7 @@ bool scriptcmdexec(const char* command)
     case STATUS_CONTINUE_BRANCH:
         if(!bIsRunning)
         {
-            scriptrun(scriptIp);
+            scriptrun(scriptIp, true);
         }
         break;
     }

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -630,6 +630,14 @@ void scriptrun(int destline, bool silentRet)
     bIsRunning = true;
     std::thread t([destline, silentRet]
     {
+        // When this command is called from a breakpoint callback, it may need to wait until debugger is paused
+        // FIXME: It's assumed that the user set break condition to 1 when using scriptcmd, but what happens when it is not the case?
+        int time = 0;
+        while(DbgIsDebugging() && dbgisrunning() && !bAbort && time < 1000)  //while not locked (NOTE: possible deadlock)
+        {
+            Sleep(1);
+            time++;
+        }
         scriptRunSync(destline, silentRet);
     });
     t.detach();

--- a/src/dbg/simplescript.h
+++ b/src/dbg/simplescript.h
@@ -26,7 +26,7 @@ struct LINEMAPENTRY
 //functions
 void scriptload(const char* filename);
 void scriptunload();
-void scriptrun(int destline);
+void scriptrun(int destline, bool silentRet = false);
 void scriptstep();
 bool scriptbptoggle(int line);
 bool scriptbpget(int line);
@@ -38,7 +38,7 @@ void scriptreset();
 bool scriptgetbranchinfo(int line, SCRIPTBRANCH* info);
 void scriptlog(const char* msg);
 bool scriptLoadSync(const char* filename);
-bool scriptRunSync(int destline, bool silentRet);
+bool scriptRunSync(int destline, bool silentRet = false);
 
 //script commands
 


### PR DESCRIPTION
Now it is able to use "scriptcmd call label" in breakpoint command.
There may be some hard to tell bugs. For example, x64dbg pops up "script finished" dialog when the last label is executed. Annoying, but it's difficult to tell whether this dialog should pop up.