### PR TITLE
Fix mislabeled comments/mnemonic brief columns

### DIFF
--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -165,8 +165,8 @@ private:
         ColAddress,
         ColBytes,
         ColDisassembly,
-        ColComment,
         ColMnemonicBrief,
+        ColComment,
     };
 
     DisassemblyPopup* mDisassemblyPopup = nullptr;


### PR DESCRIPTION
#3509 is because the order of ColComment and ColMnemonicBrief is not the same as the order they are added into the table.