### PR TITLE
Follow in stack in trace registers view; fix shortcuts in registers view

### DIFF
--- a/src/gui/Src/Gui/CPURegistersView.cpp
+++ b/src/gui/Src/Gui/CPURegistersView.cpp
@@ -22,6 +22,19 @@ CPURegistersView::CPURegistersView(CPUWidget* parent) : RegistersView(parent), m
 
     setupContextMenu();
 
+    wCM_ToggleValue->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(wCM_ToggleValue);
+    wCM_Highlight->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(wCM_Highlight);
+    wCM_Incrementx87Stack->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(wCM_Incrementx87Stack);
+    wCM_Decrementx87Stack->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(wCM_Decrementx87Stack);
+    wCM_FollowInDump->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(wCM_FollowInDump);
+    wCM_FollowInStack->setShortcutContext(Qt::WidgetShortcut);
+    this->addAction(wCM_FollowInStack);
+
     refreshShortcutsSlot();
 }
 
@@ -89,6 +102,8 @@ void CPURegistersView::refreshShortcutsSlot()
     wCM_Highlight->setShortcut(ConfigShortcut("ActionHighlightingMode"));
     wCM_Incrementx87Stack->setShortcut(ConfigShortcut("ActionIncrementx87Stack"));
     wCM_Decrementx87Stack->setShortcut(ConfigShortcut("ActionDecrementx87Stack"));
+    wCM_FollowInDump->setShortcut(ConfigShortcut("ActionFollowDwordQwordDump"));
+    wCM_FollowInStack->setShortcut(ConfigShortcut("ActionFollowStack"));
     RegistersView::refreshShortcutsSlot();
 }
 

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1441,6 +1441,7 @@ RegistersView::RegistersView(QWidget* parent) : QScrollArea(parent), mVScrollOff
     connect(wCM_CopySymbolToClipboard, SIGNAL(triggered()), this, SLOT(onCopySymbolToClipboardAction()));
     connect(wCM_CopyAll, SIGNAL(triggered()), this, SLOT(onCopyAllAction()));
     connect(wCM_ChangeFPUView, SIGNAL(triggered()), this, SLOT(onChangeFPUViewAction()));
+    connect(Config(), SIGNAL(shortcutsUpdated()), this, SLOT(refreshShortcutsSlot()));
 
     memset(&mRegDumpStruct, 0, sizeof(REGDUMP));
     memset(&mCipRegDumpStruct, 0, sizeof(REGDUMP));

--- a/src/gui/Src/Tracer/TraceRegisters.h
+++ b/src/gui/Src/Tracer/TraceRegisters.h
@@ -15,9 +15,11 @@ public:
 
 public slots:
     virtual void displayCustomContextMenuSlot(QPoint pos);
+    virtual void refreshShortcutsSlot();
     void onCopySIMDRegister();
     void onSetCurrentRegister();
     void onFollowInDump();
+    void onFollowInStack();
     void onHighlightSlot();
 
 protected:
@@ -28,5 +30,6 @@ private:
     QAction* wCM_CopySIMDRegister;
     QAction* wCM_SetCurrentRegister;
     QAction* wCM_FollowInDump;
+    QAction* wCM_FollowInStack;
     QAction* wCM_Highlight;
 };


### PR DESCRIPTION
Add "Follow in stack" for ESP and EBP registers in trace registers view.
Properly update shortcuts in registers view when settings are changed.