### PR TITLE
Remove header size limit when reading trace file

### DIFF
--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -406,8 +406,8 @@ void TraceFileParser::readFileHeader(TraceFileReader* that)
         throw std::wstring(L"Unspecified");
     if(header.LowPart != MAKEFOURCC('T', 'R', 'A', 'C'))
         throw std::wstring(L"File type mismatch");
-    if(header.HighPart > 16384)
-        throw std::wstring(L"Header info is too big");
+    //if(header.HighPart > 16384)
+    //    throw std::wstring(L"Header info is too big");
     QByteArray jsonData = that->traceFile.read(header.HighPart);
     if(jsonData.size() != header.HighPart)
         throw std::wstring(L"JSON header is corrupted");

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -406,8 +406,6 @@ void TraceFileParser::readFileHeader(TraceFileReader* that)
         throw std::wstring(L"Unspecified");
     if(header.LowPart != MAKEFOURCC('T', 'R', 'A', 'C'))
         throw std::wstring(L"File type mismatch");
-    //if(header.HighPart > 16384)
-    //    throw std::wstring(L"Header info is too big");
     QByteArray jsonData = that->traceFile.read(header.HighPart);
     if(jsonData.size() != header.HighPart)
         throw std::wstring(L"JSON header is corrupted");


### PR DESCRIPTION
I’m developing a plugin to enhance the trace functionality of x64dbg (then it can carry more useful information to assist with reverse engineering). To achieve this, I considered appending additional data into the existing JSON blob inside the trace file. However, currently x64dbg enforces a size limit of 16,384 bytes (0x4000) for the JSON blob, which prevents this approach.

I’d like to remove this restriction. Or is there a specific reason why the JSON blob size must be limited when parsing trace files?
