### PR TITLE
Update heap enumeration in Windows 11 24H2

### DIFF
--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -337,6 +337,46 @@ static void ProcessSystemPages(std::vector<MEMPAGE> & pageVector)
     for(uint32_t i = 0; i < HeapCount; i++)
         processHeapIds.emplace(ProcessHeaps[i], i);
 
+	// On Windows 11 24H2+, PEB does not store all the heap in the process.
+	// Reference: https://cafe.naver.com/megayuchi/683, https://cafe.naver.com/megayuchi/684
+	static auto buildNumber = BridgeGetNtBuildNumber();
+	if (buildNumber >= 26100 && HeapCount == 1)
+	{
+		ULONG SegmentSignature = 0;
+		MemRead(ProcessHeaps[0] + offsetof(HEAP, SegmentSignature), &SegmentSignature, sizeof(SegmentSignature));
+
+		duint ProcessHeapDescriptorPtr = 0;
+		if (SegmentSignature == RTL_NT_HEAP_SIGNATURE)
+		{
+			MemRead(ProcessHeaps[0] + offsetof(HEAP, UserContext), &ProcessHeapDescriptorPtr, sizeof(ProcessHeapDescriptorPtr));
+		}
+		else if (SegmentSignature == RTL_SEGMENT_HEAP_SIGNATURE)
+		{
+			MemRead(ProcessHeaps[0] + offsetof(SEGMENT_HEAP, UserContext), &ProcessHeapDescriptorPtr, sizeof(ProcessHeapDescriptorPtr));
+		}
+
+		duint CurrentProcessHeapId = HeapCount;
+		duint CurrentProcessHeapDescriptorPtr = ProcessHeapDescriptorPtr;
+
+		while (CurrentProcessHeapDescriptorPtr != 0) {
+			MemRead(CurrentProcessHeapDescriptorPtr + offsetof(PROCESS_HEAP_DESCRIPTOR, Next), &CurrentProcessHeapDescriptorPtr, sizeof(CurrentProcessHeapDescriptorPtr));
+			if (CurrentProcessHeapDescriptorPtr == 0)
+				break;
+
+			duint ProcessHeapPtr = 0;
+			MemRead(CurrentProcessHeapDescriptorPtr + offsetof(PROCESS_HEAP_DESCRIPTOR, Heap), &ProcessHeapPtr, sizeof(ProcessHeapPtr));
+			if (ProcessHeapPtr == 0)
+				break;
+
+			// Check for current heap is correct
+			MemRead(ProcessHeapPtr + offsetof(HEAP, SegmentSignature), &SegmentSignature, sizeof(SegmentSignature));
+			if (SegmentSignature != RTL_NT_HEAP_SIGNATURE && SegmentSignature != RTL_SEGMENT_HEAP_SIGNATURE)
+				break;
+
+			processHeapIds.emplace(ProcessHeapPtr, CurrentProcessHeapId++);
+		} 
+	}
+
     for(auto & page : pageVector)
     {
         const duint pageBase = (duint)page.mbi.BaseAddress;

--- a/src/dbg/ntdll/ntdll.h
+++ b/src/dbg/ntdll/ntdll.h
@@ -3800,6 +3800,39 @@ typedef struct _PEB
     ULONG CloudFileFlags;
 } PEB, *PPEB;
 
+#define RTL_NT_HEAP_SIGNATURE 0xFFEEFFEE
+#define RTL_SEGMENT_HEAP_SIGNATURE 0xDDEEDDEE
+
+// Only for Windows 11 24H2+
+typedef struct _SEGMENT_HEAP
+{
+	UCHAR Reserved0[0x10];  // 0x0  ~ 0x10	Skip unused members
+	ULONG Signature;        // 0x10 ~ 0x14
+	UCHAR Padding0[0x04];   // 0x14 ~ 0x18
+	UCHAR Reserved1[0x20];  // 0x18 ~ 0x38	Skip unused members
+	PVOID UserContext;      // 0x38 ~ 0x40
+} SEGMENT_HEAP, *PSEGMENT_HEAP;
+
+// Only for Windows 11 24H2+
+typedef struct _HEAP
+{
+	UCHAR Reserved0[0x10];   // 0x0   ~ 0x10  Skip unused members
+	ULONG SegmentSignature;  // 0x10  ~ 0x14
+	UCHAR Padding0[0x04];    // 0x14  ~ 0x18
+	UCHAR Reserved1[0x170];  // 0x18  ~ 0x188 Skip unused members
+	PVOID UserContext;       // 0x188 ~ 0x190
+	UCHAR Reserved2[0x130];  // 0x190 ~ 0x2C0 Skip unused members
+} HEAP, *PHEAP;
+
+// Only for Windows 11 24H2+
+typedef struct _PROCESS_HEAP_DESCRIPTOR
+{
+	PVOID Next;
+	PVOID Prev;
+	PHEAP Heap;
+} PROCESS_HEAP_DESCRIPTOR, *PPROCESS_HEAP_DESCRIPTOR;
+
+
 #define GDI_BATCH_BUFFER_SIZE 310
 
 typedef struct _GDI_TEB_BATCH

--- a/src/dbg/ntdll/ntdll.h
+++ b/src/dbg/ntdll/ntdll.h
@@ -3806,30 +3806,30 @@ typedef struct _PEB
 // Only for Windows 11 24H2+
 typedef struct _SEGMENT_HEAP
 {
-	UCHAR Reserved0[0x10];  // 0x0  ~ 0x10	Skip unused members
-	ULONG Signature;        // 0x10 ~ 0x14
-	UCHAR Padding0[0x04];   // 0x14 ~ 0x18
-	UCHAR Reserved1[0x20];  // 0x18 ~ 0x38	Skip unused members
-	PVOID UserContext;      // 0x38 ~ 0x40
+    UCHAR Reserved0[0x10];  // 0x0  ~ 0x10  Skip unused members
+    ULONG Signature;        // 0x10 ~ 0x14
+    UCHAR Padding0[0x04];   // 0x14 ~ 0x18
+    UCHAR Reserved1[0x20];  // 0x18 ~ 0x38  Skip unused members
+    PVOID UserContext;      // 0x38 ~ 0x40
 } SEGMENT_HEAP, *PSEGMENT_HEAP;
 
 // Only for Windows 11 24H2+
 typedef struct _HEAP
 {
-	UCHAR Reserved0[0x10];   // 0x0   ~ 0x10  Skip unused members
-	ULONG SegmentSignature;  // 0x10  ~ 0x14
-	UCHAR Padding0[0x04];    // 0x14  ~ 0x18
-	UCHAR Reserved1[0x170];  // 0x18  ~ 0x188 Skip unused members
-	PVOID UserContext;       // 0x188 ~ 0x190
-	UCHAR Reserved2[0x130];  // 0x190 ~ 0x2C0 Skip unused members
+    UCHAR Reserved0[0x10];   // 0x0   ~ 0x10  Skip unused members
+    ULONG SegmentSignature;  // 0x10  ~ 0x14
+    UCHAR Padding0[0x04];    // 0x14  ~ 0x18
+    UCHAR Reserved1[0x170];  // 0x18  ~ 0x188 Skip unused members
+    PVOID UserContext;       // 0x188 ~ 0x190
+    UCHAR Reserved2[0x130];  // 0x190 ~ 0x2C0 Skip unused members
 } HEAP, *PHEAP;
 
 // Only for Windows 11 24H2+
 typedef struct _PROCESS_HEAP_DESCRIPTOR
 {
-	PVOID Next;
-	PVOID Prev;
-	PHEAP Heap;
+    PVOID Next;
+    PVOID Prev;
+    PHEAP Heap;
 } PROCESS_HEAP_DESCRIPTOR, *PPROCESS_HEAP_DESCRIPTOR;
 
 

--- a/src/dbg/ntdll/ntdll.h
+++ b/src/dbg/ntdll/ntdll.h
@@ -3808,8 +3808,7 @@ typedef struct _SEGMENT_HEAP
 {
     UCHAR Reserved0[0x10];  // 0x0  ~ 0x10  Skip unused members
     ULONG Signature;        // 0x10 ~ 0x14
-    UCHAR Padding0[0x04];   // 0x14 ~ 0x18
-    UCHAR Reserved1[0x20];  // 0x18 ~ 0x38  Skip unused members
+    UCHAR Reserved1[0x24];  // 0x14 ~ 0x38  Skip unused members
     PVOID UserContext;      // 0x38 ~ 0x40
 } SEGMENT_HEAP, *PSEGMENT_HEAP;
 
@@ -3818,8 +3817,7 @@ typedef struct _HEAP
 {
     UCHAR Reserved0[0x10];   // 0x0   ~ 0x10  Skip unused members
     ULONG SegmentSignature;  // 0x10  ~ 0x14
-    UCHAR Padding0[0x04];    // 0x14  ~ 0x18
-    UCHAR Reserved1[0x170];  // 0x18  ~ 0x188 Skip unused members
+    UCHAR Reserved1[0x174];  // 0x14  ~ 0x188 Skip unused members
     PVOID UserContext;       // 0x188 ~ 0x190
     UCHAR Reserved2[0x130];  // 0x190 ~ 0x2C0 Skip unused members
 } HEAP, *PHEAP;


### PR DESCRIPTION
From Windows 11 24H2, no all heap information exists in the PEB (only the first heap is stored).
So we must enumerate the entire heap along the process heap descriptor.

You can see https://cafe.naver.com/megayuchi/683 for more details