### PR TITLE
Changed ctrl+a to select all items instead of selecting all characters of search filter.

### DIFF
--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -350,7 +350,6 @@ bool SearchListView::eventFilter(QObject* obj, QEvent* event)
                 return QWidget::eventFilter(obj, event);
             // Search box shortcuts reliant on mSearchBox not being empty
             case Qt::Key_X: //Ctrl+X
-            case Qt::Key_A: //Ctrl+A
                 if(keyEvent->modifiers() == Qt::ControlModifier)
                     return QWidget::eventFilter(obj, event);
             }


### PR DESCRIPTION
Closes #3698

This affects the searchbars(QLineEdit).

Current behavior:
If the user has NOT entered a search filter and they press ctrl+a, it selects all items. For example, if the user is looking at the references tab to see all intermodular calls, it will select all those calls.

If the user has entered a search filter, when they press ctrl+a, their search filter is selected instead.

Proposed change:
Always select all items when ctrl+a is pressed. (ctrl+a will no longer select the search filter)

<img width="2559" height="1092" alt="image" src="https://github.com/user-attachments/assets/5c3cd3ef-9cef-45dd-9a82-10937f990cd4" />
