### PR TITLE
Fix messages breakpoints: wnd proc or handle is unavailable (wine)

### DIFF
--- a/src/gui/Src/Gui/MessagesBreakpoints.h
+++ b/src/gui/Src/Gui/MessagesBreakpoints.h
@@ -24,6 +24,7 @@ public:
     explicit MessagesBreakpoints(MsgBreakpointData pbpData, QWidget* parent = nullptr);
     ~MessagesBreakpoints();
     MsgBreakpointData bpData;
+    duint procVA;
 
 private slots:
     void on_btnOk_clicked();


### PR DESCRIPTION
Messages breakpoints don't work on wine.
When run in wine GetClassLongPtrA/W GCLP_WNDPROC return 0 then Proc is 0.
![image](https://github.com/user-attachments/assets/939c4b9f-6315-4ff9-a143-e947c0b2db04)
