### PR TITLE
Fix: Trim trailing whitespace in script labels #3589

### DIFF
--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -208,6 +208,11 @@ static bool scriptcreatelinemap(const char* filename)
         }
 
         int rawlen = (int)strlen(cur.raw);
+        while ((rawlen > 0) && isspace(cur.raw[rawlen - 1])) //Trim trailing whitespace
+        {
+            rawlen--;
+        }
+        cur.raw[rawlen] = '\0'; //// Truncate the string by setting a new null terminator
         if(!rawlen) //empty
         {
             cur.type = lineempty;


### PR DESCRIPTION
Fixes #3589.

This patch ensures that script labels like `label:` are correctly parsed even if there is trailing whitespace after the colon.