### PR TITLE
Added FollowSelectionInView feature when pressing Shift, PgDn, PgUp

### DIFF
--- a/src/cross/widgets/Configuration.cpp
+++ b/src/cross/widgets/Configuration.cpp
@@ -311,6 +311,7 @@ Configuration::Configuration(const ConfigurationPalette & p) : QObject(), noMore
     disassemblyBool.insert("PermanentHighlightingMode", false);
     disassemblyBool.insert("NoBranchDisasmPreview", false);
     disassemblyBool.insert("NoCurrentModuleText", false);
+    disassemblyBool.insert("FollowSelectionInView", false);
     defaultBools.insert("Disassembler", disassemblyBool);
 
     QMap<QString, bool> engineBool;

--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -948,7 +948,19 @@ void Disassembly::keyPressEvent(QKeyEvent* event)
         followInstruction(getInitialSelection());
     }
     else
+    {
         AbstractTableView::keyPressEvent(event);
+        if (key == Qt::Key_PageUp)
+        {
+            followSelectionInView(event);
+        }
+        else if (key == Qt::Key_PageDown)
+        {
+            followSelectionInView(event);
+        }
+    }
+        
+        
 }
 
 /************************************************************************************
@@ -1679,6 +1691,27 @@ duint Disassembly::getSelectedVa() const
     // Converts the selected index to a valid virtual address
     return rvaToVa(getInitialSelection());
 }
+
+void Disassembly::followSelectionInView(QKeyEvent* event)
+{
+    mFollowSelectionInView = ConfigBool("Disassembler", "FollowSelectionInView");
+    if (mFollowSelectionInView)
+    {
+        int key = event->key();
+        if (key == Qt::Key_PageUp)
+        {
+            auto firstVisibleRva = getTableOffset();
+            setSingleSelection(firstVisibleRva);
+        }
+        else if (key == Qt::Key_PageDown)
+        {
+            auto lastVisibleRva = getInstructionRVA(getTableOffset(), getNbrOfLineToPrint() - 1);
+            setSingleSelection(lastVisibleRva);
+        }
+    }
+}
+
+
 
 /************************************************************************************
                          Update/Reload/Refresh/Repaint

--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -55,6 +55,7 @@ public:
     bool isSelected(duint base, dsint offset);
     bool isSelected(QList<Instruction_t>* buffer, int index) const;
     duint getSelectedVa() const;
+    void followSelectionInView(QKeyEvent* event);
 
     // Update/Reload/Refresh/Repaint
     void prepareData() override;
@@ -260,6 +261,7 @@ protected:
     ZydisTokenizer::SingleToken mHighlightToken;
     bool mPermanentHighlightingMode;
     bool mNoCurrentModuleText;
+    bool mFollowSelectionInView;
     bool mIsMain = false;
 
     struct RichTextInfo

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -684,6 +684,31 @@ void HexDump::keyPressEvent(QKeyEvent* event)
                 action = 1;
         }
         break;
+        case Qt::Key_PageUp:
+        {
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderPageStepSub);
+            mFollowSelectionInView = ConfigBool("Disassembler", "FollowSelectionInView");
+            if (mFollowSelectionInView)
+            {
+                //Taking current view left-top
+                selStart = getTableOffsetRva();
+                action = -2;
+            }
+            break;
+        }
+        case Qt::Key_PageDown:
+        {
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderPageStepAdd);
+            mFollowSelectionInView = ConfigBool("Disassembler", "FollowSelectionInView");
+            if (mFollowSelectionInView)
+            {
+                // Taking left-bottom
+                constexpr duint oneRowLess = 1;
+                selStart = (getViewableRowsCount() - oneRowLess) * getBytePerRowCount() + getTableOffsetRva();
+                action = 2;
+            }
+            break;
+        }
         default:
             AbstractTableView::keyPressEvent(event);
         }
@@ -733,6 +758,68 @@ void HexDump::keyPressEvent(QKeyEvent* event)
     else if(modifiers == Qt::ShiftModifier)
     {
         //TODO
+        duint selection;
+        switch (key)
+        {
+        case Qt::Key_Left:
+            selection = getSelectionStart();
+            selection -= granularity;
+            if (0 <= selection)
+                action = -1;
+            break;
+        case Qt::Key_Right:
+            selection = getSelectionEnd();
+            selection += granularity;
+            if (mMemPage->getSize() > selection)
+                action = 1;
+            break;
+        case Qt::Key_Up:
+            selection = getSelectionStart();
+            selection -= getBytePerRowCount();
+            if (0 <= selection)
+                action = -1;
+            break;
+        case Qt::Key_Down:
+            selection = getSelectionEnd();
+            selection += getBytePerRowCount();
+            if (mMemPage->getSize() > selection)
+                action = 1;
+            break;
+        case Qt::Key_PageUp:
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderPageStepSub);
+            //Taking top current view
+            selection = getTableOffsetRva();
+            action = -2;
+            break;
+        case Qt::Key_PageDown:
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderPageStepAdd);
+            //Taking end of view
+            selection = getViewableRowsCount() * getBytePerRowCount() + getTableOffsetRva();
+            action = 2;
+            break;
+        case Qt::Key_Home:
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderToMinimum);
+            selection = getTableOffsetRva();
+            action = -2;
+            break;
+        case Qt::Key_End:
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderToMaximum);
+            selection = getViewableRowsCount() * getBytePerRowCount() + getTableOffsetRva();
+            action = 2;
+            break;
+        default:
+            AbstractTableView::keyPressEvent(event);
+        }
+        if (action == 1 && selection >= getViewableRowsCount() * getBytePerRowCount() + getTableOffsetRva())
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderSingleStepAdd);
+        else if (action == -1 && selection < getTableOffsetRva())
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderSingleStepSub);
+
+        if(action != 0)
+        {
+            expandSelectionUpTo(selection);
+            reloadData();
+        }
     }
     else
     {

--- a/src/gui/Src/BasicView/HexDump.h
+++ b/src/gui/Src/BasicView/HexDump.h
@@ -232,4 +232,5 @@ protected:
     duint mUnderlineRangeEndVa = 0;
     bool mPointerUnderliningEnabled = true;
     bool mSelectionUnderliningEnabled = false;
+    bool mFollowSelectionInView = false;
 };

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -239,6 +239,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Disassembler", "NoBranchDisasmPreview", &settings.disasmNoBranchDisasmPreview);
     GetSettingBool("Disassembler", "NoSourceLineAutoComments", &settings.disasmNoSourceLineAutoComments);
     GetSettingBool("Disassembler", "AssembleOnDoubleClick", &settings.disasmAssembleOnDoubleClick);
+    GetSettingBool("Disassembler", "FollowSelectionInView", &settings.disasmFollowSelectionInView);
 
     if(BridgeSettingGetUint("Disassembler", "0xPrefixValues", &cur))
     {
@@ -270,6 +271,7 @@ void SettingsDialog::LoadSettings()
     ui->chkNoSourceLinesAutoComments->setChecked(settings.disasmNoSourceLineAutoComments);
     ui->chkDoubleClickAssemble->setChecked(settings.disasmAssembleOnDoubleClick);
     ui->spinMaximumModuleNameSize->setValue(settings.disasmMaxModuleSize);
+    ui->chkFollowSelectionInView->setChecked(settings.disasmFollowSelectionInView);
 
     //Gui tab
     GetSettingBool("Gui", "FpuRegistersLittleEndian", &settings.guiFpuRegistersLittleEndian);
@@ -439,6 +441,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Disassembler", "NoSourceLineAutoComments", settings.disasmNoSourceLineAutoComments);
     BridgeSettingSetUint("Disassembler", "AssembleOnDoubleClick", settings.disasmAssembleOnDoubleClick);
     BridgeSettingSetUint("Disassembler", "MaxModuleSize", settings.disasmMaxModuleSize);
+    BridgeSettingSetUint("Disassembler", "FollowSelectionInView", settings.disasmFollowSelectionInView);
 
     //Gui tab
     BridgeSettingSetUint("Gui", "FpuRegistersLittleEndian", settings.guiFpuRegistersLittleEndian);
@@ -1116,6 +1119,11 @@ void SettingsDialog::on_chkDoubleClickAssemble_toggled(bool checked)
 void SettingsDialog::on_spinMaximumModuleNameSize_valueChanged(int arg1)
 {
     settings.disasmMaxModuleSize = arg1;
+}
+
+void SettingsDialog::on_chkFollowSelectionInView_toggled(bool checked)
+{
+    settings.disasmFollowSelectionInView = checked;
 }
 
 void SettingsDialog::on_chkShowGraphRva_toggled(bool checked)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -96,6 +96,7 @@ private slots:
     void on_chkNoSourceLinesAutoComments_toggled(bool checked);
     void on_chkDoubleClickAssemble_toggled(bool checked);
     void on_spinMaximumModuleNameSize_valueChanged(int arg1);
+    void on_chkFollowSelectionInView_toggled(bool checked);
     //Gui Tab
     void on_chkFpuRegistersLittleEndian_stateChanged(int arg1);
     void on_chkSaveColumnOrder_stateChanged(int arg1);
@@ -232,6 +233,7 @@ private:
         bool disasmNoSourceLineAutoComments = false;
         bool disasmAssembleOnDoubleClick = false;
         int disasmMaxModuleSize = -1;
+        bool disasmFollowSelectionInView = false;
         //Gui Tab
         bool guiFpuRegistersLittleEndian = false;
         bool guiSaveColumnOrder = false;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -859,6 +859,13 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkFollowSelectionInView">
+         <property name="text">
+          <string>Follow Selection with PageDown, PageUp</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacerDisasm">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -264,6 +264,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     disassemblyBool.insert("NoBranchDisasmPreview", false);
     disassemblyBool.insert("NoCurrentModuleText", false);
     disassemblyBool.insert("ShowMnemonicBrief", false);
+    disassemblyBool.insert("FollowSelectionInView", false);
     defaultBools.insert("Disassembler", disassemblyBool);
 
     QMap<QString, bool> engineBool;


### PR DESCRIPTION
Hello, 

This PR Closes #3337:

- The feature relocates the cursor selection in the current view (CPU and Dump) when pressing Page Down, Page Up, also with the Shift modifier.
- Added an option in settings to Enable/Disable the Follow View feature for people who may not like it?

Let me know if there are any issues or changes.

Thanks.