### PR TITLE
Fix ordinal imports display by resolving to function names

### DIFF
--- a/src/dbg/symbolinfo.cpp
+++ b/src/dbg/symbolinfo.cpp
@@ -15,6 +15,8 @@
 #include "WinInet-Downloader/downslib.h"
 #include <shlwapi.h>
 
+void GetModuleInfo(MODINFO& Info, ULONG_PTR FileMapVA);
+
 duint symbolDownloadingBase = 0;
 
 struct SYMBOLCBDATA
@@ -504,11 +506,43 @@ bool SymbolFromAddressExact(duint address, SYMBOLINFO* info)
         auto modImport = modInfo->findImport(rva);
         if(modImport != nullptr)
         {
+            if(modImport->ordinal != -1 && modImport->moduleIndex < modInfo->importModules.size())
+            {
+                const auto& targetModuleName = modInfo->importModules[modImport->moduleIndex];
+                auto targetBase = ModBaseFromName(targetModuleName.c_str());
+                auto targetModInfo = ModInfoFromAddr(targetBase);
+                if(targetModInfo)
+                {
+                    if(targetModInfo->exports.empty() && targetModInfo->fileMapVA != 0)
+                    {
+                        GetModuleInfo(*targetModInfo, targetModInfo->fileMapVA);
+                    }
+                    if(!targetModInfo->exports.empty())
+                    {
+                        auto exportIndex = modImport->ordinal - targetModInfo->exportOrdinalBase;
+                        if(exportIndex < targetModInfo->exports.size() && exportIndex >= 0)
+                        {
+                            const auto& exportEntry = targetModInfo->exports[exportIndex];
+                            if(targetModInfo->symbols->isOpen())
+                            {
+                                SymbolInfo symInfo;
+                                if(targetModInfo->symbols->findSymbolExact(exportEntry.rva, symInfo))
+                                {
+                                    MODIMPORT resolvedImport = *modImport;
+                                    resolvedImport.name = symInfo.decoratedName;
+                                    resolvedImport.undecoratedName = symInfo.undecoratedName;
+                                    resolvedImport.copyToGuiSymbol(base, info);
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             modImport->copyToGuiSymbol(base, info);
             return true;
         }
     }
-
     return false;
 }
 

--- a/src/dbg/symbolinfo.cpp
+++ b/src/dbg/symbolinfo.cpp
@@ -493,36 +493,34 @@ bool SymbolFromAddressExact(duint address, SYMBOLINFO* info)
         }
     }
 
+    // module entry point pseudo-symbol
     if(modInfo->entry != 0 && modInfo->entrySymbol.rva == rva)
     {
         modInfo->entrySymbol.convertToGuiSymbol(base, info);
         return true;
     }
 
-    // search in module imports
+    // search in module imports (iat)
     {
         auto modImport = modInfo->findImport(rva);
         if(modImport != nullptr)
         {
+            // for imports by ordinal, try to resolve the real symbol
             if(modImport->ordinal != -1)
             {
                 duint exportAddress = 0;
                 if(DbgMemRead(address, &exportAddress, sizeof(exportAddress)) && exportAddress != 0)
                 {
-                    SYMBOLINFO exportInfo = {};
-                    if(SymbolFromAddressExact(exportAddress, &exportInfo))
+                    if(SymbolFromAddressExact(exportAddress, info))
                     {
+                        // override the address of the export symbol with the IAT address
                         info->addr = address;
-                        info->decoratedSymbol = exportInfo.decoratedSymbol;
-                        info->undecoratedSymbol = exportInfo.undecoratedSymbol;
-                        info->type = exportInfo.type;
-                        info->freeDecorated = exportInfo.freeDecorated;
-                        info->freeUndecorated = exportInfo.freeUndecorated;
-                        info->ordinal = exportInfo.ordinal;
                         return true;
                     }
                 }
             }
+
+            // fall back to the import symbol itself
             modImport->copyToGuiSymbol(base, info);
             return true;
         }

--- a/src/dbg/symbolinfo.cpp
+++ b/src/dbg/symbolinfo.cpp
@@ -15,8 +15,6 @@
 #include "WinInet-Downloader/downslib.h"
 #include <shlwapi.h>
 
-void GetModuleInfo(MODINFO& Info, ULONG_PTR FileMapVA);
-
 duint symbolDownloadingBase = 0;
 
 struct SYMBOLCBDATA
@@ -506,36 +504,22 @@ bool SymbolFromAddressExact(duint address, SYMBOLINFO* info)
         auto modImport = modInfo->findImport(rva);
         if(modImport != nullptr)
         {
-            if(modImport->ordinal != -1 && modImport->moduleIndex < modInfo->importModules.size())
+            if(modImport->ordinal != -1)
             {
-                const auto& targetModuleName = modInfo->importModules[modImport->moduleIndex];
-                auto targetBase = ModBaseFromName(targetModuleName.c_str());
-                auto targetModInfo = ModInfoFromAddr(targetBase);
-                if(targetModInfo)
+                duint exportAddress = 0;
+                if(DbgMemRead(address, &exportAddress, sizeof(exportAddress)) && exportAddress != 0)
                 {
-                    if(targetModInfo->exports.empty() && targetModInfo->fileMapVA != 0)
+                    SYMBOLINFO exportInfo = {};
+                    if(SymbolFromAddressExact(exportAddress, &exportInfo))
                     {
-                        GetModuleInfo(*targetModInfo, targetModInfo->fileMapVA);
-                    }
-                    if(!targetModInfo->exports.empty())
-                    {
-                        auto exportIndex = modImport->ordinal - targetModInfo->exportOrdinalBase;
-                        if(exportIndex < targetModInfo->exports.size() && exportIndex >= 0)
-                        {
-                            const auto& exportEntry = targetModInfo->exports[exportIndex];
-                            if(targetModInfo->symbols->isOpen())
-                            {
-                                SymbolInfo symInfo;
-                                if(targetModInfo->symbols->findSymbolExact(exportEntry.rva, symInfo))
-                                {
-                                    MODIMPORT resolvedImport = *modImport;
-                                    resolvedImport.name = symInfo.decoratedName;
-                                    resolvedImport.undecoratedName = symInfo.undecoratedName;
-                                    resolvedImport.copyToGuiSymbol(base, info);
-                                    return true;
-                                }
-                            }
-                        }
+                        info->addr = address;
+                        info->decoratedSymbol = exportInfo.decoratedSymbol;
+                        info->undecoratedSymbol = exportInfo.undecoratedSymbol;
+                        info->type = exportInfo.type;
+                        info->freeDecorated = exportInfo.freeDecorated;
+                        info->freeUndecorated = exportInfo.freeUndecorated;
+                        info->ordinal = exportInfo.ordinal;
+                        return true;
                     }
                 }
             }


### PR DESCRIPTION
API symbols loaded by ordinal are not displayed correctly in the disassembly. Instead of showing the function name such as `??0CWinApp@@QEAA@PEBD@Z` they display as generic `Ordinal#` placeholders instead. The symbol resolution system wasnt using PDB symbols to resolve ordinal imports to their function names from the target modules export table.

I modified `SymbolFromAddressExact` in `symbolinfo.cpp` to:

1. Detect ordinal imports by checking if an import has `ordinal != -1`
2. Find target module by locating the module that exports the function
3. Resolve the import using the target modules PDB symbols to obtain the un/decorated function name
4. Display resolved name by showing the proper function name instead of `Ordinal#XXX`

I verified with `mfc140.dll` Ordinal#981 now correctly displays:
- Before: `call qword ptr ds:[<Ordinal#981>]`
- After: 
Decorated: `call qword ptr ds:[<??0CWinApp@@QEAA@PEBD@Z>]`
Undecorated: `call qword ptr ds:[<public: __cdecl CWinApp::CWinApp(char const *)>]`

> This PR fixes #3608