### PR TITLE
Copy graph image

### DIFF
--- a/src/gui/Src/Gui/DisassemblerGraphView.h
+++ b/src/gui/Src/Gui/DisassemblerGraphView.h
@@ -283,6 +283,7 @@ public slots:
     void followDisassemblySlot();
     void refreshSlot();
     void saveImageSlot();
+    void copyImageSlot();
     void xrefSlot();
     void mnemonicHelpSlot();
     void fitToWindowSlot();
@@ -392,4 +393,5 @@ private:
 
     void addReferenceAction(QMenu* menu, duint addr, const QString & description);
     bool getHighlightedTokenValueText(QString & text) const;
+    QImage getImage();
 };

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -581,6 +581,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ActionGraphZoomToCursor", Shortcut({tr("Actions"), tr("Graph"), tr("Zoom to cursor")}, "Z"));
     defaultShortcuts.insert("ActionGraphFitToWindow", Shortcut({tr("Actions"), tr("Graph"), tr("Fit To Window")}, "Shift+Z"));
     defaultShortcuts.insert("ActionGraphFollowDisassembler", Shortcut({tr("Actions"), tr("Graph"), tr("Follow in disassembler")}, "Shift+Return"));
+    defaultShortcuts.insert("ActionGraphCopyImage", Shortcut({tr("Actions"), tr("Graph"), tr("Copy image")}, ""));
     defaultShortcuts.insert("ActionGraphSaveImage", Shortcut({tr("Actions"), tr("Graph"), tr("Save as image")}, "I"));
     defaultShortcuts.insert("ActionGraphToggleOverview", Shortcut({tr("Actions"), tr("Graph"), tr("Toggle overview")}, "O"));
     defaultShortcuts.insert("ActionGraphToggleSummary", Shortcut({tr("Actions"), tr("Graph"), tr("Toggle summary")}, "U"));


### PR DESCRIPTION
The user can copy the image in addition to save image. However, the copied image may have different resolution with saved image due to HiDPI settings.