### PR TITLE
Use library for command line parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(dbg_SOURCES
 	"src/dbg/analysis/xrefsanalysis.h"
 	"src/dbg/animate.cpp"
 	"src/dbg/animate.h"
+	"src/dbg/args.h"
 	"src/dbg/argument.cpp"
 	"src/dbg/argument.h"
 	"src/dbg/assemble.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ set(dbg_SOURCES
 	"src/dbg/jansson/jansson_x64dbg.h"
 	"src/dbg/jit.cpp"
 	"src/dbg/jit.h"
+	"src/dbg/jobqueue.h"
 	"src/dbg/label.cpp"
 	"src/dbg/label.h"
 	"src/dbg/loop.cpp"

--- a/docs/commands/script/index.rst
+++ b/docs/commands/script/index.rst
@@ -20,3 +20,5 @@ This section contains various commands that are only used or available in a scri
    scriptload
    scriptdll
    scriptcmd
+   scriptrun
+   scriptexec

--- a/docs/commands/script/scriptcmd.md
+++ b/docs/commands/script/scriptcmd.md
@@ -12,6 +12,10 @@ For example `scriptcmd add rax, 0x1245` will execute the command `add rax, 0x123
 
 This command does not set any result variables.
 
+## execution behavior
+
+This command blocks until the specified command completes execution. Script execution is handled by a single dedicated thread, ensuring commands execute in the order they are submitted without interference from other operations.
+
 ## example
 
 This command can be used in combination with [SetBreakpointCommand](../conditional-breakpoint-control/SetBreakpointCommand.md) to execute scripts on breakpoint callbacks:
@@ -21,7 +25,7 @@ fn_addr = module.dll:$0x1234 // module.dll RVA 0x1234
 bp fn_addr
 SetBreakpointCommand fn_addr, "scriptcmd call mycallback"
 
-// make sure the script is not unloaded
+// TODO: make sure the script is not unloaded (using run)
 
 mycallback:
 log "fn({arg.get(0)}, {arg.get(1)})"

--- a/docs/commands/script/scriptexec.md
+++ b/docs/commands/script/scriptexec.md
@@ -1,0 +1,28 @@
+# scriptexec
+
+Load and execute a script file in a single operation.
+
+## arguments
+
+`arg1` Script file path to load and execute.
+
+## result
+
+This command does not set any result variables.
+
+## execution behavior
+
+This command blocks until the script completes execution. It performs the following operations:
+1. Loads the specified script file
+2. Executes the script from the beginning
+3. Automatically unloads the script only if execution completes successfully
+
+Script execution is handled by a single dedicated thread, ensuring that only one script runs at a time.
+
+## notes
+
+- Cannot be used from within a running script
+- If script execution fails or is aborted, the script remains loaded
+- This is the most convenient way to run standalone scripts
+- Execution always starts from the beginning of the script
+- You can use the Script tab context menu to abort a running script if needed

--- a/docs/commands/script/scriptrun.md
+++ b/docs/commands/script/scriptrun.md
@@ -1,0 +1,26 @@
+# scriptrun
+
+Run the currently loaded script from the current position.
+
+## arguments
+
+`arg1` (optional) Line number to stop execution at. If not provided, the script runs until completion.
+
+## result
+
+This command does not set any result variables.
+
+## execution behavior
+
+This command blocks until the script completes execution, reaches the specified stop line, encounters an error, or is manually aborted. Script execution is handled by a single dedicated thread, ensuring that only one script runs at a time.
+
+## prerequisites
+
+A script must be loaded using [`scriptload`](scriptload.md) before using this command.
+
+## notes
+
+- Only one script can run at a time
+- Execution starts from the current script instruction pointer
+- The script instruction pointer is automatically managed during execution
+- Use [`scriptabort`](scriptabort.md) to stop a running script

--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -13,6 +13,7 @@
 
 static HINSTANCE hInst;
 static Utf8Ini settings;
+static wchar_t szWorkingDirectory[MAX_PATH] = L"";
 static wchar_t szUserDirectory[MAX_PATH] = L"";
 static wchar_t szIniFile[MAX_PATH] = L"";
 static CRITICAL_SECTION csIni;
@@ -78,6 +79,9 @@ static const wchar_t* InitializeUserDirectory(HINSTANCE hMainModule, const wchar
         return L"Error getting module directory!";
 
     *backslash = L'\0';
+
+    // Preserve the working directory for the debuggee
+    GetCurrentDirectoryW(_countof(szWorkingDirectory), szWorkingDirectory);
 
     // Set the current directory to the application directory
     SetCurrentDirectoryW(szUserDirectory);
@@ -472,6 +476,11 @@ BRIDGE_IMPEXP unsigned int BridgeGetNtBuildNumber()
         NtBuildNumber = NtBuildNumber7;
     }
     return NtBuildNumber;
+}
+
+BRIDGE_IMPEXP const wchar_t* BridgeWorkingDirectory()
+{
+    return szWorkingDirectory;
 }
 
 BRIDGE_IMPEXP const wchar_t* BridgeUserDirectory()

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -147,6 +147,12 @@ BRIDGE_IMPEXP bool BridgeIsProcessElevated();
 BRIDGE_IMPEXP unsigned int BridgeGetNtBuildNumber();
 
 /// <summary>
+/// Returns the original working directory when starting the debugger.
+/// The working directory is changed to the x64dbg directory after initialization.
+/// </summary>
+BRIDGE_IMPEXP const wchar_t* BridgeWorkingDirectory();
+
+/// <summary>
 /// Returns the user directory (without trailing backslash).
 /// </summary>
 BRIDGE_IMPEXP const wchar_t* BridgeUserDirectory();

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -92,7 +92,7 @@ extern "C" DLL_EXPORT bool _dbg_valfromstring(const char* string, duint* value)
 
 extern "C" DLL_EXPORT bool _dbg_isdebugging()
 {
-    return hDebugLoopThread && IsFileBeingDebugged();
+    return bIsDebugging;
 }
 
 extern "C" DLL_EXPORT bool _dbg_isjumpgoingtoexecute(duint addr)

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -924,67 +924,67 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
     {
     case DBG_SCRIPT_LOAD:
     {
-        scriptload((const char*)param1);
+        ScriptLoadAwait((const char*)param1);
     }
     break;
 
     case DBG_SCRIPT_UNLOAD:
     {
-        scriptunload();
+        ScriptUnloadAwait();
     }
     break;
 
     case DBG_SCRIPT_RUN:
     {
-        scriptrun((int)(duint)param1, param2 != nullptr);
+        ScriptRunAsync((int)(duint)param1, param2 != nullptr);
     }
     break;
 
     case DBG_SCRIPT_STEP:
     {
-        scriptstep();
+        ScriptStepAsync();
     }
     break;
 
     case DBG_SCRIPT_BPTOGGLE:
     {
-        return scriptbptoggle((int)(duint)param1);
+        return ScriptBpToggleLocked((int)(duint)param1);
     }
     break;
 
     case DBG_SCRIPT_BPGET:
     {
-        return scriptbpget((int)(duint)param1);
+        return ScriptBpGetLocked((int)(duint)param1);
     }
     break;
 
     case DBG_SCRIPT_CMDEXEC:
     {
-        return scriptcmdexec((const char*)param1);
+        return ScriptCmdExecAwait((const char*)param1);
     }
     break;
 
     case DBG_SCRIPT_ABORT:
     {
-        scriptabort();
+        ScriptAbortAwait();
     }
     break;
 
     case DBG_SCRIPT_GETLINETYPE:
     {
-        return (duint)scriptgetlinetype((int)(duint)param1);
+        return (duint)ScriptGetLineTypeLocked((int)(duint)param1);
     }
     break;
 
     case DBG_SCRIPT_SETIP:
     {
-        scriptsetip((int)(duint)param1);
+        ScriptSetIpAsync((int)(duint)param1);
     }
     break;
 
     case DBG_SCRIPT_GETBRANCHINFO:
     {
-        return (duint)scriptgetbranchinfo((int)(duint)param1, (SCRIPTBRANCH*)param2);
+        return (duint)ScriptGetBranchInfoLocked((int)(duint)param1, (SCRIPTBRANCH*)param2);
     }
     break;
 

--- a/src/dbg/_plugins.cpp
+++ b/src/dbg/_plugins.cpp
@@ -150,7 +150,7 @@ PLUG_IMPEXP void _plugin_startscript(CBPLUGINSCRIPT cbScript)
 
 PLUG_IMPEXP bool _plugin_waituntilpaused()
 {
-    while(DbgIsDebugging() && dbgisrunning()) //wait until the debugger paused
+    while(bIsDebugging && dbgisrunning()) //wait until the debugger paused
     {
         Sleep(1);
         GuiProcessEvents(); //workaround for scripts being executed on the GUI thread

--- a/src/dbg/args.h
+++ b/src/dbg/args.h
@@ -1,0 +1,337 @@
+/**
+ Based on https://github.com/LLVMParty/args
+*/
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <functional>
+#include <unordered_set>
+#include <stdexcept>
+
+class ArgumentParser
+{
+protected:
+    void addPositional(const std::string & name, std::string & value, const std::string & help, bool required = false)
+    {
+        auto fn = [this, &value]()
+        {
+            value = arg;
+        };
+        positionalArgs.push_back(Arg{name, help, required, fn});
+    }
+
+    void addString(const std::string & flagname, std::string & value, const std::string & help, bool required = false)
+    {
+        auto fn = [this, flagname, &value]
+        {
+            if(arg.substr(0, flagname.length()) == flagname)
+            {
+                if(arg.length() == flagname.length())
+                {
+                    // -flagname <value>
+                    if(i + 1 >= argc)
+                    {
+                        throw std::runtime_error("missing value for '" + flagname + "' argument");
+                    }
+                    value = argv[++i];
+                    if(value.empty())
+                    {
+                        throw std::runtime_error("empty value for '" + flagname + "' argument");
+                    }
+                    markExtracted(flagname);
+                }
+                else if(arg[flagname.length()] == '=')
+                {
+                    // -flagname=<value>
+                    value = arg.substr(flagname.length() + 1);
+                    markExtracted(flagname);
+                }
+            }
+        };
+        flagArgs.push_back(Arg{flagname, help, required, fn});
+    }
+
+    void addBool(const std::string & flagname, bool & value, const std::string & help, bool required = false)
+    {
+        auto fn = [this, flagname, &value]
+        {
+            if(arg.substr(0, flagname.length()) == flagname)
+            {
+                if(arg.length() == flagname.length())
+                {
+                    // -flagname
+                    value = true;
+                    markExtracted(flagname);
+                }
+                else if(arg[flagname.length()] == '=')
+                {
+                    // -flagname=<value>
+                    auto strValue = arg.substr(flagname.length() + 1);
+                    if(strValue.empty())
+                    {
+                        throw std::runtime_error("empty value for '" + flagname + "' argument");
+                    }
+                    value = strValue == "1" || strValue == "true";
+                    markExtracted(flagname);
+                }
+            }
+        };
+        flagArgs.push_back(Arg{flagname, help, required, fn});
+    }
+
+    void addExtra(std::vector<std::string> & args)
+    {
+        if(extra != nullptr)
+        {
+            throw std::runtime_error("cannot add extra arguments multiple times");
+        }
+        extra = &args;
+    }
+
+    explicit ArgumentParser(std::string description) : description(std::move(description))
+    {
+    }
+
+public:
+    virtual ~ArgumentParser()                        = default;
+    ArgumentParser(const ArgumentParser &)            = delete;
+    ArgumentParser & operator=(const ArgumentParser &) = delete;
+    ArgumentParser(ArgumentParser &&)                 = delete;
+    ArgumentParser & operator=(ArgumentParser &&)      = delete;
+
+    void parseOrExit(int argc, const char* const* argv, const char* helpflag = "-help")
+    {
+        bool help = false;
+        addBool(helpflag, help, "Show this message");
+
+        try
+        {
+            parse(argc, argv);
+        }
+        catch(const std::exception & e)
+        {
+            printf("Error: %s\n\nHelp:\n%s\n", e.what(), helpStr().c_str());
+            std::exit(help ? EXIT_SUCCESS : EXIT_FAILURE);
+        }
+        if(help)
+        {
+            puts(helpStr().c_str());
+            std::exit(EXIT_SUCCESS);
+        }
+    }
+
+    void parse(int argc, const char* const* argv)
+    {
+        this->argc        = argc;
+        this->argv        = argv;
+        bool seenRequired = false;
+        for(const auto & positionalArg : positionalArgs)
+        {
+            if(positionalArg.name.empty())
+            {
+                throw std::runtime_error("cannot add positional argument without name");
+            }
+            if(!positionalArg.required)
+            {
+                if(seenRequired)
+                {
+                    throw std::runtime_error("cannot add required positional argument after an optional one");
+                }
+            }
+            else
+            {
+                seenRequired = true;
+            }
+        }
+        for(const auto & flagArg : flagArgs)
+        {
+            if(flagArg.name.empty())
+            {
+                throw std::runtime_error("cannot add argument without name");
+            }
+            if(flagArg.name[0] != '-')
+            {
+                throw std::runtime_error("invalid argument name '" + flagArg.name + "'");
+            }
+        }
+        size_t positionalIndex = 0;
+        for(i = 1; i < argc; i++)
+        {
+            arg = std::string(argv[i]);
+            if(arg.empty())
+            {
+                continue;
+            }
+
+            if(arg == "--" && extra != nullptr)
+            {
+                for(int j = i + 1; j < argc; j++)
+                {
+                    extra->push_back(argv[j]);
+                }
+                break;
+            }
+
+            if(arg[0] == '-')
+            {
+                didExtract = false;
+                for(const auto & flag : flagArgs)
+                {
+                    flag.fn();
+                }
+                if(!didExtract)
+                {
+                    throw std::runtime_error("unknown argument '" + arg + "'");
+                }
+            }
+            else
+            {
+                if(positionalIndex + 1 > positionalArgs.size())
+                {
+                    throw std::runtime_error("unexpected positional argument '" + arg + "'");
+                }
+                const auto & positionalArg = positionalArgs[positionalIndex++];
+                if(positionalArg.name[0] == '-')
+                {
+                    markExtracted(positionalArg.name);
+                }
+                positionalArg.fn();
+            }
+        }
+        for(const auto & flagArg : flagArgs)
+        {
+            if(!flagArg.required)
+            {
+                continue;
+            }
+            if(flagsExtracted.count(flagArg.name) == 0)
+            {
+                throw std::runtime_error("required argument '" + flagArg.name + "' missing");
+            }
+        }
+        for(size_t i = positionalIndex; i < positionalArgs.size(); i++)
+        {
+            const auto & positionalArg = positionalArgs[i];
+            if(positionalArg.required)
+            {
+                if(flagsExtracted.count(positionalArg.name) > 0)
+                {
+                    continue;
+                }
+                throw std::runtime_error("required positional argument missing");
+            }
+        }
+    }
+
+    std::string helpStr() const
+    {
+        std::string help;
+        help += "  ";
+        help += argv[0];
+        help += " {OPTIONS}";
+
+        for(const auto & positionalArg : positionalArgs)
+        {
+            help += " ";
+            if(!positionalArg.required)
+            {
+                help += '[';
+            }
+            if(positionalArg.name[0] == '-')
+            {
+                help += "[" + positionalArg.name + "]";
+                help += " <value>";
+            }
+            else
+            {
+                help += positionalArg.name;
+            }
+            if(!positionalArg.required)
+            {
+                help += ']';
+            }
+        }
+        if(extra != nullptr)
+        {
+            help += " -- [extra arguments]";
+        }
+        help += '\n';
+
+        if(!description.empty())
+        {
+            help += "\n    ";
+            help += description;
+            help += "\n\n";
+        }
+
+        help += "  OPTIONS:\n";
+
+        size_t maxLen = 0;
+        for(const auto & flagArg : flagArgs)
+        {
+            if(flagArg.name.size() > maxLen)
+            {
+                maxLen = flagArg.name.size();
+            }
+        }
+        for(const auto & flagArg : flagArgs)
+        {
+            help += "\n    ";
+            help += flagArg.name;
+            for(size_t i = 0; i < maxLen - flagArg.name.size(); i++)
+            {
+                help += ' ';
+            }
+            help += "  ";
+            help += flagArg.help;
+            if(!flagArg.required)
+            {
+                help += " (optional)";
+            }
+        }
+
+        return help;
+    }
+
+private:
+    struct Arg
+    {
+        std::string           name;
+        std::string           help;
+        bool                  required = false;
+        std::function<void()> fn;
+
+        Arg() = default;
+        Arg(std::string name, std::string help, bool required, std::function<void()> fn)
+            : name(std::move(name))
+            , help(std::move(help))
+            , required(required)
+            , fn(std::move(fn))
+        {
+        }
+    };
+
+    std::string               description;
+    std::vector<Arg>          positionalArgs;
+    std::vector<Arg>          flagArgs;
+    std::vector<std::string>* extra = nullptr;
+
+    int                             i          = 1;
+    int                             argc       = 0;
+    const char* const*              argv       = nullptr;
+    bool                            didExtract = false;
+    std::string                     arg;
+    std::unordered_set<std::string> flagsExtracted;
+
+    void markExtracted(const std::string & flagname)
+    {
+        didExtract = true;
+        if(flagsExtracted.count(flagname) > 0)
+        {
+            throw std::runtime_error("duplicate value for '" + flagname + "' argument");
+        }
+        flagsExtracted.insert(flagname);
+    }
+};

--- a/src/dbg/command.cpp
+++ b/src/dbg/command.cpp
@@ -204,8 +204,6 @@ bool cmddel(const char* name)
     return true;
 }
 
-bool cbCommandProvider(char* cmd, int maxlen);
-
 void cmdsplit(const char* cmd, StringList & commands)
 {
     // Allow prefixing commands with $ to format them
@@ -254,7 +252,7 @@ void cmdsplit(const char* cmd, StringList & commands)
         commands.push_back(split);
 }
 
-bool cmdexeccallback(COMMAND* cmd, const std::string & command)
+static bool cmdexeccallback(COMMAND* cmd, const std::string & command)
 {
     Command commandParsed(command);
     int argcount = commandParsed.GetArgCount();
@@ -272,6 +270,9 @@ bool cmdexeccallback(COMMAND* cmd, const std::string & command)
     efree(argv, "cmdloop:argv");
     return res;
 }
+
+// Defined in x64dbg.cpp
+bool cbCommandProvider(char* cmd, int maxlen);
 
 /**
 \brief Initiates the command loop. This function will not return until a command returns ::STATUS_EXIT.

--- a/src/dbg/command.h
+++ b/src/dbg/command.h
@@ -30,6 +30,7 @@ bool cmdnew(const char* name, CBCOMMAND cbCommand, bool debugonly);
 COMMAND* cmdget(const char* cmd);
 CBCOMMAND cmdset(const char* name, CBCOMMAND cbCommand, bool debugonly);
 bool cmddel(const char* name);
+void cmdsplit(const char* cmd, StringList & commands);
 void cmdloop();
 bool cmddirectexec(const char* cmd);
 

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -222,6 +222,7 @@ bool cbDebugStop(int argc, char* argv[])
                     DbSave(DbLoadSaveType::All);
                     TerminateThread(hDebugLoopThreadCopy, 1); // TODO: this will lose state and cause possible corruption if a critical section is still owned
                     CloseHandle(hDebugLoopThreadCopy);
+                    bIsDebugging = false;
                     return false;
                 }
             }

--- a/src/dbg/commands/cmd-script.cpp
+++ b/src/dbg/commands/cmd-script.cpp
@@ -5,12 +5,14 @@
 #include "stackinfo.h"
 #include "debugger.h"
 #include "simplescript.h"
+#include "value.h"
+#include "command.h"
 
 bool cbScriptLoad(int argc, char* argv[])
 {
     if(argc < 2)
         return false;
-    scriptload(argv[1]);
+    ScriptLoadAwait(argv[1]);
     return true;
 }
 
@@ -39,7 +41,22 @@ bool cbScriptCmd(int argc, char* argv[])
         return false;
     while(isspace(*scriptcmd))
         scriptcmd++;
-    return scriptcmdexec(scriptcmd);
+    return ScriptCmdExecAwait(scriptcmd);
+}
+
+bool cbScriptRun(int argc, char* argv[])
+{
+    duint destline = 0;
+    if(argc > 2 && !valfromstring(argv[1], &destline, false))
+        return false;
+    return ScriptRunAwait((int)destline);
+}
+
+bool cbScriptExec(int argc, char* argv[])
+{
+    if(IsArgumentsLessThan(argc, 2))
+        return false;
+    return ScriptExecAwait(argv[1]);
 }
 
 static bool cbGenericLog(int argc, char* argv[], void(*logputs)(const char* msg))
@@ -68,7 +85,7 @@ bool cbInstrLog(int argc, char* argv[])
     return cbGenericLog(argc, argv, [](const char* msg)
     {
         dputs_untranslated(msg);
-        scriptlog(msg);
+        ScriptLogLocked(msg);
     });
 }
 

--- a/src/dbg/commands/cmd-script.h
+++ b/src/dbg/commands/cmd-script.h
@@ -6,6 +6,8 @@ bool cbScriptLoad(int argc, char* argv[]);
 bool cbScriptMsg(int argc, char* argv[]);
 bool cbScriptMsgyn(int argc, char* argv[]);
 bool cbScriptCmd(int argc, char* argv[]);
+bool cbScriptRun(int argc, char* argv[]);
+bool cbScriptExec(int argc, char* argv[]);
 bool cbInstrLog(int argc, char* argv[]);
 bool cbInstrHtmlLog(int argc, char* argv[]);
 bool cbInstrPrintStack(int argc, char* argv[]);

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1715,22 +1715,12 @@ static DWORD WINAPI cbInitializationScriptThread(void*)
     Memory<char*> script(MAX_SETTING_SIZE + 1);
     if(BridgeSettingGet("Engine", "InitializeScript", script())) // Global script file
     {
-        if(scriptLoadSync(script()))
-        {
-            if(scriptRunSync(0, true))
-                scriptunload();
-        }
-        else
+        if(!ScriptExecAwait(script()))
             dputs(QT_TRANSLATE_NOOP("DBG", "Error: Cannot load global initialization script."));
     }
     if(szDebuggeeInitializationScript[0] != 0)
     {
-        if(scriptLoadSync(szDebuggeeInitializationScript))
-        {
-            if(scriptRunSync(0, true))
-                scriptunload();
-        }
-        else
+        if(!ScriptExecAwait(szDebuggeeInitializationScript))
             dputs(QT_TRANSLATE_NOOP("DBG", "Error: Cannot load debuggee initialization script."));
     }
     return 0;

--- a/src/dbg/debugger.h
+++ b/src/dbg/debugger.h
@@ -163,5 +163,6 @@ extern HANDLE mProcHandle;
 extern HANDLE mForegroundHandle;
 extern duint gRtrPreviousCSP;
 extern HANDLE hDebugLoopThread;
+extern std::atomic_bool bIsDebugging;
 
 #endif // _DEBUGGER_H

--- a/src/dbg/jobqueue.h
+++ b/src/dbg/jobqueue.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "bridgemain.h"
+#include "concurrentqueue/blockingconcurrentqueue.h"
+#include <functional>
+
+class JobQueue
+{
+    moodycamel::BlockingConcurrentQueue<std::function<bool()>> mQueue;
+    std::thread mThread;
+
+public:
+    JobQueue()
+    {
+        start();
+    }
+
+    ~JobQueue()
+    {
+        stop();
+    }
+
+    JobQueue(const JobQueue &) = delete;
+    JobQueue & operator=(const JobQueue &) = delete;
+    JobQueue(JobQueue &&) = delete;
+    JobQueue & operator=(JobQueue &&) = delete;
+
+    void start()
+    {
+        if(mThread.joinable())
+        {
+            return;
+        }
+
+        mThread = std::thread([this]()
+        {
+            while(true)
+            {
+                std::function<bool()> job;
+                mQueue.wait_dequeue(job);
+                if(!job())
+                {
+                    break;
+                }
+            }
+        });
+    }
+
+    void stop()
+    {
+        if(!mThread.joinable())
+        {
+            return;
+        }
+
+        mQueue.enqueue([]()
+        {
+            return false;
+        });
+        mThread.join();
+    }
+
+    bool async(std::function<void()> job)
+    {
+        return mQueue.enqueue([job = std::move(job)]()
+        {
+            job();
+            return true;
+        });
+    }
+
+    // Non-void return
+    template < typename F,
+               typename R = decltype(std::declval<F>()()),
+               typename std::enable_if < !std::is_void<R>::value, int >::type = 0 >
+    R await(F && job)
+    {
+        R result = {};
+        impl_await([job = std::move(job), &result]()
+        {
+            result = job();
+        });
+        return result;
+    }
+
+    // Void return
+    template <typename F,
+              typename R = decltype(std::declval<F>()()),
+              typename std::enable_if<std::is_void<R>::value, int>::type = 0>
+    void await(F && job)
+    {
+        impl_await(std::forward<F>(job));
+    }
+
+private:
+    template<class Func>
+    void impl_await(Func && job)
+    {
+        auto event = CreateEventW(nullptr, false, false, nullptr);
+        auto func = [job = std::move(job), event]()
+        {
+            job();
+            SetEvent(event);
+            return true;
+        };
+        if(!mQueue.enqueue(std::move(func)))
+        {
+            CloseHandle(event);
+            return;
+        }
+        while(WaitForSingleObject(event, 100) == WAIT_TIMEOUT)
+        {
+            //workaround for scripts being executed on the GUI thread
+            GuiProcessEvents();
+        }
+        CloseHandle(event);
+        return;
+    }
+};

--- a/src/dbg/msgqueue.cpp
+++ b/src/dbg/msgqueue.cpp
@@ -1,13 +1,13 @@
 #include "msgqueue.h"
 
 // Allocate a message stack
-MESSAGE_STACK* MsgAllocStack()
+MESSAGE_QUEUE* MsgAllocQueue()
 {
-    return new MESSAGE_STACK();
+    return new MESSAGE_QUEUE();
 }
 
 // Free a message stack
-void MsgFreeStack(MESSAGE_STACK* Stack)
+void MsgFreeQueue(MESSAGE_QUEUE* Stack)
 {
     ASSERT_NONNULL(Stack);
 
@@ -26,7 +26,7 @@ void MsgFreeStack(MESSAGE_STACK* Stack)
 }
 
 // Add a message to the stack
-bool MsgSend(MESSAGE_STACK* Stack, int Msg, duint Param1, duint Param2)
+bool MsgSend(MESSAGE_QUEUE* Stack, int Msg, duint Param1, duint Param2)
 {
     if(Stack->Destroy)
         return false;
@@ -42,7 +42,7 @@ bool MsgSend(MESSAGE_STACK* Stack, int Msg, duint Param1, duint Param2)
 }
 
 // Get a message from the stack (will return false when there are no messages)
-bool MsgGet(MESSAGE_STACK* Stack, MESSAGE* Msg)
+bool MsgGet(MESSAGE_QUEUE* Stack, MESSAGE* Msg)
 {
     if(Stack->Destroy)
         return false;
@@ -52,7 +52,7 @@ bool MsgGet(MESSAGE_STACK* Stack, MESSAGE* Msg)
 }
 
 // Wait for a message on the specified stack
-void MsgWait(MESSAGE_STACK* Stack, MESSAGE* Msg)
+void MsgWait(MESSAGE_QUEUE* Stack, MESSAGE* Msg)
 {
     if(Stack->Destroy)
         return;

--- a/src/dbg/msgqueue.h
+++ b/src/dbg/msgqueue.h
@@ -15,7 +15,7 @@ struct MESSAGE
 };
 
 // Message stack structure
-class MESSAGE_STACK
+class MESSAGE_QUEUE
 {
 public:
     moodycamel::BlockingConcurrentQueue<MESSAGE> msgs;
@@ -25,10 +25,10 @@ public:
 };
 
 // Function definitions
-MESSAGE_STACK* MsgAllocStack();
-void MsgFreeStack(MESSAGE_STACK* Stack);
-bool MsgSend(MESSAGE_STACK* Stack, int Msg, duint Param1, duint Param2);
-bool MsgGet(MESSAGE_STACK* Stack, MESSAGE* Msg);
-void MsgWait(MESSAGE_STACK* Stack, MESSAGE* Msg);
+MESSAGE_QUEUE* MsgAllocQueue();
+void MsgFreeQueue(MESSAGE_QUEUE* Stack);
+bool MsgSend(MESSAGE_QUEUE* Stack, int Msg, duint Param1, duint Param2);
+bool MsgGet(MESSAGE_QUEUE* Stack, MESSAGE* Msg);
+void MsgWait(MESSAGE_QUEUE* Stack, MESSAGE* Msg);
 
 #endif // _MSGQUEUE_H

--- a/src/dbg/plugin_loader.cpp
+++ b/src/dbg/plugin_loader.cpp
@@ -296,7 +296,7 @@ bool pluginload(const char* pluginName, bool loadall)
 
     // Add plugin menus
     {
-        SectionLocker<LockPluginMenuList, false, false> menuLock; //exclusive lock
+        ExclusiveSectionLocker<LockPluginMenuList> menuLock;
 
         auto addPluginMenu = [](GUIMENUTYPE type)
         {
@@ -328,7 +328,7 @@ bool pluginload(const char* pluginName, bool loadall)
 
     // Add the plugin to the list
     {
-        SectionLocker<LockPluginList, false> pluginLock; //exclusive lock
+        ExclusiveSectionLocker<LockPluginList> pluginLock;
         gPluginList.push_back(gLoadingPlugin);
     }
 
@@ -934,7 +934,7 @@ void pluginmenucall(int hEntry)
     if(hEntry == -1)
         return;
 
-    SectionLocker<LockPluginMenuList, true, false> menuLock; //shared lock
+    SharedSectionLocker<LockPluginMenuList> menuLock;
     auto i = gPluginMenuEntryList.begin();
     while(i != gPluginMenuEntryList.end())
     {
@@ -944,7 +944,7 @@ void pluginmenucall(int hEntry)
         {
             PLUG_CB_MENUENTRY menuEntryInfo;
             menuEntryInfo.hEntry = currentMenu.hEntryPlugin;
-            SectionLocker<LockPluginCallbackList, true> callbackLock; //shared lock
+            SharedSectionLocker<LockPluginCallbackList, true> callbackLock;
             const auto & cbList = gPluginCallbackList[CB_MENUENTRY];
             for(auto j = cbList.begin(); j != cbList.end();)
             {

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -460,7 +460,7 @@ static CMDRESULT scriptInternalCmdExec(const char* cmd, bool silentRet)
     }
     if(scriptIsInternalCommand(cmd, "invalid")) //invalid command for testing
         return STATUS_ERROR;
-    if(bScriptRunning && scriptIsInternalCommand(cmd, "scriptrun"))  // do not allow recursive script runs
+    if(bScriptRunning && (scriptIsInternalCommand(cmd, "scriptrun") || scriptIsInternalCommand(cmd, "scriptexec")))  // do not allow recursive script runs
         return STATUS_ERROR;
     if(scriptIsInternalCommand(cmd, "pause")) //pause the script
         return STATUS_PAUSE;

--- a/src/dbg/simplescript.h
+++ b/src/dbg/simplescript.h
@@ -1,46 +1,18 @@
-#ifndef _SIMPLESCRIPT_H
-#define _SIMPLESCRIPT_H
+#pragma once
 
-#include "command.h"
+#include "_global.h"
 
-//structures
-struct SCRIPTBP
-{
-    int line;
-    bool silent; //do not show in GUI
-};
-
-struct LINEMAPENTRY
-{
-    SCRIPTLINETYPE type;
-    char raw[256];
-    union
-    {
-        char command[256];
-        SCRIPTBRANCH branch;
-        char label[256];
-        char comment[256];
-    } u;
-};
-
-//functions
-void scriptload(const char* filename);
-void scriptunload();
-void scriptrun(int destline, bool silentRet = false);
-void scriptstep();
-bool scriptbptoggle(int line);
-bool scriptbpget(int line);
-bool scriptcmdexec(const char* command);
-void scriptabort();
-SCRIPTLINETYPE scriptgetlinetype(int line);
-void scriptsetip(int line);
-void scriptreset();
-bool scriptgetbranchinfo(int line, SCRIPTBRANCH* info);
-void scriptlog(const char* msg);
-bool scriptLoadSync(const char* filename);
-bool scriptRunSync(int destline, bool silentRet = false);
-
-//script commands
-
-
-#endif // _SIMPLESCRIPT_H
+bool ScriptLoadAwait(const char* filename);
+void ScriptUnloadAwait();
+void ScriptRunAsync(int destline, bool silentRet = false);
+bool ScriptRunAwait(int destline, bool silentRet = false);
+void ScriptStepAsync();
+bool ScriptBpGetLocked(int line);
+bool ScriptBpToggleLocked(int line);
+bool ScriptCmdExecAwait(const char* command);
+void ScriptSetIpAsync(int line);
+void ScriptAbortAwait();
+SCRIPTLINETYPE ScriptGetLineTypeLocked(int line);
+bool ScriptGetBranchInfoLocked(int line, SCRIPTBRANCH* info);
+void ScriptLogLocked(const char* msg);
+bool ScriptExecAwait(const char* filename);

--- a/src/dbg/threading.h
+++ b/src/dbg/threading.h
@@ -75,6 +75,8 @@ enum SectionLock
     LockFormatFunctions,
     LockDllBreakpoints,
     LockHandleCache,
+    LockScriptLineMap,
+    LockScriptBreakpoints,
 
     // Number of elements in this enumeration. Must always be the last index.
     LockLast

--- a/src/dbg/threading.h
+++ b/src/dbg/threading.h
@@ -255,6 +255,12 @@ private:
     using Internal = SectionLockerGlobal;
 };
 
+template <SectionLock LockIndex, bool ProcessGuiEvents = false>
+using SharedSectionLocker = SectionLocker<LockIndex, true, ProcessGuiEvents>;
+
+template <SectionLock LockIndex, bool ProcessGuiEvents = false>
+using ExclusiveSectionLocker = SectionLocker<LockIndex, false, ProcessGuiEvents>;
+
 struct TLSData
 {
     String moduleHashLower;

--- a/src/dbg/variable.cpp
+++ b/src/dbg/variable.cpp
@@ -186,7 +186,7 @@ bool varget(const char* Name, VAR_VALUE* Value, int* Size, VAR_TYPE* Type)
     auto found = variables.find(name_);
     if(found == variables.end()) //not found
         return false;
-    if(found->second.alias.length())
+    if(!found->second.alias.empty())
         return varget(found->second.alias.c_str(), Value, Size, Type);
     if(Type)
         *Type = found->second.type;

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "_global.h"
+#include "args.h"
 #include "command.h"
 #include "variable.h"
 #include "debugger.h"
@@ -28,6 +29,8 @@
 #include "stringformat.h"
 #include "dbghelp_safe.h"
 #include <shellapi.h>
+#include <shlwapi.h>
+#include <fstream>
 
 static MESSAGE_STACK* gMsgStack = 0;
 static HANDLE hCommandLoopThread = 0;
@@ -681,11 +684,150 @@ static DWORD WINAPI loadDbThread(LPVOID hEvent)
     return 0;
 }
 
-static WString escape(WString cmdline)
+static String escape(String cmdline)
 {
-    StringUtils::ReplaceAll(cmdline, L"\\", L"\\\\");
-    StringUtils::ReplaceAll(cmdline, L"\"", L"\\\"");
+    StringUtils::ReplaceAll(cmdline, "\\", "\\\\");
+    StringUtils::ReplaceAll(cmdline, "\"", "\\\"");
     return cmdline;
+}
+
+class CommandlineArguments : public ArgumentParser
+{
+public:
+    String filename;
+    std::vector<std::string> extraCmdline;
+    String currentDir;
+    String pid;
+    String tid;
+    String event;
+    String command;
+    String commandFile;
+    bool help = false;
+
+    CommandlineArguments() : ArgumentParser("x64dbg")
+    {
+        addPositional("filename", filename, "Filename of program to debug");
+        addExtra(extraCmdline);
+
+        addString("-workingDir", currentDir, "Current working directory of new process. Defaults to current working directory if not specified.");
+        addString("-p", pid, "Process ID to attach to.");
+        addString("-a", pid, "Alias for -p.");
+        addString("-tid", tid, "Thread Identifier (TID) of the thread to resume after attaching.");
+        addString("-e", event, "Handle to an Event Object to signal on attach");
+
+        // TODO: Allow repeating multiple -c arguments
+        addString("-c", command, "Specifies the initial debugger command to run at start-up.");
+        addString("-cf", commandFile, "Specifies the path and name of a script file. This script file is executed as soon as the debugger is started.");
+
+        addBool("-help", help, "Show this message");
+    }
+};
+
+const char* parseArguments()
+{
+    int argc = 0;
+    auto argvW = std::unique_ptr<wchar_t* [], decltype(&::LocalFree)>(CommandLineToArgvW(GetCommandLineW(), &argc), ::LocalFree);
+    //MessageBoxW(0, GetCommandLineW(), StringUtils::sprintf(L"%d", argc).c_str(), MB_SYSTEMMODAL);
+    auto argvS = std::make_unique<String[]>(argc);
+    auto argvA = std::make_unique<const char* []>(argc);
+    for(int i = 0; i < argc; ++i)
+    {
+        argvS[i] = StringUtils::Utf16ToUtf8(argvW[i]);
+        argvA[i] = argvS[i].c_str();
+    }
+
+    CommandlineArguments args;
+    try
+    {
+        args.parse(argc, argvA.get());
+    }
+    catch(const std::exception & e)
+    {
+        return _strdup(StringUtils::sprintf("Error: %s\n\nHelp:\n%s\n", e.what(), args.helpStr().c_str()).c_str());
+    }
+    if(args.help)
+    {
+        return _strdup(args.helpStr().c_str());
+    }
+    // Default to current working directory if not specified otherwise
+    auto currentDir = args.currentDir;
+    if(currentDir.empty())
+    {
+        currentDir = StringUtils::Utf16ToUtf8(BridgeWorkingDirectory());
+    }
+    if(!args.filename.empty())
+    {
+        if(!args.extraCmdline.empty())
+        {
+            std::string cmdline;
+            for(const auto & arg : args.extraCmdline)
+            {
+                cmdline += StringUtils::sprintf("\"%s\" ", escape(arg).c_str());
+            }
+            if(!currentDir.empty())
+            {
+                //3 arguments (init filename, cmdline, currentdir)
+                DbgCmdExec(StringUtils::sprintf("init \"%s\", \"%s\", \"%s\"", escape(args.filename).c_str(), escape(cmdline).c_str(), escape(currentDir).c_str()).c_str());
+            }
+            else
+            {
+                //2 arguments (init filename, cmdline)
+                DbgCmdExec(StringUtils::sprintf("init \"%s\", \"%s\"", escape(args.filename).c_str(), escape(cmdline).c_str()).c_str());
+            }
+        }
+        else
+        {
+            //1 argument (init filename)
+            DbgCmdExec(StringUtils::sprintf("init \"%s\"", escape(args.filename).c_str()).c_str());
+        }
+    }
+    else if(!args.pid.empty())
+    {
+        if(!args.event.empty())
+        {
+            //4 arguments (JIT)
+            DbgCmdExec(StringUtils::sprintf("attach .%s, .%s", args.pid, args.event).c_str()); //attach pid, event
+        }
+        else if(!args.tid.empty())
+        {
+            //4 arguments (PLMDebug)
+            DbgCmdExec(StringUtils::sprintf("attach .%s, 0, .%s", args.pid, args.tid).c_str()); //attach pid, 0, tid
+        }
+        else
+        {
+            //2 arguments (-p PID)
+            DbgCmdExec(StringUtils::sprintf("attach .%s", args.pid).c_str()); //attach pid
+        }
+    }
+
+    if(!args.command.empty())
+    {
+        DbgCmdExec(("scriptcmd " + args.command).c_str());
+    }
+
+    if(!args.commandFile.empty())
+    {
+        WString commandFilePath = StringUtils::Utf8ToUtf16(args.commandFile);
+        if(PathIsRelativeW(commandFilePath.c_str()))
+        {
+            wchar_t commandPath[MAX_PATH] = L"";
+            PathCombineW(commandPath, StringUtils::Utf8ToUtf16(currentDir).c_str(), commandFilePath.c_str());
+            commandFilePath = commandPath;
+        }
+        String commandFile = StringUtils::Utf16ToUtf8(commandFilePath);
+        std::ifstream commandFileStream(commandFile);
+        if(!commandFileStream.is_open())
+        {
+            return _strdup(StringUtils::sprintf("Error: Command file \"%s\" couldn't be opened.\n", commandFile.c_str()).c_str());
+        }
+        if(dbggetdebuggeeinitscript()[0] != 0)
+        {
+            return _strdup(StringUtils::sprintf("Error: Command file \"%s\" cannot be set. There is a debuggee init script configured already to \"%s\".\n", commandFile.c_str(), dbggetdebuggeeinitscript()).c_str());
+        }
+        dbgsetdebuggeeinitscript(commandFile.c_str());
+    }
+
+    return nullptr;
 }
 
 extern "C" DLL_EXPORT const char* _dbg_dbginit()
@@ -808,24 +950,7 @@ extern "C" DLL_EXPORT const char* _dbg_dbginit()
     dputs(QT_TRANSLATE_NOOP("DBG", "Handling command line..."));
     dprintf("  %s\n", StringUtils::Utf16ToUtf8(GetCommandLineW()).c_str());
     //handle command line
-    int argc = 0;
-    wchar_t** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    //MessageBoxW(0, GetCommandLineW(), StringUtils::sprintf(L"%d", argc).c_str(), MB_SYSTEMMODAL);
-    if(argc == 2) //1 argument (init filename)
-        DbgCmdExec(StringUtils::Utf16ToUtf8(StringUtils::sprintf(L"init \"%s\"", escape(argv[1]).c_str())).c_str());
-    else if(argc == 3 && !_wcsicmp(argv[1], L"-p")) //2 arguments (-p PID)
-        DbgCmdExec(StringUtils::Utf16ToUtf8(StringUtils::sprintf(L"attach .%s", argv[2])).c_str()); //attach pid
-    else if(argc == 3) //2 arguments (init filename, cmdline)
-        DbgCmdExec(StringUtils::Utf16ToUtf8(StringUtils::sprintf(L"init \"%s\", \"%s\"", escape(argv[1]).c_str(), escape(argv[2]).c_str())).c_str());
-    else if(argc == 4) //3 arguments (init filename, cmdline, currentdir)
-        DbgCmdExec(StringUtils::Utf16ToUtf8(StringUtils::sprintf(L"init \"%s\", \"%s\", \"%s\"", escape(argv[1]).c_str(), escape(argv[2]).c_str(), escape(argv[3]).c_str())).c_str());
-    else if(argc == 5 && (!_wcsicmp(argv[1], L"-a") || !_wcsicmp(argv[1], L"-p")) && !_wcsicmp(argv[3], L"-e")) //4 arguments (JIT)
-        DbgCmdExec(StringUtils::Utf16ToUtf8(StringUtils::sprintf(L"attach .%s, .%s", argv[2], argv[4])).c_str()); //attach pid, event
-    else if(argc == 5 && !_wcsicmp(argv[1], L"-p") && !_wcsicmp(argv[3], L"-tid")) //4 arguments (PLMDebug)
-        DbgCmdExec(StringUtils::Utf16ToUtf8(StringUtils::sprintf(L"attach .%s, 0, .%s", argv[2], argv[4])).c_str()); //attach pid, 0, tid
-    LocalFree(argv);
-
-    return nullptr;
+    return parseArguments();
 }
 
 /**

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -696,7 +696,7 @@ class CommandlineArguments : public ArgumentParser
 public:
     String filename;
     std::vector<std::string> extraCmdline;
-    String currentDir;
+    String workingDir;
     String pid;
     String tid;
     String event;
@@ -709,7 +709,7 @@ public:
         addPositional("filename", filename, "Filename of program to debug");
         addExtra(extraCmdline);
 
-        addString("-workingDir", currentDir, "Current working directory of new process. Defaults to current working directory if not specified.");
+        addString("-workingDir", workingDir, "Current working directory of new process. Defaults to current working directory if not specified.");
         addString("-p", pid, "Process ID to attach to.");
         addString("-a", pid, "Alias for -p.");
         addString("-tid", tid, "Thread Identifier (TID) of the thread to resume after attaching.");
@@ -750,10 +750,10 @@ const char* parseArguments()
         return _strdup(args.helpStr().c_str());
     }
     // Default to current working directory if not specified otherwise
-    auto currentDir = args.currentDir;
-    if(currentDir.empty())
+    auto workingDir = args.workingDir;
+    if(workingDir.empty())
     {
-        currentDir = StringUtils::Utf16ToUtf8(BridgeWorkingDirectory());
+        workingDir = StringUtils::Utf16ToUtf8(BridgeWorkingDirectory());
     }
     if(!args.filename.empty())
     {
@@ -764,10 +764,10 @@ const char* parseArguments()
             {
                 cmdline += StringUtils::sprintf("\"%s\" ", escape(arg).c_str());
             }
-            if(!currentDir.empty())
+            if(!workingDir.empty())
             {
                 //3 arguments (init filename, cmdline, currentdir)
-                DbgCmdExec(StringUtils::sprintf("init \"%s\", \"%s\", \"%s\"", escape(args.filename).c_str(), escape(cmdline).c_str(), escape(currentDir).c_str()).c_str());
+                DbgCmdExec(StringUtils::sprintf("init \"%s\", \"%s\", \"%s\"", escape(args.filename).c_str(), escape(cmdline).c_str(), escape(workingDir).c_str()).c_str());
             }
             else
             {
@@ -811,7 +811,7 @@ const char* parseArguments()
         if(PathIsRelativeW(commandFilePath.c_str()))
         {
             wchar_t commandPath[MAX_PATH] = L"";
-            PathCombineW(commandPath, StringUtils::Utf8ToUtf16(currentDir).c_str(), commandFilePath.c_str());
+            PathCombineW(commandPath, StringUtils::Utf8ToUtf16(workingDir).c_str(), commandFilePath.c_str());
             commandFilePath = commandPath;
         }
         String commandFile = StringUtils::Utf16ToUtf8(commandFilePath);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -431,9 +431,9 @@ static void registercommands()
     dbgcmdnew("log", cbInstrLog, false); //log command with superawesome hax
     dbgcmdnew("htmllog", cbInstrHtmlLog, false); //command for testing
     dbgcmdnew("scriptdll,dllscript", cbScriptDll, false); //execute a script DLL
-    dbgcmdnew("scriptcmd", cbScriptCmd, false); // execute a script command TODO: undocumented
-    dbgcmdnew("scriptrun", cbScriptRun, false); // run the currently-loaded script TODO: undocumented
-    dbgcmdnew("scriptexec", cbScriptExec, false); // run a script file TODO: undocumented
+    dbgcmdnew("scriptcmd", cbScriptCmd, false); // execute a script command
+    dbgcmdnew("scriptrun", cbScriptRun, false); // run the currently-loaded script
+    dbgcmdnew("scriptexec", cbScriptExec, false); // run a script file
 
     //gui
     dbgcmdnew("showthreadid", cbShowThreadId, false); // show given thread in threads

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -432,6 +432,8 @@ static void registercommands()
     dbgcmdnew("htmllog", cbInstrHtmlLog, false); //command for testing
     dbgcmdnew("scriptdll,dllscript", cbScriptDll, false); //execute a script DLL
     dbgcmdnew("scriptcmd", cbScriptCmd, false); // execute a script command TODO: undocumented
+    dbgcmdnew("scriptrun", cbScriptRun, false); // run the currently-loaded script TODO: undocumented
+    dbgcmdnew("scriptexec", cbScriptExec, false); // run a script file TODO: undocumented
 
     //gui
     dbgcmdnew("showthreadid", cbShowThreadId, false); // show given thread in threads
@@ -965,7 +967,7 @@ extern "C" DLL_EXPORT void _dbg_dbgexitsignal()
     dputs(QT_TRANSLATE_NOOP("DBG", "Stopping running debuggee..."));
     cbDebugStop(0, 0); //after this, debugging stopped
     dputs(QT_TRANSLATE_NOOP("DBG", "Aborting scripts..."));
-    scriptabort();
+    ScriptAbortAwait();
     dputs(QT_TRANSLATE_NOOP("DBG", "Unloading plugins..."));
     pluginunloadall();
     dputs(QT_TRANSLATE_NOOP("DBG", "Cleaning up allocated data..."));

--- a/src/exe/signaturecheck.cpp
+++ b/src/exe/signaturecheck.cpp
@@ -496,6 +496,7 @@ bool InitializeSignatureCheck()
         return false;
 #endif // DEBUG_SIGNATURE_CHECKS
 
+#ifndef _DEBUG
     // Safely load the MSVC runtime DLLs (since they cannot be delay loaded)
     auto loadRuntimeDll = [&szSystemDir](const wchar_t* szDll) -> HMODULE
     {
@@ -522,6 +523,7 @@ bool InitializeSignatureCheck()
         MessageBoxW(nullptr, L"Failed to load msvcp140.dll!", L"Error", MB_ICONERROR | MB_SYSTEMMODAL);
         ExitProcess(ERROR_MOD_NOT_FOUND);
     }
+#endif // _DEBUG
 
     return true;
 }

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -997,7 +997,8 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
     break;
 
     case GUI_PROCESS_EVENTS:
-        QCoreApplication::processEvents();
+        if(GetCurrentThreadId() == mMainThreadId)
+            QCoreApplication::processEvents();
         break;
 
     case GUI_TYPE_ADDNODE:

--- a/src/test/cmdline/CMakeLists.txt
+++ b/src/test/cmdline/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.15)
+project(cmdline)
+if(MSVC)
+    add_link_options(/DEBUG:FULL /INCREMENTAL:NO /OPT:REF /OPT:ICF)
+endif()
+add_executable(cmdline test_cmdline.cpp)

--- a/src/test/cmdline/test_cmdline.cpp
+++ b/src/test/cmdline/test_cmdline.cpp
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <Windows.h>
+
+static void printArgs(const wchar_t* prefix, int argc, wchar_t** argv)
+{
+    wprintf(L"[%s] argc: %d\n", prefix, argc);
+    for(int i = 0; i < argc; i++)
+        wprintf(L"[%s] argv[%d]: '%s'\n", prefix, i, argv[i]);
+    puts("");
+}
+
+int wmain(int argc, wchar_t** argv, wchar_t** envp)
+{
+    printArgs(L"CRT", argc, argv);
+
+    auto winArgc = 0;
+    auto winArgv = CommandLineToArgvW(GetCommandLineW(), &winArgc);
+    printArgs(L"WIN", winArgc, winArgv);
+    LocalFree(winArgv);
+
+    puts("Press enter to exit...");
+    getchar();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This allows to add additional command line flags more easily. ~~It probably requires https://github.com/LLVMParty/args/pull/3 unless I messed up the compilation setup.~~
https://github.com/LLVMParty/args is copied into the tree. You can pass additional arguments to the target program after `--` on the command line.

Add `-c` flag to run a command right away on startup and `-cf` to run multiple commands read from a file on startup.

Closes #3428