### PR TITLE
Fixed inverted logic

### DIFF
--- a/src/dbg/commands/cmd-searching.cpp
+++ b/src/dbg/commands/cmd-searching.cpp
@@ -327,7 +327,7 @@ bool cbInstrFindAllMem(int argc, char* argv[])
             }
         }
 
-        if(page.address >= addr && (find_size == -1 || page.address + page.size <= addr + find_size))
+        if(page.address <= addr && (find_size == -1 || page.address + page.size <= addr + find_size))
             searchPages.push_back(page);
     }
     SHARED_RELEASE();


### PR DESCRIPTION
The following commands were not working or at least returned strange results:

```
findmemall $var, E8, 0x1000
findmemall $var, E8, 123456
```

Where on the other hand these seemed to work (I guess it just seems like since they returned 5000 results [limit]):

```
findmemall $var, E8, -1
```

I'm pretty sure the start-address of the page must be **below** the search-address.
