### PR TITLE
Fix autocomment precedence

### DIFF
--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -570,14 +570,10 @@ extern "C" DLL_EXPORT bool _dbg_addrinfoget(duint addr, SEGMENTREG segment, BRID
         }
         else
         {
-            char label[MAX_LABEL_SIZE] = "";
-            if(!getLabel(addr, label, true)) //comment > label > autocomment
-            {
-                String comment;
-                retval = getAutoComment(addr, comment);
-                strcpy_s(addrinfo->comment, "\1");
-                strncat_s(addrinfo->comment, comment.c_str(), _TRUNCATE);
-            }
+            String comment;
+            retval = getAutoComment(addr, comment);
+            strcpy_s(addrinfo->comment, "\1");
+            strncat_s(addrinfo->comment, comment.c_str(), _TRUNCATE);
         }
     }
     PLUG_CB_ADDRINFO info;

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -570,10 +570,14 @@ extern "C" DLL_EXPORT bool _dbg_addrinfoget(duint addr, SEGMENTREG segment, BRID
         }
         else
         {
-            String comment;
-            retval = getAutoComment(addr, comment);
-            strcpy_s(addrinfo->comment, "\1");
-            strncat_s(addrinfo->comment, comment.c_str(), _TRUNCATE);
+            char label[MAX_LABEL_SIZE] = "";
+            if(!getLabel(addr, label, true)) //comment > label > autocomment
+            {
+                String comment;
+                retval = getAutoComment(addr, comment);
+                strcpy_s(addrinfo->comment, "\1");
+                strncat_s(addrinfo->comment, comment.c_str(), _TRUNCATE);
+            }
         }
     }
     PLUG_CB_ADDRINFO info;

--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -611,18 +611,28 @@ QString Disassembly::paintContent(QPainter* painter, duint row, duint col, int x
         char label[MAX_LABEL_SIZE] = "";
         if(GetCommentFormat(va, comment, &autoComment))
         {
-            if(autoComment)
+            if(autoComment && DbgGetLabelAt(va, SEG_DEFAULT, label)) // prefer label over auto-comment
             {
-                richComment.textColor = mAutoCommentColor;
-                richComment.textBackground = mAutoCommentBackgroundColor;
+                richComment.textColor = mLabelColor;
+                richComment.textBackground = mLabelBackgroundColor;
+                richComment.text = label;
             }
-            else //user comment
+            else
             {
-                richComment.textColor = mCommentColor;
-                richComment.textBackground = mCommentBackgroundColor;
+                if(autoComment)
+                {
+                    richComment.textColor = mAutoCommentColor;
+                    richComment.textBackground = mAutoCommentBackgroundColor;
+                }
+                else //user comment
+                {
+                    richComment.textColor = mCommentColor;
+                    richComment.textBackground = mCommentBackgroundColor;
+                }
+
+                richComment.text = std::move(comment);
             }
 
-            richComment.text = std::move(comment);
             richText.emplace_back(std::move(richComment));
         }
         else if(DbgGetLabelAt(va, SEG_DEFAULT, label)) // label but no comment


### PR DESCRIPTION
Fixes #3591.

Before:
![_before](https://github.com/user-attachments/assets/dc93d820-106a-4975-9f12-2f47e8da5f9d)

After:
![_after](https://github.com/user-attachments/assets/c4b48dda-2018-4536-b4df-08152b58ea09)