### PR TITLE
Add two plugin callback for trace(StartTrace and StopTrace)

### DIFF
--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -550,7 +550,6 @@ bool TraceRecordManager::enableTraceRecording(bool enabled, const char* fileName
             dprintf(QT_TRANSLATE_NOOP("DBG", "Started trace recording to file: %s\n"), fileName);
             PLUG_CB_STARTTRACE startTraceInfo{};
             startTraceInfo.traceFilePath = fileName;
-            startTraceInfo.reserved = nullptr;
             plugincbcall(CB_STARTTRACE, &startTraceInfo);
             Zydis zydis;
             unsigned char instr[MAX_DISASM_BUFFER];

--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -548,6 +548,10 @@ bool TraceRecordManager::enableTraceRecording(bool enabled, const char* fileName
             for(size_t i = 0; i < _countof(rtOldContextChanged); i++)
                 rtOldContextChanged[i] = true;
             dprintf(QT_TRANSLATE_NOOP("DBG", "Started trace recording to file: %s\n"), fileName);
+            PLUG_CB_STARTTRACE startTraceInfo{};
+            startTraceInfo.traceFilePath = fileName;
+            startTraceInfo.reserved = nullptr;
+            plugincbcall(CB_STARTTRACE, &startTraceInfo);
             Zydis zydis;
             unsigned char instr[MAX_DISASM_BUFFER];
             auto cip = GetContextDataEx(hActiveThread, UE_CIP);
@@ -574,6 +578,9 @@ bool TraceRecordManager::enableTraceRecording(bool enabled, const char* fileName
             rtPrevInstAvailable = false;
             rtEnabled = false;
             dputs(QT_TRANSLATE_NOOP("DBG", "Trace recording stopped."));
+            PLUG_CB_STOPTRACE stopTraceInfo{};
+            stopTraceInfo.reserved = nullptr;
+            plugincbcall(CB_STOPTRACE, &stopTraceInfo);
         }
         return true;
     }

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -239,7 +239,6 @@ typedef struct
 typedef struct
 {
     const char* traceFilePath;
-    void* reserved;
 } PLUG_CB_STARTTRACE;
 
 typedef struct

--- a/src/dbg/_plugins.h
+++ b/src/dbg/_plugins.h
@@ -236,6 +236,17 @@ typedef struct
     GUIMENUTYPE hMenu;
 } PLUG_CB_MENUPREPARE;
 
+typedef struct
+{
+    const char* traceFilePath;
+    void* reserved;
+} PLUG_CB_STARTTRACE;
+
+typedef struct
+{
+    void* reserved;
+} PLUG_CB_STOPTRACE;
+
 typedef enum
 {
     ValueTypeNumber,
@@ -295,6 +306,8 @@ typedef enum
     CB_VALTOSTRING, //PLUG_CB_VALTOSTRING
     CB_MENUPREPARE, //PLUG_CB_MENUPREPARE
     CB_STOPPINGDEBUG, //PLUG_CB_STOPDEBUG
+    CB_STARTTRACE, //PLUG_CB_STARTTRACE
+    CB_STOPTRACE, //PLUG_CB_STOPTRACE
     CB_LAST
 } CBTYPE;
 


### PR DESCRIPTION
While developing an x64dbg module to enhance the existing code tracing functionality, I’ve been stuck for a long time on one problem: **retrieving the file path of the generated .trace32/.trace64 files.**

To address this, I came up with a possible solution. I propose adding two new callbacks to the current plugin SDK: one for the start of code tracing and one for the end of code tracing (**StartTrace** and **StopTrace**).

When the user begins code tracing, the StartTrace callback would be triggered and provide the plugin instance with the file path of the newly created .trace32 / .trace64 file. When code tracing stops, the StopTrace callback would be triggered accordingly.



```cpp
#include "plugin.h"

void traceStartCB(CBTYPE cbType, PLUG_CB_STARTTRACE* callbackInfo) {
    dprintf("open tracefile: %s\n", callbackInfo->traceFilePath);
}
void traceStopCB(CBTYPE cbType, PLUG_CB_STOPTRACE* callbackInfo) {
    dprintf("close tracefile\n");
}

bool pluginInit(PLUG_INITSTRUCT* initStruct) {
    _plugin_registercallback(pluginHandle, CB_STARTTRACE, (CBPLUGIN)traceStartCB);
    _plugin_registercallback(pluginHandle, CB_STOPTRACE, (CBPLUGIN)traceStopCB);
    return true;
}
void pluginStop() {
    _plugin_unregistercallback(pluginHandle, CB_STOPTRACE);
    _plugin_unregistercallback(pluginHandle, CB_STARTTRACE);
}

void pluginSetup() {}
```

<img width="824" height="807" alt="image" src="https://github.com/user-attachments/assets/2291f864-e80b-42ac-872f-cb12b66b41c6" />



I noticed that this seems to be the first time anyone has proposed adding these two callbacks, so are there any considerations or potential issues that should be taken into account?
