### PR TITLE
align char buffer sizes with defined limit in GuiGetDisassembly

### DIFF
--- a/src/dbg/commands/cmd-searching.cpp
+++ b/src/dbg/commands/cmd-searching.cpp
@@ -219,7 +219,7 @@ bool cbInstrFindAll(int argc, char* argv[])
             break;
         i += foundoffset + 1;
         result = addr + i - 1;
-        char msg[deflen] = "";
+        char msg[GUI_MAX_DISASSEMBLY_SIZE] = "";
         sprintf_s(msg, "%p", (void*)result);
         GuiReferenceSetRowCount(refCount + 1);
         GuiReferenceSetCellContent(refCount, 0, msg);
@@ -327,15 +327,15 @@ bool cbInstrFindAllMem(int argc, char* argv[])
             }
         }
 
-        if (
+        if(
             (page.address <= addr && addr < page.address + page.size) ||
             (addr <= page.address && page.address < addr + find_size)
-            )
+        )
         {
             // One (partially or fully) overlaps the other
             searchPages.push_back(page);
         }
-        else if (find_size == -1 && addr <= page.address)
+        else if(find_size == -1 && addr <= page.address)
         {
             // Not overlapping, but past the address
             searchPages.push_back(page);
@@ -366,12 +366,12 @@ bool cbInstrFindAllMem(int argc, char* argv[])
     int refCount = 0;
     for(duint result : results)
     {
-        if ((result < addr) || ((find_size != -1) && (addr + find_size <= (result + searchpattern.size()))))
+        if((result < addr) || ((find_size != -1) && (addr + find_size <= (result + searchpattern.size()))))
         {
             continue;
         }
 
-        char msg[deflen] = "";
+        char msg[GUI_MAX_DISASSEMBLY_SIZE] = "";
         sprintf_s(msg, "%p", (void*)result);
         GuiReferenceSetRowCount(refCount + 1);
         GuiReferenceSetCellContent(refCount, 0, msg);
@@ -623,7 +623,7 @@ static bool cbRefStr(Zydis* disasm, BASIC_INSTRUCTION_INFO* basicinfo, REFINFO* 
         sprintf_s(strAddrText, "%p", (void*)strAddr);
         GuiReferenceSetRowCount(refinfo->refcount + 1);
         GuiReferenceSetCellContent(refinfo->refcount, 0, addrText);
-        char disassembly[4096] = "";
+        char disassembly[GUI_MAX_DISASSEMBLY_SIZE] = "";
         if(GuiGetDisassembly((duint)disasm->Address(), disassembly))
             GuiReferenceSetCellContent(refinfo->refcount, 1, disassembly);
         else
@@ -668,7 +668,7 @@ static bool cbRefFuncPtr(Zydis* disasm, BASIC_INSTRUCTION_INFO* basicinfo, REFIN
         sprintf_s(addrText, "%p", (void*)(duint)disasm->Address());
         GuiReferenceSetRowCount(refinfo->refcount + 1);
         GuiReferenceSetCellContent(refinfo->refcount, 0, addrText);
-        char disassembly[4096] = "";
+        char disassembly[GUI_MAX_DISASSEMBLY_SIZE] = "";
         if(GuiGetDisassembly((duint)disasm->Address(), disassembly))
             GuiReferenceSetCellContent(refinfo->refcount, 1, disassembly);
         else
@@ -1010,7 +1010,7 @@ static bool cbGUIDFind(Zydis* disasm, BASIC_INSTRUCTION_INFO* basicinfo, REFINFO
             sprintf_s(addrText, "%p", (void*)(duint)disasm->Address());
             GuiReferenceSetRowCount(refinfo->refcount + 1);
             GuiReferenceSetCellContent(refinfo->refcount, 0, addrText);
-            char disassembly[4096] = "";
+            char disassembly[GUI_MAX_DISASSEMBLY_SIZE] = "";
             if(GuiGetDisassembly((duint)disasm->Address(), disassembly))
                 GuiReferenceSetCellContent(refinfo->refcount, 1, disassembly);
             else


### PR DESCRIPTION
GuiGetDisassembly is limited by the constant GUI_MAX_DISASSEMBLY_SIZE 2048.

Consider to define a more reasonable size for GUI_MAX_DISASSEMBLY_SIZE?