### PR TITLE
Add mem.cmp Expression Function for Memory Comparison

### DIFF
--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -92,7 +92,7 @@ void ExpressionFunctions::Init()
     RegisterEasy("mem.iscode", memiscode);
     RegisterEasy("mem.isstring", memisstring);
     RegisterEasy("mem.decodepointer", memdecodepointer);
-    ExpressionFunctions::Register("mem.cmp", ValueTypeNumber, {ValueTypeNumber, ValueTypeString}, memcmpextfn);
+    ExpressionFunctions::Register("mem.match", ValueTypeNumber, {ValueTypeNumber, ValueTypeString}, memmatch);
 
     //Disassembly
     RegisterEasy("dis.len,dis.size", dislen);

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -92,6 +92,7 @@ void ExpressionFunctions::Init()
     RegisterEasy("mem.iscode", memiscode);
     RegisterEasy("mem.isstring", memisstring);
     RegisterEasy("mem.decodepointer", memdecodepointer);
+    ExpressionFunctions::Register("mem.cmp", ValueTypeNumber, {ValueTypeNumber, ValueTypeString}, memcmpextfn);
 
     //Disassembly
     RegisterEasy("dis.len,dis.size", dislen);

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -244,7 +244,12 @@ namespace Exprfunc
         if(!patterntransform(argv[1].string.ptr, pattern))
             return false;
 
-        *result = ValueNumber(patternfind((unsigned char*)argv[0].number, pattern.size(), pattern) == 0);
+        std::vector<unsigned char> data(pattern.size());
+        if(!MemRead(argv[0].number, data.data(), data.size()))
+            return false;
+
+        *result = ValueNumber(patternfind(data.data(), pattern.size(), pattern) == 0);
+
 
         return true;
     }

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -241,36 +241,8 @@ namespace Exprfunc
         assert(argv[1].type == ValueTypeString);
 
         std::vector<PatternByte> pattern;
-        PatternByte pb{};
-        size_t ni = 0;
-
-        for(size_t i = 0; i < ::strlen(argv[1].string.ptr); i++)
-        {
-            unsigned char v = argv[1].string.ptr[i];
-            if(iswspace(v)) continue;
-
-            if(v >= 'A' && v <= 'F') v = (v - 'A') + 0xA;
-            else if(v >= 'a' && v <= 'f') v = (v - 'a') + 0xA;
-            else if(v >= '0' && v <= '9') v = (v - '0');
-            else if(v == '?');
-            else return false;
-
-            if(v == '?')
-                pb.nibble[ni % 2].wildcard = true;
-            else
-                pb.nibble[ni % 2].data = v;
-
-            if(ni % 2)
-            {
-                pattern.push_back(pb);
-                pb = {};
-            }
-
-            ni++;
-        }
-
-        // fail on invald odd input length (excluding whitespaces)
-        if(ni % 2) return false;
+        if(!patterntransform(argv[1].string.ptr, pattern))
+            return false;
 
         *result = ValueNumber(patternfind((unsigned char*)argv[0].number, pattern.size(), pattern) == 0);
 

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -244,17 +244,18 @@ namespace Exprfunc
         size_t n_nibbles = 0;
         bool nibble = false;
 
-        for (size_t i = 0; i < ::strlen(argv[1].string.ptr); i++) {
+        for(size_t i = 0; i < ::strlen(argv[1].string.ptr); i++)
+        {
             unsigned char v = *(argv[1].string.ptr + i);
-            if (iswspace(v)) continue;
-            
-            if (v >= 'A' && v <= 'F') v = (v-'A') + 0xA;
-            else if (v >= 'a' && v <= 'f') v = (v-'a') + 0xA;
-            else if (v >= '0' && v <= '9') v = (v-'0');
+            if(iswspace(v)) continue;
+
+            if(v >= 'A' && v <= 'F') v = (v - 'A') + 0xA;
+            else if(v >= 'a' && v <= 'f') v = (v - 'a') + 0xA;
+            else if(v >= '0' && v <= '9') v = (v - '0');
             else return false;
 
-            if (nibble)
-                bytes[bytes.size()-1] |= v;
+            if(nibble)
+                bytes[bytes.size() - 1] |= v;
             else
                 bytes.push_back(v << 4);
 
@@ -263,9 +264,11 @@ namespace Exprfunc
 
         // edge case: the user entered an odd number of hex-digits
         // in this case, we need to shift each nibble to the right
-        if (nibble) {
+        if(nibble)
+        {
             unsigned char carry_nibble = 0;
-            for (size_t i = 0; i < bytes.size(); i++) {
+            for(size_t i = 0; i < bytes.size(); i++)
+            {
                 unsigned char lower = bytes[i] & 0xF;
                 bytes[i] >>= 4;
                 bytes[i] |= carry_nibble << 4;
@@ -274,10 +277,11 @@ namespace Exprfunc
         }
 
         unsigned char* rel_data = (unsigned char*)malloc(bytes.size() * sizeof(unsigned char));
-        if (rel_data == NULL)
+        if(rel_data == NULL)
             return false;
 
-        if (!MemRead(argv[0].number, rel_data, bytes.size() * sizeof(unsigned char))) {
+        if(!MemRead(argv[0].number, rel_data, bytes.size() * sizeof(unsigned char)))
+        {
             free(rel_data);
             return false;
         }

--- a/src/dbg/exprfunc.h
+++ b/src/dbg/exprfunc.h
@@ -34,6 +34,7 @@ namespace Exprfunc
     duint memiscode(duint addr);
     duint memisstring(duint addr);
     duint memdecodepointer(duint ptr);
+    bool memcmpextfn(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);
 
     duint dislen(duint addr);
     duint disiscond(duint addr);

--- a/src/dbg/exprfunc.h
+++ b/src/dbg/exprfunc.h
@@ -34,7 +34,7 @@ namespace Exprfunc
     duint memiscode(duint addr);
     duint memisstring(duint addr);
     duint memdecodepointer(duint ptr);
-    bool memcmpextfn(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);
+    bool memmatch(ExpressionValue* result, int argc, const ExpressionValue* argv, void* userdata);
 
     duint dislen(duint addr);
     duint disiscond(duint addr);


### PR DESCRIPTION
## Description
This PR introduces the mem.cmp(address, "hex-byte-string") expression function, allowing users to compare memory at a given address with a specified byte sequence

### Related Issue / Feature Request
Closes #3525 - `Add mem.cmp expression function to x64dbg`

### Changes & Implementation Details

- Added mem.cmp(address, "hex-byte-string") as an expression function.
- Parses the hex string into bytes and compares it with memory contents at the specified address.
- (On odd-length hex inputs, a prefix `0` is assumed, will need feedback if that part is reasonable.)
- Returns `0` if memory matches, positive and negative otherwise, refer to [memcmp](https://www.man7.org/linux/man-pages/man3/memcmp.3.html) for return value.

### Why This Is Useful
Makes weird workarounds like `byte(ptr) == .... && ... && byte(ptr+n) = ...` obsolete and allows convenient memory comparison inside breakpoint conditions.