### PR TITLE
Patch file: fix wine usage

### DIFF
--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -470,7 +470,7 @@ void PatchDialog::on_btnPatchFile_clicked()
     strcpy_s(szDirName, szModName);
     szDirName[len] = '\0';
 
-    QString filename = QFileDialog::getSaveFileName(this, tr("Save file"), szDirName, tr("All files (*.*)"));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save file"), szDirName);
     if(!filename.length())
         return;
     filename = QDir::toNativeSeparators(filename); //convert to native path format (with backlashes)


### PR DESCRIPTION
In wine: `Patch file` tries to create `patched_file.exe.*` instead `patched_file.exe`
![photo_2025-08-02_16-07-55](https://github.com/user-attachments/assets/14c5154b-ad09-43f6-bc15-3108eb44a26f)
