### PR TITLE
Add `mod.fromoffset`, `mod.fromfileoffset` to command language

### DIFF
--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -72,7 +72,7 @@ void ExpressionFunctions::Init()
     RegisterEasy("mod.main,mod.mainbase", dbgdebuggedbase);
     RegisterEasy("mod.rva", modrva);
     RegisterEasy("mod.offset,mod.fileoffset", valvatofileoffset);
-    RegisterEasy("mod.fromoffset,mod.fromfileoffset", valfileoffsettova);
+    ExpressionFunctions::Register("mod.fromoffset,mod.fromfileoffset", ValueTypeNumber, { ValueTypeString, ValueTypeNumber }, valfileoffsettova);
     RegisterEasy("mod.headerva", modheaderva);
     RegisterEasy("mod.isexport", modisexport);
     ExpressionFunctions::Register("mod.fromname", ValueTypeNumber, { ValueTypeString }, Exprfunc::modbasefromname);
@@ -303,4 +303,5 @@ bool ExpressionFunctions::isValidName(const String & name)
             return false;
     return true;
 }
+
 

--- a/src/dbg/expressionfunctions.cpp
+++ b/src/dbg/expressionfunctions.cpp
@@ -72,6 +72,7 @@ void ExpressionFunctions::Init()
     RegisterEasy("mod.main,mod.mainbase", dbgdebuggedbase);
     RegisterEasy("mod.rva", modrva);
     RegisterEasy("mod.offset,mod.fileoffset", valvatofileoffset);
+    RegisterEasy("mod.fromoffset,mod.fromfileoffset", valfileoffsettova);
     RegisterEasy("mod.headerva", modheaderva);
     RegisterEasy("mod.isexport", modisexport);
     ExpressionFunctions::Register("mod.fromname", ValueTypeNumber, { ValueTypeString }, Exprfunc::modbasefromname);
@@ -302,3 +303,4 @@ bool ExpressionFunctions::isValidName(const String & name)
             return false;
     return true;
 }
+


### PR DESCRIPTION
This function should perform the inverse of what `mod.offset` does: to get the virtual address from a file offset.

I added it because I'm trying to get the start of the `.data` region of an EXE.

Specifically, I am trying to use the `find` command to find a quick way to reconstruct [global data that gets initialised by `_initterm` upon runtime](https://medium.com/@naore32/beyond-the-main-unearthing-sneaky-functions-521f593ebeb3) (hope that doesn't raise too many questions).

However, there is no way to convert a file offset (in variable form) to a virtual offset.

The following should print out the file offset.

```
find :0,"2e 64 61 74 61"; dword:[($result+14)]
```

However, the following is invalid in the command syntax:

```
:#(dword:[($result+14)])
```