### PR TITLE
Fix missing stdint types when building with vs2022 v120_xp toolset

### DIFF
--- a/src/dbg/types.h
+++ b/src/dbg/types.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <cstdint>
 
 namespace Types
 {


### PR DESCRIPTION
Building the project in a clean environment using Visual Studio 2022 with the v120_xp Platform Toolset (VS2013) fails due to missing type definitions for standard fixed width integers like `uint8_t`, `uint32_t`, and `uint64_t`.

These types are defined in `<cstdint>`, but the file `types.h` doesn't currently include it explicitly.

Adding:

```cpp
#include <cstdint>
```

to the top of `src/dbg/types.h` resolves the issue.

---

Error Output:
<details>
<summary>Expand error output</summary>

```text
Severity	Code	Description	Project	File	Line
Error	C4430	missing type specifier - int assumed. Note: C++ does not support default-int	x64dbg_dbg	src/dbg/types.h	132
Error	C2238	unexpected token(s) preceding ';'	x64dbg_dbg	src/dbg/types.h	35
Error	C2061	syntax error : identifier 'uint8_t'	x64dbg_dbg	src/dbg/types.h	112
Error	C2061	syntax error : identifier 'uint64_t'	x64dbg_dbg	src/dbg/types.h	113
Error	C2061	syntax error : identifier 'uint32_t'	x64dbg_dbg	src/dbg/types.h	124
Error	C2065	'uint64_t' : undeclared identifier	x64dbg_dbg	src/dbg/types.h	82
Error	C2065	'uint32_t' : undeclared identifier	x64dbg_dbg	src/dbg/types.h	133
Error	C2146	syntax error : missing ';' before identifier 'typeId'	x64dbg_dbg	src/dbg/types.h	35
Error	C2143	syntax error : missing ';' before '='	x64dbg_dbg	src/dbg/types.h	132
Error	C2923	'std::unordered_map' : 'uint32_t' is not a valid template type argument	x64dbg_dbg	src/dbg/types.h	133
Error	C2923	'std::pair' : 'uint64_t' is not a valid template type argument	x64dbg_dbg	src/dbg/types.h	82
Error	C3203	'pair' : unspecialized class template can't be used as a template argument	x64dbg_dbg	src/dbg/types.h	82
...
```

</details>

---

Environment:
- Visual Studio 2022
- Platform Toolset: `v120_xp` (Visual Studio 2013)
- Clean build environment (no precompiled headers)