### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/dbg/stringformat.cpp
+++ b/src/dbg/stringformat.cpp
@@ -31,6 +31,10 @@ static size_t getSSERegisterOffset(FormatValueType value, size_t elementSize)
 {
     char buf[16]; // a safe buffer with sufficient length to prevent buffer overflow while parsing
     memset(buf, 0, sizeof(buf));
+    if(strlen(value) > sizeof(buf))
+    {
+        return 0;
+    }
     strcpy_s(buf, value); // copy value into buf
     _strlwr_s(buf); // convert "XMM" to "xmm"
     if(buf[1] == 'm' && buf[2] == 'm' && (buf[0] == 'x' || buf[0] == 'y'))  // begins with /[xy]mm/

--- a/src/dbg/stringformat.cpp
+++ b/src/dbg/stringformat.cpp
@@ -31,7 +31,7 @@ static size_t getSSERegisterOffset(FormatValueType value, size_t elementSize)
 {
     char buf[16]; // a safe buffer with sufficient length to prevent buffer overflow while parsing
     memset(buf, 0, sizeof(buf));
-    if(strlen(value) > sizeof(buf))
+    if(strlen(value) >= sizeof(buf))
     {
         return 0;
     }


### PR DESCRIPTION
Oh no, I can’t believe I just wrote that code that causes a crash, right next to something "prevent buffer overflow". This is only discovered when upgrading this feature to support AVX512.