### PR TITLE
Move deleted trace file to trash can (requires Qt 5.15)

### DIFF
--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -8,7 +8,6 @@
 #include "QZydis.h"
 #include "GotoDialog.h"
 #include "CommonActions.h"
-#include "LineEditDialog.h"
 #include "WordEditDialog.h"
 #include "CachedFontMetrics.h"
 #include "MRUList.h"

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -79,7 +79,7 @@ bool TraceFileReader::Delete()
         parser->requestInterruption();
         parser->wait();
     }
-    bool value = traceFile.remove();
+    bool value = traceFile.moveToTrash();
     progress.store(0);
     length = 0;
     fileIndex.clear();


### PR DESCRIPTION
Now when clicking on "Delete" action in trace tab, the deleted trace file can be undeleted from recycler. This feature requires Qt 5.15 to compile.