### PR TITLE
[Refined] Adding Interactive Diagram for `x64dbg`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,6 +33,12 @@ As with any open source project, documentation is lacking and the code can seem 
 
 This is by no means an exhaustive list and we are still working on lowering the barrier for new contributors. The feedback of new contributors is vital to reaching this goal.
 
+#### How does `x64dbg` work under the hood?
+
+Check out this interactive walkthrough of the `x64dbg` codebase on CodeCanvas [here](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=x64dbg&owner=Abdullah85MBA&branch=development&OnboardingTutorial=true).
+
+<img width="3760" height="1794" alt="image" src="https://github.com/user-attachments/assets/8eb6e670-ca6c-496d-865c-00b603223f2b" />
+
 #### Sending a pull request
 
 Here is a little guide on how to do a clean pull request for people who don't yet know how to use git:

--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@ An open-source binary debugger for Windows, aimed at malware analysis and revers
 
 You can also [compile](https://github.com/x64dbg/x64dbg/wiki/Compiling-the-whole-project) x64dbg yourself with a few easy steps!
 
-
-### How does `x64dbg` work under the hood?
-
-Check out this interactive walkthrough of the `x64dbg` codebase on CodeCanvas [here](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=x64dbg&owner=Abdullah85MBA&branch=development&OnboardingTutorial=true).
-
-To refine existing dataflow simulation or create new ones, follow the quick tutorial [here](https://docs.code-canvas.com/updating-diagram).
-
-<img width="1916" alt="CodeCanvas Screenshot" src="https://codecanvas-media-public.s3.amazonaws.com/images/codecanvas-readme-screenshot.png" />
-
 ## Sponsors
 
 [![](.github/sponsors/malcore.png)](https://sponsors.x64dbg.com/malcore)
@@ -102,3 +93,4 @@ You can find an exhaustive list of GitHub contributors [here](https://github.com
 - [JustMagic](https://github.com/JustasMasiulis)
 
 Without the help of many people and other open-source projects, it would not have been possible to make x64dbg what it is today, thank you!
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ An open-source binary debugger for Windows, aimed at malware analysis and revers
 
 You can also [compile](https://github.com/x64dbg/x64dbg/wiki/Compiling-the-whole-project) x64dbg yourself with a few easy steps!
 
+
+### How does `x64dbg` work under the hood?
+
+Check out this interactive walkthrough of the `x64dbg` codebase on CodeCanvas [here](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=x64dbg&owner=Abdullah85MBA&branch=development&OnboardingTutorial=true).
+
+To refine existing dataflow simulation or create new ones, follow the quick tutorial [here](https://docs.code-canvas.com/updating-diagram).
+
+<img width="1916" alt="CodeCanvas Screenshot" src="https://codecanvas-media-public.s3.amazonaws.com/images/codecanvas-readme-screenshot.png" />
+
 ## Sponsors
 
 [![](.github/sponsors/malcore.png)](https://sponsors.x64dbg.com/malcore)

--- a/README.md
+++ b/README.md
@@ -93,4 +93,3 @@ You can find an exhaustive list of GitHub contributors [here](https://github.com
 - [JustMagic](https://github.com/JustasMasiulis)
 
 Without the help of many people and other open-source projects, it would not have been possible to make x64dbg what it is today, thank you!
-


### PR DESCRIPTION
Earlier on I opened this PR: https://github.com/x64dbg/x64dbg/pull/3711

It was closed because adding the diagram file to root level was not desired.

Since then I was thinking about where I could host the diagram, I didn't want to host it on 3rd-party database because I want the owners of this repo to have complete control over the file. So I found a better approach:

- This PR only references the diagram in the .github/CONTRIBUTING.md
- I gave you collaborator access to my forked version of x64dbg where the diagram is current stored in the `development` branch.
- The references of the diagram in the .github/CONTRIBUTING.md is now pointing to the diagram file that's stored in the forked repository.
- I will transfer repo ownership to you once you are comfortable with using and maintaining the diagram (or right now if you prefer)