### PR TITLE
Optimize expression evaluation for tracing performance

### DIFF
--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -233,7 +233,7 @@ static void HandleZydisOperand(const Zydis & zydis, int opindex, DISASM_ARGTYPE*
         const auto & mem = op.mem;
         if(mem.segment == ArchValue(ZYDIS_REGISTER_FS, ZYDIS_REGISTER_GS))
         {
-            *value += ThreadGetLocalBase(ThreadGetId(hActiveThread));
+            *value += ThreadGetLocalBase(GetDebugData()->dwThreadId);
         }
         *memorySize = op.size / 8;
         if(*memorySize <= memoryContentSize && DbgMemIsValidReadPtr(*value))
@@ -264,7 +264,7 @@ void TraceRecordManager::TraceExecuteRecord(const Zydis & newInstruction)
     duint oldMemory[memoryArrayCount];
     unsigned char newMemoryArrayCount = 0;
     DbgGetRegDumpEx((REGDUMP_AVX512*)&newContext.registers, sizeof(REGDUMP)); //TODO: Migrate
-    newThreadId = ThreadGetId(hActiveThread);
+    newThreadId = GetDebugData()->dwThreadId;
     // Don't try to resolve memory values for invalid/lea/nop instructions
     if(newInstruction.Success() && !newInstruction.IsNop() && newInstruction.GetId() != ZYDIS_MNEMONIC_LEA)
     {

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -728,7 +728,7 @@ extern "C" DLL_EXPORT bool _dbg_getregdump(REGDUMP_AVX512* regdump)
 
     TranslateTitanContextToRegContext(titcontext, titcontext_AVX512, regdump->regcontext);
 
-    auto threadId = ThreadGetId(hActiveThread);
+    auto threadId = GetDebugData()->dwThreadId;
     regdump->lastError = ThreadGetLastError(threadId);
     regdump->lastStatus =  ThreadGetLastStatus(threadId);
 
@@ -1528,7 +1528,7 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
 
     case DBG_GET_THREAD_ID:
     {
-        return duint(ThreadGetId(hActiveThread));
+        return duint(GetDebugData()->dwThreadId);
     }
     break;
 

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -421,7 +421,7 @@ bool cbDebugPause(int argc, char* argv[])
     //WORKAROUND: If a program is stuck in NtUserGetMessage (GetMessage was called), this
     //will send a WM_NULL to stop the waiting. This only works if the message is not filtered.
     //OllyDbg also does this in a similar way.
-    PostThreadMessageA(ThreadGetId(hActiveThread), WM_NULL, 0, 0);
+    PostThreadMessageA(GetDebugData()->dwThreadId, WM_NULL, 0, 0);
     if(ResumeThread(hActiveThread) == -1)
     {
         dputs(QT_TRANSLATE_NOOP("DBG", "Error resuming thread"));

--- a/src/dbg/commands/cmd-thread-control.cpp
+++ b/src/dbg/commands/cmd-thread-control.cpp
@@ -58,7 +58,7 @@ bool cbDebugSwitchthread(int argc, char* argv[])
         return false;
     }
     //switch thread
-    if(ThreadGetId(hActiveThread) != threadid)
+    if(GetDebugData()->dwThreadId != threadid)
     {
         hActiveThread = ThreadGetHandle((DWORD)threadid);
         HistoryClear();

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -283,7 +283,7 @@ void cbDebuggerPaused()
         static DWORD PrevThreadId = 0;
         if(PrevThreadId == 0)
             PrevThreadId = fdProcessInfo->dwThreadId; // Initialize to Main Thread
-        DWORD currentThreadId = ThreadGetId(hActiveThread);
+        DWORD currentThreadId = GetDebugData()->dwThreadId;
         if(currentThreadId != PrevThreadId && PrevThreadId != 0)
         {
             dprintf(QT_TRANSLATE_NOOP("DBG", "Thread switched from %X to %X !\n"), PrevThreadId, currentThreadId);
@@ -501,7 +501,7 @@ static void DebugUpdateTitle(duint disasm_addr, bool analyzeThreadSwitch)
     else
         _snprintf_s(modtext, _TRUNCATE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Module: %s - ")), modname);
     char threadswitch[256] = "";
-    DWORD currentThreadId = ThreadGetId(hActiveThread);
+    DWORD currentThreadId = GetDebugData()->dwThreadId;
     if(analyzeThreadSwitch)
     {
         static DWORD PrevThreadId = 0;

--- a/src/dbg/disasm_helper.cpp
+++ b/src/dbg/disasm_helper.cpp
@@ -150,7 +150,7 @@ static void HandleZydisOperand(Zydis & zydis, int opindex, DISASM_ARG* arg, bool
         if(mem.segment == ArchValue(ZYDIS_REGISTER_FS, ZYDIS_REGISTER_GS))
         {
             arg->segment = ArchValue(SEG_FS, SEG_GS);
-            value += ThreadGetLocalBase(ThreadGetId(hActiveThread));
+            value += ThreadGetLocalBase(GetDebugData()->dwThreadId);
         }
         else
         {

--- a/src/dbg/exception.cpp
+++ b/src/dbg/exception.cpp
@@ -38,6 +38,7 @@ static bool UniversalCodeInit(const String & file, std::unordered_map<unsigned i
             result = false;
             break;
         }
+        // TODO: Detect invalid constant names that is indistinguishable from numbers (deadbeef)
         names.insert({ (unsigned int)code, split[1] });
     }
     return result;

--- a/src/dbg/expressionparser.cpp
+++ b/src/dbg/expressionparser.cpp
@@ -140,6 +140,7 @@ ExpressionParser::ExpressionParser(const String & expression)
     const size_t r = 50;
     mTokens.reserve(r);
     mCurToken.reserve(r);
+    mIsConstValue = false;
     tokenize();
 #if 0
     // Print the tokens for debugging
@@ -150,6 +151,13 @@ ExpressionParser::ExpressionParser(const String & expression)
     }
     dprintf_untranslated("\n");
 #endif
+    if(mTokens.size() == 1)
+    {
+        if(mTokens[0].type() == Token::Type::NumericLiteral)
+        {
+            mIsConstValue = true;
+        }
+    }
     shuntingYard();
 }
 
@@ -366,7 +374,7 @@ void ExpressionParser::tokenize()
     }
     if(mCurToken.length() != 0) //make sure the last token is added
     {
-        mTokens.push_back(Token(mCurToken, resolveQuotedData()));
+        mTokens.push_back(Token(mCurToken, resolveQuotedData()).tryConvertToNumericLiteral());
         mCurToken.clear();
         mCurTokenQuoted.clear();
     }
@@ -382,7 +390,7 @@ void ExpressionParser::addOperatorToken(const String & data, Token::Type type)
         }
         else
         {
-            mTokens.push_back(Token(mCurToken, resolveQuotedData()));
+            mTokens.push_back(Token(mCurToken, resolveQuotedData()).tryConvertToNumericLiteral());
         }
         mCurToken.clear();
         mCurTokenQuoted.clear();
@@ -404,7 +412,7 @@ bool ExpressionParser::isUnaryOperator() const
         return true;
     auto lastType = mTokens.back().type();
     //if the previous token is not data or a close bracket, this operator is a unary operator
-    return lastType != Token::Type::Data && lastType != Token::Type::QuotedData && lastType != Token::Type::CloseParen;
+    return lastType != Token::Type::Data && lastType != Token::Type::QuotedData && lastType != Token::Type::NumericLiteral && lastType != Token::Type::CloseParen;
 }
 
 void ExpressionParser::shuntingYard()
@@ -424,6 +432,7 @@ void ExpressionParser::shuntingYard()
         {
         case Token::Type::Data: //If the token is a number, then push it to the output queue.
         case Token::Type::QuotedData:
+        case Token::Type::NumericLiteral:
             queue.push_back(token);
             break;
         case Token::Type::Function: //If the token is a function token, then push it onto the stack.
@@ -829,6 +838,12 @@ bool ExpressionParser::signedOperation(Token::Type type, const EvalValue & op1, 
 
 bool ExpressionParser::Calculate(duint & value, bool signedcalc, bool allowassign, bool silent, bool baseonly, int* value_size, bool* isvar, bool* hexonly) const
 {
+    if(mIsConstValue && mTokens[0].type() == Token::Type::NumericLiteral)
+    {
+        // Just a number, optimize this very common case for tracing performance
+        value = mTokens[0].info();
+        return true;
+    }
     EvalValue evalue(0);
     if(!Calculate(evalue, signedcalc, allowassign, silent, baseonly, value_size, isvar, hexonly))
         return false;
@@ -1138,7 +1153,21 @@ bool ExpressionParser::Calculate(EvalValue & value, bool signedcalc, bool allowa
                 stack.emplace_back(result.number);
         }
         else
-            stack.push_back(EvalValue(token.data(), token.type() == Token::Type::QuotedData));
+        {
+            switch(token.type())
+            {
+            default:
+            case Token::Type::Data:
+                stack.push_back(EvalValue(token.data(), false));
+                break;
+            case Token::Type::QuotedData:
+                stack.push_back(EvalValue(token.data(), true));
+                break;
+            case Token::Type::NumericLiteral:
+                stack.push_back(EvalValue(token.info()));
+                break;
+            }
+        }
     }
     if(stack.size() != 1) //there should only be one value left on the stack
         return false;

--- a/src/dbg/expressionparser.cpp
+++ b/src/dbg/expressionparser.cpp
@@ -842,6 +842,12 @@ bool ExpressionParser::Calculate(duint & value, bool signedcalc, bool allowassig
     {
         // Just a number, optimize this very common case for tracing performance
         value = mTokens[0].info();
+        if(isvar)
+            *isvar = false;
+        if(value_size)
+            *value_size = sizeof(duint);
+        if(hexonly)
+            *hexonly = false;
         return true;
     }
     EvalValue evalue(0);

--- a/src/dbg/expressionparser.h
+++ b/src/dbg/expressionparser.h
@@ -59,6 +59,7 @@ public:
             Error,
             Data,
             QuotedData,
+            NumericLiteral,
             Function,
             Comma,
             OpenParen,
@@ -143,6 +144,15 @@ public:
             mInfo = info;
         }
 
+        Token & tryConvertToNumericLiteral()
+        {
+            if(type() == Type::Data && valfromstring_noexpr_isvar(data().c_str()) != 0 && valfromstring_noexpr(mData.c_str(), &mInfo, true, true))
+            {
+                mType = Type::NumericLiteral;
+            }
+            return *this;
+        }
+
         Associativity associativity() const;
         int precedence() const;
         bool isOperator() const;
@@ -180,6 +190,7 @@ private:
 
     String mExpression;
     bool mIsValidExpression;
+    bool mIsConstValue;
     std::vector<Token> mTokens;
     std::vector<Token> mPrefixTokens;
     String mCurToken;

--- a/src/dbg/exprfunc.cpp
+++ b/src/dbg/exprfunc.cpp
@@ -174,7 +174,7 @@ namespace Exprfunc
 
     duint tid()
     {
-        return duint(ThreadGetId(hActiveThread));
+        return duint(GetDebugData()->dwThreadId);
     }
 
     duint kusd()

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -1619,11 +1619,31 @@ bool convertLongLongNumber(const char* str, unsigned long long & result, int rad
 */
 static bool isdigitduint(char digit)
 {
-#ifdef _WIN64
-    return digit >= '1' && digit <= '8';
-#else //x86
-    return digit >= '1' && digit <= '4';
-#endif //_WIN64
+    return digit >= '1' && digit <= ArchValue('4', '8');
+}
+
+/**
+\brief Check whether the given string is a variable or a constant
+*/
+int valfromstring_noexpr_isvar(const char* string)
+{
+    if(!string || !*string)
+        return 0;
+
+    if(isdecnumber(string))  //decimal numbers come 'first'
+    {
+        return 1;
+    }
+    else if(ishexnumber(string))  //then hex numbers
+    {
+        return 2;
+    }
+    duint value;
+    if(ConstantFromName(string, value))
+    {
+        return 3;
+    }
+    return 0;
 }
 
 /**
@@ -1642,6 +1662,32 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
     if(!value || !string || !*string)
         return false;
 
+    switch(valfromstring_noexpr_isvar(string))
+    {
+    case 1:
+        if(value_size)
+            *value_size = 0;
+        if(isvar)
+            *isvar = false;
+        return convertNumber(string + 1, *value, 10);
+    case 2:
+        if(value_size)
+            *value_size = 0;
+        if(isvar)
+            *isvar = false;
+        //hexadecimal value
+        return convertNumber(string + ((*string == 'x') ? 1 : 0), *value, 16);
+    case 3:
+        if(value_size)
+            *value_size = 0;
+        if(isvar)
+            *isvar = false;
+        return ConstantFromName(string, *value);
+    default:
+        if(isvar)
+            *isvar = true;
+        break;
+    }
     if(string[0] == '['
             || (isdigitduint(string[0]) && string[1] == ':' && string[2] == '[')
             || (string[1] == 's' && (string[0] == 'c' || string[0] == 'd' || string[0] == 'e' || string[0] == 'f' || string[0] == 'g' || string[0] == 's') && string[2] == ':' && string[3] == '[') //memory location
@@ -1656,8 +1702,6 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             *value = 0;
             if(value_size)
                 *value_size = 0;
-            if(isvar)
-                *isvar = true;
             return true;
         }
         int len = (int)strlen(string);
@@ -1776,14 +1820,10 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
         }
         if(value_size)
             *value_size = read_size;
-        if(isvar)
-            *isvar = true;
         return true;
     }
     else if(varget(string, value, value_size, 0)) //then come variables
     {
-        if(isvar)
-            *isvar = true;
         return true;
     }
     else if(isregister(string)) //register
@@ -1795,13 +1835,9 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             *value = 0;
             if(value_size)
                 *value_size = 0;
-            if(isvar)
-                *isvar = true;
             return true;
         }
         *value = getregister(value_size, string);
-        if(isvar)
-            *isvar = true;
         return true;
     }
     else if(*string == '_' && isflag(string + 1)) //flag
@@ -1813,8 +1849,6 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             *value = 0;
             if(value_size)
                 *value_size = 0;
-            if(isvar)
-                *isvar = true;
             return true;
         }
         duint eflags = GetContextDataEx(hActiveThread, UE_CFLAGS);
@@ -1824,40 +1858,12 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             *value = 0;
         if(value_size)
             *value_size = 0;
-        if(isvar)
-            *isvar = true;
         return true;
     }
-    else if(isdecnumber(string)) //decimal numbers come 'first'
-    {
-        if(value_size)
-            *value_size = 0;
-        if(isvar)
-            *isvar = false;
-        return convertNumber(string + 1, *value, 10);
-    }
-    else if(ishexnumber(string)) //then hex numbers
-    {
-        if(value_size)
-            *value_size = 0;
-        if(isvar)
-            *isvar = false;
-        //hexadecimal value
-        int inc = 0;
-        if(*string == 'x')
-            inc = 1;
-        return convertNumber(string + inc, *value, 16);
-    }
-
-    if(isvar)
-        *isvar = false;
     if(hexonly)
         *hexonly = true;
     if(value_size)
         *value_size = sizeof(duint);
-
-    if(ConstantFromName(string, *value))
-        return true;
 
     PLUG_CB_VALFROMSTRING info;
     info.string = string;

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -887,54 +887,29 @@ duint getregister(int* size, const char* string)
     {
         return GetContextDataEx(hActiveThread, UE_DR7);
     }
-
     if(scmp(string, "cax"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RAX);
-#else
-        return GetContextDataEx(hActiveThread, UE_EAX);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_EAX, UE_RAX));
     }
     if(scmp(string, "cbx"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RBX);
-#else
-        return GetContextDataEx(hActiveThread, UE_EBX);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_EBX, UE_RBX));
     }
     if(scmp(string, "ccx"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RCX);
-#else
-        return GetContextDataEx(hActiveThread, UE_ECX);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_ECX, UE_RCX));
     }
     if(scmp(string, "cdx"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RDX);
-#else
-        return GetContextDataEx(hActiveThread, UE_EDX);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_EDX, UE_RDX));
     }
     if(scmp(string, "csi"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RSI);
-#else
-        return GetContextDataEx(hActiveThread, UE_ESI);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_ESI, UE_RSI));
     }
     if(scmp(string, "cdi"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RDI);
-#else
-        return GetContextDataEx(hActiveThread, UE_EDI);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_EDI, UE_RDI));
     }
     if(scmp(string, "cip"))
     {
@@ -946,11 +921,7 @@ duint getregister(int* size, const char* string)
     }
     if(scmp(string, "cbp"))
     {
-#ifdef _WIN64
-        return GetContextDataEx(hActiveThread, UE_RBP);
-#else
-        return GetContextDataEx(hActiveThread, UE_EBP);
-#endif //_WIN64
+        return GetContextDataEx(hActiveThread, ArchValue(UE_EBP, UE_RBP));
     }
     if(scmp(string, "cflags"))
     {
@@ -1261,51 +1232,23 @@ bool setregister(const char* string, duint value)
         return SetContextDataEx(hActiveThread, UE_DR7, value);
 
     if(scmp(string, "cax"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RAX, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_EAX, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_EAX, UE_RAX), value);
     if(scmp(string, "cbx"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RBX, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_EBX, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_EBX, UE_RBX), value);
     if(scmp(string, "ccx"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RCX, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_ECX, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_ECX, UE_RCX), value);
     if(scmp(string, "cdx"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RDX, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_EDX, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_EDX, UE_RDX), value);
     if(scmp(string, "csi"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RSI, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_ESI, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_ESI, UE_RSI), value);
     if(scmp(string, "cdi"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RDI, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_EDI, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_EDI, UE_RDI), value);
     if(scmp(string, "cip"))
         return SetContextDataEx(hActiveThread, UE_CIP, value);
     if(scmp(string, "csp"))
         return SetContextDataEx(hActiveThread, UE_CSP, value);
     if(scmp(string, "cbp"))
-#ifdef _WIN64
-        return SetContextDataEx(hActiveThread, UE_RBP, value);
-#else
-        return SetContextDataEx(hActiveThread, UE_EBP, value);
-#endif //_WIN64
+        return SetContextDataEx(hActiveThread, ArchValue(UE_EBP, UE_RBP), value);
     if(scmp(string, "cflags"))
         return SetContextDataEx(hActiveThread, UE_CFLAGS, value);
 

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -968,223 +968,363 @@ duint getregister(int* size, const char* string)
 */
 bool setregister(const char* string, duint value)
 {
-    if(scmp(string, "eax"))
-        return SetContextDataEx(hActiveThread, UE_EAX, value & 0xFFFFFFFF);
-    if(scmp(string, "ebx"))
-        return SetContextDataEx(hActiveThread, UE_EBX, value & 0xFFFFFFFF);
-    if(scmp(string, "ecx"))
-        return SetContextDataEx(hActiveThread, UE_ECX, value & 0xFFFFFFFF);
-    if(scmp(string, "edx"))
-        return SetContextDataEx(hActiveThread, UE_EDX, value & 0xFFFFFFFF);
-    if(scmp(string, "edi"))
-        return SetContextDataEx(hActiveThread, UE_EDI, value & 0xFFFFFFFF);
-    if(scmp(string, "esi"))
-        return SetContextDataEx(hActiveThread, UE_ESI, value & 0xFFFFFFFF);
-    if(scmp(string, "ebp"))
-        return SetContextDataEx(hActiveThread, UE_EBP, value & 0xFFFFFFFF);
-    if(scmp(string, "esp"))
-        return SetContextDataEx(hActiveThread, UE_ESP, value & 0xFFFFFFFF);
-    if(scmp(string, "eip"))
-        return SetContextDataEx(hActiveThread, UE_EIP, value & 0xFFFFFFFF);
-    if(scmp(string, "eflags"))
-        return SetContextDataEx(hActiveThread, UE_EFLAGS, value & 0xFFFFFFFF);
+    TitanRegister titanIndex = UE_XMM0;
+    const int string_int = read_string_4char_ucase(string);
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(EAX):
+        titanIndex = UE_EAX;
+        break;
+    case MAKE_WORD_INTO_INT(EBX):
+        titanIndex = UE_EBX;
+        break;
+    case MAKE_WORD_INTO_INT(ECX):
+        titanIndex = UE_ECX;
+        break;
+    case MAKE_WORD_INTO_INT(EDX):
+        titanIndex = UE_EDX;
+        break;
+    case MAKE_WORD_INTO_INT(EDI):
+        titanIndex = UE_EDI;
+        break;
+    case MAKE_WORD_INTO_INT(ESI):
+        titanIndex = UE_ESI;
+        break;
+    case MAKE_WORD_INTO_INT(EBP):
+        titanIndex = UE_EBP;
+        break;
+    case MAKE_WORD_INTO_INT(ESP):
+        titanIndex = UE_ESP;
+        break;
+    case MAKE_WORD_INTO_INT(EIP):
+        titanIndex = UE_EIP;
+        break;
+    default:
+        if(scmp(string, "eflags"))
+            titanIndex = UE_EFLAGS;
+        else
+            titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, value & 0xFFFFFFFF);
+
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(CAX):
+        titanIndex = ArchValue(UE_EAX, UE_RAX);
+        break;
+    case MAKE_WORD_INTO_INT(CBX):
+        titanIndex = ArchValue(UE_EBX, UE_RBX);
+        break;
+    case MAKE_WORD_INTO_INT(CCX):
+        titanIndex = ArchValue(UE_ECX, UE_RCX);
+        break;
+    case MAKE_WORD_INTO_INT(CDX):
+        titanIndex = ArchValue(UE_EDX, UE_RDX);
+        break;
+    case MAKE_WORD_INTO_INT(CDI):
+        titanIndex = ArchValue(UE_EDI, UE_RDI);
+        break;
+    case MAKE_WORD_INTO_INT(CSI):
+        titanIndex = ArchValue(UE_ESI, UE_RSI);
+        break;
+    case MAKE_WORD_INTO_INT(CBP):
+        titanIndex = ArchValue(UE_EBP, UE_RBP);
+        break;
+    case MAKE_WORD_INTO_INT(CSP):
+        titanIndex = UE_CSP;
+        break;
+    case MAKE_WORD_INTO_INT(CIP):
+        titanIndex = UE_CIP;
+        break;
+#ifdef _WIN64
+    case MAKE_WORD_INTO_INT(RAX):
+        titanIndex = UE_RAX;
+        break;
+    case MAKE_WORD_INTO_INT(RBX):
+        titanIndex = UE_RBX;
+        break;
+    case MAKE_WORD_INTO_INT(RCX):
+        titanIndex = UE_RCX;
+        break;
+    case MAKE_WORD_INTO_INT(RDX):
+        titanIndex = UE_RDX;
+        break;
+    case MAKE_WORD_INTO_INT(RDI):
+        titanIndex = UE_RDI;
+        break;
+    case MAKE_WORD_INTO_INT(RSI):
+        titanIndex = UE_RSI;
+        break;
+    case MAKE_WORD_INTO_INT(RBP):
+        titanIndex = UE_RBP;
+        break;
+    case MAKE_WORD_INTO_INT(RSP):
+        titanIndex = UE_RSP;
+        break;
+    case MAKE_WORD_INTO_INT(RIP):
+        titanIndex = UE_RIP;
+        break;
+    case MAKE_WORD_INTO_INT(R9):
+        titanIndex = UE_R9;
+        break;
+    case MAKE_WORD_INTO_INT(R10):
+        titanIndex = UE_R10;
+        break;
+    case MAKE_WORD_INTO_INT(R11):
+        titanIndex = UE_R11;
+        break;
+    case MAKE_WORD_INTO_INT(R12):
+        titanIndex = UE_R12;
+        break;
+    case MAKE_WORD_INTO_INT(R13):
+        titanIndex = UE_R13;
+        break;
+    case MAKE_WORD_INTO_INT(R14):
+        titanIndex = UE_R14;
+        break;
+    case MAKE_WORD_INTO_INT(R15):
+        titanIndex = UE_R15;
+        break;
+#endif //_WIN64
+    default:
+        if(scmp(string, "cflags"))
+            titanIndex = UE_CFLAGS;
+#ifdef _WIN64
+        else if(scmp(string, "rflags"))
+            titanIndex = UE_RFLAGS;
+#endif //_WIN64
+        else
+            titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, value);
+
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(AX):
+        titanIndex = UE_EAX;
+        break;
+    case MAKE_WORD_INTO_INT(BX):
+        titanIndex = UE_EBX;
+        break;
+    case MAKE_WORD_INTO_INT(CX):
+        titanIndex = UE_ECX;
+        break;
+    case MAKE_WORD_INTO_INT(DX):
+        titanIndex = UE_EDX;
+        break;
+    case MAKE_WORD_INTO_INT(SI):
+        titanIndex = UE_ESI;
+        break;
+    case MAKE_WORD_INTO_INT(DI):
+        titanIndex = UE_EDI;
+        break;
+    case MAKE_WORD_INTO_INT(SP):
+        titanIndex = UE_ESP;
+        break;
+    case MAKE_WORD_INTO_INT(BP):
+        titanIndex = UE_EBP;
+        break;
+    case MAKE_WORD_INTO_INT(IP):
+        titanIndex = UE_EIP;
+        break;
+    default:
+        titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, titanIndex) & 0xFFFF0000));
+
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(AH):
+        titanIndex = UE_EAX;
+        break;
+    case MAKE_WORD_INTO_INT(BH):
+        titanIndex = UE_EBX;
+        break;
+    case MAKE_WORD_INTO_INT(CH):
+        titanIndex = UE_ECX;
+        break;
+    case MAKE_WORD_INTO_INT(DH):
+        titanIndex = UE_EDX;
+        break;
+    case MAKE_WORD_INTO_INT(SIH):
+        titanIndex = UE_ESI;
+        break;
+    case MAKE_WORD_INTO_INT(DIH):
+        titanIndex = UE_EDI;
+        break;
+    case MAKE_WORD_INTO_INT(BPH):
+        titanIndex = UE_EBP;
+        break;
+    case MAKE_WORD_INTO_INT(SPH):
+        titanIndex = UE_ESP;
+        break;
+    case MAKE_WORD_INTO_INT(IPH):
+        titanIndex = UE_EIP;
+        break;
+    default:
+        titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, titanIndex) & 0xFFFF00FF));
+
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(AL):
+        titanIndex = UE_EAX;
+        break;
+    case MAKE_WORD_INTO_INT(BL):
+        titanIndex = UE_EBX;
+        break;
+    case MAKE_WORD_INTO_INT(CL):
+        titanIndex = UE_ECX;
+        break;
+    case MAKE_WORD_INTO_INT(DL):
+        titanIndex = UE_EDX;
+        break;
+    case MAKE_WORD_INTO_INT(SIL):
+        titanIndex = UE_ESI;
+        break;
+    case MAKE_WORD_INTO_INT(DIL):
+        titanIndex = UE_EDI;
+        break;
+    case MAKE_WORD_INTO_INT(BPL):
+        titanIndex = UE_EBP;
+        break;
+    case MAKE_WORD_INTO_INT(SPL):
+        titanIndex = UE_ESP;
+        break;
+    case MAKE_WORD_INTO_INT(IPL):
+        titanIndex = UE_EIP;
+        break;
+    default:
+        titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, (value & 0xFF) | (GetContextDataEx(hActiveThread, titanIndex) & 0xFFFFFF00));
+
+#ifdef _WIN64
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(R9D):
+    case MAKE_WORD_INTO_INT(R9W):
+    case MAKE_WORD_INTO_INT(R9B):
+        titanIndex = UE_R9;
+        break;
+    case MAKE_WORD_INTO_INT(R10D):
+    case MAKE_WORD_INTO_INT(R10W):
+    case MAKE_WORD_INTO_INT(R10B):
+        titanIndex = UE_R10;
+        break;
+    case MAKE_WORD_INTO_INT(R11D):
+    case MAKE_WORD_INTO_INT(R11W):
+    case MAKE_WORD_INTO_INT(R11B):
+        titanIndex = UE_R11;
+        break;
+    case MAKE_WORD_INTO_INT(R12D):
+    case MAKE_WORD_INTO_INT(R12W):
+    case MAKE_WORD_INTO_INT(R12B):
+        titanIndex = UE_R12;
+        break;
+    case MAKE_WORD_INTO_INT(R13D):
+    case MAKE_WORD_INTO_INT(R13W):
+    case MAKE_WORD_INTO_INT(R13B):
+        titanIndex = UE_R13;
+        break;
+    case MAKE_WORD_INTO_INT(R14D):
+    case MAKE_WORD_INTO_INT(R14W):
+    case MAKE_WORD_INTO_INT(R14B):
+        titanIndex = UE_R14;
+        break;
+    case MAKE_WORD_INTO_INT(R15D):
+    case MAKE_WORD_INTO_INT(R15W):
+    case MAKE_WORD_INTO_INT(R15B):
+        titanIndex = UE_R15;
+        break;
+    default:
+        titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+    {
+        duint mask;
+        if((string_int & 0xFF0000) == 0x440000 || (string_int & 0xFF000000) == 0x44000000)  // contains D
+        {
+            mask = 0xFFFFFFFF;
+        }
+        else if((string_int & 0xFF0000) == 0x570000 || (string_int & 0xFF000000) == 0x57000000)  // contains W
+        {
+            mask = 0xFFFF;
+        }
+        else if((string_int & 0xFF0000) == 0x420000 || (string_int & 0xFF000000) == 0x42000000)  // contains B
+        {
+            mask = 0xFF;
+        }
+        else
+        {
+            return false; // not possible
+        }
+        return SetContextDataEx(hActiveThread, titanIndex, (value & mask) | (GetContextDataEx(hActiveThread, titanIndex) & ~mask));
+    }
+#endif // _WIN64
+
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(DR0):
+        titanIndex = UE_DR0;
+        break;
+    case MAKE_WORD_INTO_INT(DR1):
+        titanIndex = UE_DR1;
+        break;
+    case MAKE_WORD_INTO_INT(DR2):
+        titanIndex = UE_DR2;
+        break;
+    case MAKE_WORD_INTO_INT(DR3):
+        titanIndex = UE_DR3;
+        break;
+    case MAKE_WORD_INTO_INT(DR4):
+    case MAKE_WORD_INTO_INT(DR6):
+        titanIndex = UE_DR6;
+        break;
+    case MAKE_WORD_INTO_INT(DR5):
+    case MAKE_WORD_INTO_INT(DR7):
+        titanIndex = UE_DR7;
+        break;
+    default:
+        titanIndex = UE_XMM0;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, value);
 
     if(scmp(string, "lasterror"))
         return MemWrite((duint)GetTEBLocation(hActiveThread) + ArchValue(0x34, 0x68), &value, 4);
     if(scmp(string, "laststatus"))
         return MemWrite((duint)GetTEBLocation(hActiveThread) + ArchValue(0xBF4, 0x1250), &value, 4);
 
-    if(scmp(string, "gs"))
-        return SetContextDataEx(hActiveThread, UE_SEG_GS, value & 0xFFFF);
-    if(scmp(string, "fs"))
-        return SetContextDataEx(hActiveThread, UE_SEG_FS, value & 0xFFFF);
-    if(scmp(string, "es"))
-        return SetContextDataEx(hActiveThread, UE_SEG_ES, value & 0xFFFF);
-    if(scmp(string, "ds"))
-        return SetContextDataEx(hActiveThread, UE_SEG_DS, value & 0xFFFF);
-    if(scmp(string, "cs"))
-        return SetContextDataEx(hActiveThread, UE_SEG_CS, value & 0xFFFF);
-    if(scmp(string, "ss"))
-        return SetContextDataEx(hActiveThread, UE_SEG_SS, value & 0xFFFF);
-
-    if(scmp(string, "ax"))
-        return SetContextDataEx(hActiveThread, UE_EAX, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_EAX) & 0xFFFF0000));
-    if(scmp(string, "bx"))
-        return SetContextDataEx(hActiveThread, UE_EBX, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_EBX) & 0xFFFF0000));
-    if(scmp(string, "cx"))
-        return SetContextDataEx(hActiveThread, UE_ECX, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_ECX) & 0xFFFF0000));
-    if(scmp(string, "dx"))
-        return SetContextDataEx(hActiveThread, UE_EDX, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_EDX) & 0xFFFF0000));
-    if(scmp(string, "si"))
-        return SetContextDataEx(hActiveThread, UE_ESI, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_ESI) & 0xFFFF0000));
-    if(scmp(string, "di"))
-        return SetContextDataEx(hActiveThread, UE_EDI, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_EDI) & 0xFFFF0000));
-    if(scmp(string, "bp"))
-        return SetContextDataEx(hActiveThread, UE_EBP, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_EBP) & 0xFFFF0000));
-    if(scmp(string, "sp"))
-        return SetContextDataEx(hActiveThread, UE_ESP, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_ESP) & 0xFFFF0000));
-    if(scmp(string, "ip"))
-        return SetContextDataEx(hActiveThread, UE_EIP, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_EIP) & 0xFFFF0000));
-
-    if(scmp(string, "ah"))
-        return SetContextDataEx(hActiveThread, UE_EAX, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_EAX) & 0xFFFF00FF));
-    if(scmp(string, "al"))
-        return SetContextDataEx(hActiveThread, UE_EAX, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_EAX) & 0xFFFFFF00));
-    if(scmp(string, "bh"))
-        return SetContextDataEx(hActiveThread, UE_EBX, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_EBX) & 0xFFFF00FF));
-    if(scmp(string, "bl"))
-        return SetContextDataEx(hActiveThread, UE_EBX, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_EBX) & 0xFFFFFF00));
-    if(scmp(string, "ch"))
-        return SetContextDataEx(hActiveThread, UE_ECX, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_ECX) & 0xFFFF00FF));
-    if(scmp(string, "cl"))
-        return SetContextDataEx(hActiveThread, UE_ECX, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_ECX) & 0xFFFFFF00));
-    if(scmp(string, "dh"))
-        return SetContextDataEx(hActiveThread, UE_EDX, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_EDX) & 0xFFFF00FF));
-    if(scmp(string, "dl"))
-        return SetContextDataEx(hActiveThread, UE_EDX, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_EDX) & 0xFFFFFF00));
-    if(scmp(string, "sih"))
-        return SetContextDataEx(hActiveThread, UE_ESI, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_ESI) & 0xFFFF00FF));
-    if(scmp(string, "sil"))
-        return SetContextDataEx(hActiveThread, UE_ESI, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_ESI) & 0xFFFFFF00));
-    if(scmp(string, "dih"))
-        return SetContextDataEx(hActiveThread, UE_EDI, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_EDI) & 0xFFFF00FF));
-    if(scmp(string, "dil"))
-        return SetContextDataEx(hActiveThread, UE_EDI, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_EDI) & 0xFFFFFF00));
-    if(scmp(string, "bph"))
-        return SetContextDataEx(hActiveThread, UE_EBP, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_EBP) & 0xFFFF00FF));
-    if(scmp(string, "bpl"))
-        return SetContextDataEx(hActiveThread, UE_EBP, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_EBP) & 0xFFFFFF00));
-    if(scmp(string, "sph"))
-        return SetContextDataEx(hActiveThread, UE_ESP, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_ESP) & 0xFFFF00FF));
-    if(scmp(string, "spl"))
-        return SetContextDataEx(hActiveThread, UE_ESP, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_ESP) & 0xFFFFFF00));
-    if(scmp(string, "iph"))
-        return SetContextDataEx(hActiveThread, UE_EIP, ((value & 0xFF) << 8) | (GetContextDataEx(hActiveThread, UE_EIP) & 0xFFFF00FF));
-    if(scmp(string, "ipl"))
-        return SetContextDataEx(hActiveThread, UE_EIP, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_EIP) & 0xFFFFFF00));
-
-    if(scmp(string, "dr0"))
-        return SetContextDataEx(hActiveThread, UE_DR0, value);
-    if(scmp(string, "dr1"))
-        return SetContextDataEx(hActiveThread, UE_DR1, value);
-    if(scmp(string, "dr2"))
-        return SetContextDataEx(hActiveThread, UE_DR2, value);
-    if(scmp(string, "dr3"))
-        return SetContextDataEx(hActiveThread, UE_DR3, value);
-    if(scmp(string, "dr6") || scmp(string, "dr4"))
-        return SetContextDataEx(hActiveThread, UE_DR6, value);
-    if(scmp(string, "dr7") || scmp(string, "dr5"))
-        return SetContextDataEx(hActiveThread, UE_DR7, value);
-
-    if(scmp(string, "cax"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_EAX, UE_RAX), value);
-    if(scmp(string, "cbx"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_EBX, UE_RBX), value);
-    if(scmp(string, "ccx"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_ECX, UE_RCX), value);
-    if(scmp(string, "cdx"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_EDX, UE_RDX), value);
-    if(scmp(string, "csi"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_ESI, UE_RSI), value);
-    if(scmp(string, "cdi"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_EDI, UE_RDI), value);
-    if(scmp(string, "cip"))
-        return SetContextDataEx(hActiveThread, UE_CIP, value);
-    if(scmp(string, "csp"))
-        return SetContextDataEx(hActiveThread, UE_CSP, value);
-    if(scmp(string, "cbp"))
-        return SetContextDataEx(hActiveThread, ArchValue(UE_EBP, UE_RBP), value);
-    if(scmp(string, "cflags"))
-        return SetContextDataEx(hActiveThread, UE_CFLAGS, value);
-
-#ifdef _WIN64
-    if(scmp(string, "rax"))
-        return SetContextDataEx(hActiveThread, UE_RAX, value);
-    if(scmp(string, "rbx"))
-        return SetContextDataEx(hActiveThread, UE_RBX, value);
-    if(scmp(string, "rcx"))
-        return SetContextDataEx(hActiveThread, UE_RCX, value);
-    if(scmp(string, "rdx"))
-        return SetContextDataEx(hActiveThread, UE_RDX, value);
-    if(scmp(string, "rdi"))
-        return SetContextDataEx(hActiveThread, UE_RDI, value);
-    if(scmp(string, "rsi"))
-        return SetContextDataEx(hActiveThread, UE_RSI, value);
-    if(scmp(string, "rbp"))
-        return SetContextDataEx(hActiveThread, UE_RBP, value);
-    if(scmp(string, "rsp"))
-        return SetContextDataEx(hActiveThread, UE_RSP, value);
-    if(scmp(string, "rip"))
-        return SetContextDataEx(hActiveThread, UE_RIP, value);
-    if(scmp(string, "rflags"))
-        return SetContextDataEx(hActiveThread, UE_RFLAGS, value);
-    if(scmp(string, "r8"))
-        return SetContextDataEx(hActiveThread, UE_R8, value);
-    if(scmp(string, "r9"))
-        return SetContextDataEx(hActiveThread, UE_R9, value);
-    if(scmp(string, "r10"))
-        return SetContextDataEx(hActiveThread, UE_R10, value);
-    if(scmp(string, "r11"))
-        return SetContextDataEx(hActiveThread, UE_R11, value);
-    if(scmp(string, "r12"))
-        return SetContextDataEx(hActiveThread, UE_R12, value);
-    if(scmp(string, "r13"))
-        return SetContextDataEx(hActiveThread, UE_R13, value);
-    if(scmp(string, "r14"))
-        return SetContextDataEx(hActiveThread, UE_R14, value);
-    if(scmp(string, "r15"))
-        return SetContextDataEx(hActiveThread, UE_R15, value);
-
-    if(scmp(string, "r8d"))
-        return SetContextDataEx(hActiveThread, UE_R8, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R8) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r9d"))
-        return SetContextDataEx(hActiveThread, UE_R9, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R9) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r10d"))
-        return SetContextDataEx(hActiveThread, UE_R10, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R10) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r11d"))
-        return SetContextDataEx(hActiveThread, UE_R11, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R11) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r12d"))
-        return SetContextDataEx(hActiveThread, UE_R12, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R12) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r13d"))
-        return SetContextDataEx(hActiveThread, UE_R13, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R13) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r14d"))
-        return SetContextDataEx(hActiveThread, UE_R14, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R14) & 0xFFFFFFFF00000000));
-    if(scmp(string, "r15d"))
-        return SetContextDataEx(hActiveThread, UE_R15, (value & 0xFFFFFFFF) | (GetContextDataEx(hActiveThread, UE_R15) & 0xFFFFFFFF00000000));
-
-    if(scmp(string, "r8w"))
-        return SetContextDataEx(hActiveThread, UE_R8, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R8) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r9w"))
-        return SetContextDataEx(hActiveThread, UE_R9, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R9) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r10w"))
-        return SetContextDataEx(hActiveThread, UE_R10, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R10) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r11w"))
-        return SetContextDataEx(hActiveThread, UE_R11, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R11) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r12w"))
-        return SetContextDataEx(hActiveThread, UE_R12, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R12) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r13w"))
-        return SetContextDataEx(hActiveThread, UE_R13, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R13) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r14w"))
-        return SetContextDataEx(hActiveThread, UE_R14, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R14) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r15w"))
-        return SetContextDataEx(hActiveThread, UE_R15, (value & 0xFFFF) | (GetContextDataEx(hActiveThread, UE_R15) & 0xFFFFFFFFFFFF0000));
-    if(scmp(string, "r8b"))
-        return SetContextDataEx(hActiveThread, UE_R8, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R8) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r9b"))
-        return SetContextDataEx(hActiveThread, UE_R9, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R9) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r10b"))
-        return SetContextDataEx(hActiveThread, UE_R10, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R10) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r11b"))
-        return SetContextDataEx(hActiveThread, UE_R11, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R11) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r12b"))
-        return SetContextDataEx(hActiveThread, UE_R12, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R12) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r13b"))
-        return SetContextDataEx(hActiveThread, UE_R13, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R13) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r14b"))
-        return SetContextDataEx(hActiveThread, UE_R14, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R14) & 0xFFFFFFFFFFFFFF00));
-    if(scmp(string, "r15b"))
-        return SetContextDataEx(hActiveThread, UE_R15, (value & 0xFF) | (GetContextDataEx(hActiveThread, UE_R15) & 0xFFFFFFFFFFFFFF00));
-#endif // _WIN64
+    switch(string_int)
+    {
+    case MAKE_WORD_INTO_INT(GS):
+        titanIndex = UE_SEG_GS;
+        break;
+    case MAKE_WORD_INTO_INT(FS):
+        titanIndex = UE_SEG_FS;
+        break;
+    case MAKE_WORD_INTO_INT(ES):
+        titanIndex = UE_SEG_ES;
+        break;
+    case MAKE_WORD_INTO_INT(DS):
+        titanIndex = UE_SEG_DS;
+        break;
+    case MAKE_WORD_INTO_INT(CS):
+        titanIndex = UE_SEG_CS;
+        break;
+    case MAKE_WORD_INTO_INT(SS):
+        titanIndex = UE_SEG_SS;
+        break;
+    }
+    if(titanIndex != UE_XMM0)
+        return SetContextDataEx(hActiveThread, titanIndex, value & 0xFFFF);
 
     return false;
 }
@@ -1476,6 +1616,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             *isvar = true;
         break;
     }
+    int len = (int)strlen(string);
     if(string[0] == '['
             || (isdigitduint(string[0]) && string[1] == ':' && string[2] == '[')
             || (string[1] == 's' && (string[0] == 'c' || string[0] == 'd' || string[0] == 'e' || string[0] == 'f' || string[0] == 'g' || string[0] == 's') && string[2] == ':' && string[3] == '[') //memory location
@@ -1492,19 +1633,18 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
                 *value_size = 0;
             return true;
         }
-        int len = (int)strlen(string);
 
         int read_size = sizeof(duint);
         int prefix_size = 1;
         size_t seg_offset = 0;
-        if(string[1] == ':') //n:[ (number of bytes to read)
+        if(len > 3 && string[1] == ':') //n:[ (number of bytes to read)
         {
             prefix_size = 3;
             int new_size = string[0] - '0';
             if(new_size < read_size)
                 read_size = new_size;
         }
-        else if(string[1] == 's' && string[2] == ':')
+        else if(len > 4 && string[1] == 's' && string[2] == ':')
         {
             prefix_size = 4;
             if(string[0] == 'f') // fs:[...]
@@ -1525,7 +1665,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
 #endif //_WIN64
             }
         }
-        else if(string[0] == 'b'
+        else if(len > 6 && string[0] == 'b'
                 && string[1] == 'y'
                 && string[2] == 't'
                 && string[3] == 'e'
@@ -1537,7 +1677,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             if(new_size < read_size)
                 read_size = new_size;
         }
-        else if(string[0] == 'w'
+        else if(len > 6 && string[0] == 'w'
                 && string[1] == 'o'
                 && string[2] == 'r'
                 && string[3] == 'd'
@@ -1549,7 +1689,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
             if(new_size < read_size)
                 read_size = new_size;
         }
-        else if(string[0] == 'd'
+        else if(len > 7 && string[0] == 'd'
                 && string[1] == 'w'
                 && string[2] == 'o'
                 && string[3] == 'r'
@@ -1563,7 +1703,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
                 read_size = new_size;
         }
 #ifdef _WIN64
-        else if(string[0] == 'q'
+        else if(len > 7 && string[0] == 'q'
                 && string[1] == 'w'
                 && string[2] == 'o'
                 && string[3] == 'r'
@@ -1628,7 +1768,7 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
         *value = getregister(value_size, string);
         return true;
     }
-    else if(*string == '_' && isflag(string + 1)) //flag
+    else if(len > 1 && *string == '_' && isflag(string + 1)) //flag
     {
         if(!DbgIsDebugging())
         {
@@ -1676,13 +1816,9 @@ bool valfromstring_noexpr(const char* string, duint* value, bool silent, bool ba
         return true;
     else if(SymAddrFromName(string, value)) //then come symbols
         return true;
-    else if(strstr(string, "sub_") == string) //then come sub_ functions
+    else if(len > 4 && string[0] == 's' && string[1] == 'u' && string[2] == 'b' && string[3] == '_') //then come sub_ functions
     {
-#ifdef _WIN64
-        bool result = sscanf_s(string, "sub_%llX", value) == 1;
-#else //x86
-        bool result = sscanf_s(string, "sub_%X", value) == 1;
-#endif //_WIN64
+        bool result = convertNumber(string + 4, *value, 16);
         duint start;
         return result && FunctionGet(*value, &start, nullptr) && *value == start;
     }

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -39,6 +39,38 @@ void valuesetsignedcalc(bool a)
     dosignedcalc = a;
 }
 
+// Macro for converting a static identifier with no more than 4 characters into an uppercased int for efficient comparison
+#define MAKE_WORD_INTO_INT(word) (#word[1]==0 ? #word[0] : (#word[2]==0 ? (#word[0]|(#word[1]<<8)) : (#word[3]==0 ? (#word[0]|(#word[1]<<8)|(#word[2]<<16)) : (#word[4]==0 ? (#word[0]|(#word[1]<<8)|(#word[2]<<16)|(#word[3]<<24)) : 0))))
+
+/**
+\brief Convert a string with no more than 4 characters into an uppercased int for efficient comparison
+*/
+int read_string_4char_ucase(const char* string)
+{
+    int a = 0;
+    char x = 'a' - 'A';
+    if(string[0] != '\0')
+        a = (string[0] >= 'a' && string[0] <= 'z' ? string[0] - x : string[0]);
+    else
+        return a;
+    if(string[1] != '\0')
+        a |= (string[1] >= 'a' && string[1] <= 'z' ? string[1] - x : string[1]) << 8;
+    else
+        return a;
+    if(string[2] != '\0')
+        a |= (string[2] >= 'a' && string[2] <= 'z' ? string[2] - x : string[2]) << 16;
+    else
+        return a;
+    if(string[3] != '\0')
+        a |= (string[3] >= 'a' && string[3] <= 'z' ? string[3] - x : string[3]) << 24;
+    else
+        return a;
+    if(string[4] != '\0')  // overflow
+        return 0;
+    else
+        return a;
+}
+
 /**
 \brief Check if a string is a flag.
 \param string The string to check.
@@ -46,37 +78,27 @@ void valuesetsignedcalc(bool a)
 */
 static bool isflag(const char* string)
 {
-    if(scmp(string, "cf"))
+    switch(read_string_4char_ucase(string))
+    {
+    case MAKE_WORD_INTO_INT(CF):
+    case MAKE_WORD_INTO_INT(PF):
+    case MAKE_WORD_INTO_INT(AF):
+    case MAKE_WORD_INTO_INT(ZF):
+    case MAKE_WORD_INTO_INT(SF):
+    case MAKE_WORD_INTO_INT(TF):
+    case MAKE_WORD_INTO_INT(IF):
+    case MAKE_WORD_INTO_INT(DF):
+    case MAKE_WORD_INTO_INT(OF):
+    case MAKE_WORD_INTO_INT(RF):
+    case MAKE_WORD_INTO_INT(VM):
+    case MAKE_WORD_INTO_INT(AC):
+    case MAKE_WORD_INTO_INT(VIF):
+    case MAKE_WORD_INTO_INT(VIP):
+    case MAKE_WORD_INTO_INT(ID):
         return true;
-    if(scmp(string, "pf"))
-        return true;
-    if(scmp(string, "af"))
-        return true;
-    if(scmp(string, "zf"))
-        return true;
-    if(scmp(string, "sf"))
-        return true;
-    if(scmp(string, "tf"))
-        return true;
-    if(scmp(string, "if"))
-        return true;
-    if(scmp(string, "df"))
-        return true;
-    if(scmp(string, "of"))
-        return true;
-    if(scmp(string, "rf"))
-        return true;
-    if(scmp(string, "vm"))
-        return true;
-    if(scmp(string, "ac"))
-        return true;
-    if(scmp(string, "vif"))
-        return true;
-    if(scmp(string, "vip"))
-        return true;
-    if(scmp(string, "id"))
-        return true;
-    return false;
+    default:
+        return false;
+    }
 }
 
 /**
@@ -86,223 +108,126 @@ static bool isflag(const char* string)
 */
 static bool isregister(const char* string)
 {
-    if(scmp(string, "eax"))
-        return true;
-    if(scmp(string, "ebx"))
-        return true;
-    if(scmp(string, "ecx"))
-        return true;
-    if(scmp(string, "edx"))
-        return true;
-    if(scmp(string, "edi"))
-        return true;
-    if(scmp(string, "esi"))
-        return true;
-    if(scmp(string, "ebp"))
-        return true;
-    if(scmp(string, "esp"))
-        return true;
-    if(scmp(string, "eip"))
-        return true;
-    if(scmp(string, "eflags"))
-        return true;
-
-    if(scmp(string, "ax"))
-        return true;
-    if(scmp(string, "bx"))
-        return true;
-    if(scmp(string, "cx"))
-        return true;
-    if(scmp(string, "dx"))
-        return true;
-    if(scmp(string, "si"))
-        return true;
-    if(scmp(string, "di"))
-        return true;
-    if(scmp(string, "bp"))
-        return true;
-    if(scmp(string, "sp"))
-        return true;
-    if(scmp(string, "ip"))
-        return true;
-
-    if(scmp(string, "ah"))
-        return true;
-    if(scmp(string, "al"))
-        return true;
-    if(scmp(string, "bh"))
-        return true;
-    if(scmp(string, "bl"))
-        return true;
-    if(scmp(string, "ch"))
-        return true;
-    if(scmp(string, "cl"))
-        return true;
-    if(scmp(string, "dh"))
-        return true;
-    if(scmp(string, "dl"))
-        return true;
-    if(scmp(string, "sih"))
-        return true;
-    if(scmp(string, "sil"))
-        return true;
-    if(scmp(string, "dih"))
-        return true;
-    if(scmp(string, "dil"))
-        return true;
-    if(scmp(string, "bph"))
-        return true;
-    if(scmp(string, "bpl"))
-        return true;
-    if(scmp(string, "sph"))
-        return true;
-    if(scmp(string, "spl"))
-        return true;
-    if(scmp(string, "iph"))
-        return true;
-    if(scmp(string, "ipl"))
-        return true;
-
-    if(scmp(string, "dr0"))
-        return true;
-    if(scmp(string, "dr1"))
-        return true;
-    if(scmp(string, "dr2"))
-        return true;
-    if(scmp(string, "dr3"))
-        return true;
-    if(scmp(string, "dr6") || scmp(string, "dr4"))
-        return true;
-    if(scmp(string, "dr7") || scmp(string, "dr5"))
-        return true;
-
-    if(scmp(string, "cax"))
-        return true;
-    if(scmp(string, "cbx"))
-        return true;
-    if(scmp(string, "ccx"))
-        return true;
-    if(scmp(string, "cdx"))
-        return true;
-    if(scmp(string, "csi"))
-        return true;
-    if(scmp(string, "cdi"))
-        return true;
-    if(scmp(string, "cip"))
-        return true;
-    if(scmp(string, "csp"))
-        return true;
-    if(scmp(string, "cbp"))
-        return true;
-    if(scmp(string, "cflags"))
-        return true;
-
-    if(scmp(string, "lasterror"))
-        return true;
-    if(scmp(string, "laststatus"))
-        return true;
-
-    if(scmp(string, "gs"))
-        return true;
-    if(scmp(string, "fs"))
-        return true;
-    if(scmp(string, "es"))
-        return true;
-    if(scmp(string, "ds"))
-        return true;
-    if(scmp(string, "cs"))
-        return true;
-    if(scmp(string, "ss"))
-        return true;
-
-#ifndef _WIN64
-    return false;
-#endif // _WIN64
-    if(scmp(string, "rax"))
-        return true;
-    if(scmp(string, "rbx"))
-        return true;
-    if(scmp(string, "rcx"))
-        return true;
-    if(scmp(string, "rdx"))
-        return true;
-    if(scmp(string, "rdi"))
-        return true;
-    if(scmp(string, "rsi"))
-        return true;
-    if(scmp(string, "rbp"))
-        return true;
-    if(scmp(string, "rsp"))
-        return true;
-    if(scmp(string, "rip"))
-        return true;
-    if(scmp(string, "rflags"))
-        return true;
-    if(scmp(string, "r8"))
-        return true;
-    if(scmp(string, "r9"))
-        return true;
-    if(scmp(string, "r10"))
-        return true;
-    if(scmp(string, "r11"))
-        return true;
-    if(scmp(string, "r12"))
-        return true;
-    if(scmp(string, "r13"))
-        return true;
-    if(scmp(string, "r14"))
-        return true;
-    if(scmp(string, "r15"))
-        return true;
-    if(scmp(string, "r8d"))
-        return true;
-    if(scmp(string, "r9d"))
-        return true;
-    if(scmp(string, "r10d"))
-        return true;
-    if(scmp(string, "r11d"))
-        return true;
-    if(scmp(string, "r12d"))
-        return true;
-    if(scmp(string, "r13d"))
-        return true;
-    if(scmp(string, "r14d"))
-        return true;
-    if(scmp(string, "r15d"))
-        return true;
-    if(scmp(string, "r8w"))
-        return true;
-    if(scmp(string, "r9w"))
-        return true;
-    if(scmp(string, "r10w"))
-        return true;
-    if(scmp(string, "r11w"))
-        return true;
-    if(scmp(string, "r12w"))
-        return true;
-    if(scmp(string, "r13w"))
-        return true;
-    if(scmp(string, "r14w"))
-        return true;
-    if(scmp(string, "r15w"))
-        return true;
-    if(scmp(string, "r8b"))
-        return true;
-    if(scmp(string, "r9b"))
-        return true;
-    if(scmp(string, "r10b"))
-        return true;
-    if(scmp(string, "r11b"))
-        return true;
-    if(scmp(string, "r12b"))
-        return true;
-    if(scmp(string, "r13b"))
-        return true;
-    if(scmp(string, "r14b"))
-        return true;
-    if(scmp(string, "r15b"))
-        return true;
-    return false;
+    switch(read_string_4char_ucase(string))
+    {
+    case MAKE_WORD_INTO_INT(EAX):
+    case MAKE_WORD_INTO_INT(EBX):
+    case MAKE_WORD_INTO_INT(ECX):
+    case MAKE_WORD_INTO_INT(EDX):
+    case MAKE_WORD_INTO_INT(EDI):
+    case MAKE_WORD_INTO_INT(ESI):
+    case MAKE_WORD_INTO_INT(EBP):
+    case MAKE_WORD_INTO_INT(ESP):
+    case MAKE_WORD_INTO_INT(EIP):
+    case MAKE_WORD_INTO_INT(AX):
+    case MAKE_WORD_INTO_INT(BX):
+    case MAKE_WORD_INTO_INT(CX):
+    case MAKE_WORD_INTO_INT(DX):
+    case MAKE_WORD_INTO_INT(SI):
+    case MAKE_WORD_INTO_INT(DI):
+    case MAKE_WORD_INTO_INT(BP):
+    case MAKE_WORD_INTO_INT(SP):
+    case MAKE_WORD_INTO_INT(IP):
+    case MAKE_WORD_INTO_INT(AH):
+    case MAKE_WORD_INTO_INT(AL):
+    case MAKE_WORD_INTO_INT(BH):
+    case MAKE_WORD_INTO_INT(BL):
+    case MAKE_WORD_INTO_INT(CH):
+    case MAKE_WORD_INTO_INT(CL):
+    case MAKE_WORD_INTO_INT(DH):
+    case MAKE_WORD_INTO_INT(DL):
+    case MAKE_WORD_INTO_INT(SIH):
+    case MAKE_WORD_INTO_INT(SIL):
+    case MAKE_WORD_INTO_INT(DIH):
+    case MAKE_WORD_INTO_INT(DIL):
+    case MAKE_WORD_INTO_INT(BPH):
+    case MAKE_WORD_INTO_INT(BPL):
+    case MAKE_WORD_INTO_INT(SPH):
+    case MAKE_WORD_INTO_INT(SPL):
+    case MAKE_WORD_INTO_INT(IPH):
+    case MAKE_WORD_INTO_INT(IPL):
+    case MAKE_WORD_INTO_INT(DR0):
+    case MAKE_WORD_INTO_INT(DR1):
+    case MAKE_WORD_INTO_INT(DR2):
+    case MAKE_WORD_INTO_INT(DR3):
+    case MAKE_WORD_INTO_INT(DR6):
+    case MAKE_WORD_INTO_INT(DR4):
+    case MAKE_WORD_INTO_INT(DR7):
+    case MAKE_WORD_INTO_INT(DR5):
+    case MAKE_WORD_INTO_INT(CAX):
+    case MAKE_WORD_INTO_INT(CBX):
+    case MAKE_WORD_INTO_INT(CCX):
+    case MAKE_WORD_INTO_INT(CDX):
+    case MAKE_WORD_INTO_INT(CSI):
+    case MAKE_WORD_INTO_INT(CDI):
+    case MAKE_WORD_INTO_INT(CIP):
+    case MAKE_WORD_INTO_INT(CSP):
+    case MAKE_WORD_INTO_INT(CBP):
+    case MAKE_WORD_INTO_INT(GS):
+    case MAKE_WORD_INTO_INT(FS):
+    case MAKE_WORD_INTO_INT(ES):
+    case MAKE_WORD_INTO_INT(DS):
+    case MAKE_WORD_INTO_INT(CS):
+    case MAKE_WORD_INTO_INT(SS):
+#ifdef _WIN64
+    case MAKE_WORD_INTO_INT(RAX):
+    case MAKE_WORD_INTO_INT(RBX):
+    case MAKE_WORD_INTO_INT(RCX):
+    case MAKE_WORD_INTO_INT(RDX):
+    case MAKE_WORD_INTO_INT(RDI):
+    case MAKE_WORD_INTO_INT(RSI):
+    case MAKE_WORD_INTO_INT(RBP):
+    case MAKE_WORD_INTO_INT(RSP):
+    case MAKE_WORD_INTO_INT(RIP):
+    case MAKE_WORD_INTO_INT(R8):
+    case MAKE_WORD_INTO_INT(R9):
+    case MAKE_WORD_INTO_INT(R10):
+    case MAKE_WORD_INTO_INT(R11):
+    case MAKE_WORD_INTO_INT(R12):
+    case MAKE_WORD_INTO_INT(R13):
+    case MAKE_WORD_INTO_INT(R14):
+    case MAKE_WORD_INTO_INT(R15):
+    case MAKE_WORD_INTO_INT(R8D):
+    case MAKE_WORD_INTO_INT(R9D):
+    case MAKE_WORD_INTO_INT(R10D):
+    case MAKE_WORD_INTO_INT(R11D):
+    case MAKE_WORD_INTO_INT(R12D):
+    case MAKE_WORD_INTO_INT(R13D):
+    case MAKE_WORD_INTO_INT(R14D):
+    case MAKE_WORD_INTO_INT(R15D):
+    case MAKE_WORD_INTO_INT(R8W):
+    case MAKE_WORD_INTO_INT(R9W):
+    case MAKE_WORD_INTO_INT(R10W):
+    case MAKE_WORD_INTO_INT(R11W):
+    case MAKE_WORD_INTO_INT(R12W):
+    case MAKE_WORD_INTO_INT(R13W):
+    case MAKE_WORD_INTO_INT(R14W):
+    case MAKE_WORD_INTO_INT(R15W):
+    case MAKE_WORD_INTO_INT(R8B):
+    case MAKE_WORD_INTO_INT(R9B):
+    case MAKE_WORD_INTO_INT(R10B):
+    case MAKE_WORD_INTO_INT(R11B):
+    case MAKE_WORD_INTO_INT(R12B):
+    case MAKE_WORD_INTO_INT(R13B):
+    case MAKE_WORD_INTO_INT(R14B):
+    case MAKE_WORD_INTO_INT(R15B):
+#endif //_WIN64
+        return true;
+    default:
+        if(scmp(string, "eflags"))
+            return true;
+        if(scmp(string, "cflags"))
+            return true;
+        if(scmp(string, "lasterror"))
+            return true;
+        if(scmp(string, "laststatus"))
+            return true;
+#ifdef _WIN64
+        if(scmp(string, "rflags"))
+            return true;
+#endif //_WIN64
+        return false;
+    };
 }
 
 #define MXCSRFLAG_IE 0x1
@@ -320,14 +245,7 @@ static bool isregister(const char* string)
 #define MXCSRFLAG_PM 0x1000
 #define MXCSRFLAG_FZ 0x8000
 
-typedef struct
-{
-    const char* name;
-    unsigned int flag;
-
-} FLAG_NAME_VALUE_TABLE_t;
-
-#define MXCSR_NAME_FLAG_TABLE_ENTRY(flag_name) { #flag_name, MXCSRFLAG_##flag_name }
+#define MXCSR_NAME_FLAG_TABLE_ENTRY(flag_name) case MAKE_WORD_INTO_INT(#flag_name): return MXCSRFLAG_##flag_name;
 
 /**
 \brief Gets the MXCSR flag AND value from a string.
@@ -336,31 +254,25 @@ typedef struct
 */
 static unsigned int getmxcsrflagfromstring(const char* string)
 {
-    static FLAG_NAME_VALUE_TABLE_t mxcsrnameflagtable[] =
+    switch(read_string_4char_ucase(string))
     {
-        MXCSR_NAME_FLAG_TABLE_ENTRY(IE),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(DE),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(ZE),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(OE),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(UE),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(PE),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(DAZ),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(IM),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(DM),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(ZM),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(OM),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(UM),
-        MXCSR_NAME_FLAG_TABLE_ENTRY(PM),
+        MXCSR_NAME_FLAG_TABLE_ENTRY(IE)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(DE)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(ZE)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(OE)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(UE)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(PE)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(DAZ)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(IM)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(DM)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(ZM)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(OM)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(UM)
+        MXCSR_NAME_FLAG_TABLE_ENTRY(PM)
         MXCSR_NAME_FLAG_TABLE_ENTRY(FZ)
-    };
-
-    for(int i = 0; i < (sizeof(mxcsrnameflagtable) / sizeof(*mxcsrnameflagtable)); i++)
-    {
-        if(scmp(string, mxcsrnameflagtable[i].name))
-            return mxcsrnameflagtable[i].flag;
+    default:
+        return 0;
     }
-
-    return 0;
 }
 
 /**
@@ -392,7 +304,7 @@ bool valmxcsrflagfromstring(duint mxcsrflags, const char* string)
 #define x87STATUSWORD_FLAG_C3 0x4000
 #define x87STATUSWORD_FLAG_B 0x8000
 
-#define X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(flag_name) { #flag_name, x87STATUSWORD_FLAG_##flag_name }
+#define X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(flag_name) case MAKE_WORD_INTO_INT(#flag_name): return x87STATUSWORD_FLAG_##flag_name;
 
 /**
 \brief Gets the x87 status word AND value from a string.
@@ -401,30 +313,24 @@ bool valmxcsrflagfromstring(duint mxcsrflags, const char* string)
 */
 static unsigned int getx87statuswordflagfromstring(const char* string)
 {
-    static FLAG_NAME_VALUE_TABLE_t statuswordflagtable[] =
+    switch(read_string_4char_ucase(string))
     {
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(I),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(D),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(Z),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(O),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(U),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(P),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(SF),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(ES),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C0),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C1),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C2),
-        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C3),
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(I)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(D)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(Z)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(O)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(U)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(P)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(SF)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(ES)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C0)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C1)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C2)
+        X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(C3)
         X87STATUSWORD_NAME_FLAG_TABLE_ENTRY(B)
-    };
-
-    for(int i = 0; i < (sizeof(statuswordflagtable) / sizeof(*statuswordflagtable)); i++)
-    {
-        if(scmp(string, statuswordflagtable[i].name))
-            return statuswordflagtable[i].flag;
+    default:
+        return 0;
     }
-
-    return 0;
 }
 
 /**
@@ -451,7 +357,7 @@ bool valx87statuswordflagfromstring(duint statusword, const char* string)
 #define x87CONTROLWORD_FLAG_IEM 0x80
 #define x87CONTROLWORD_FLAG_IC 0x1000
 
-#define X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(flag_name) { #flag_name, x87CONTROLWORD_FLAG_##flag_name }
+#define X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(flag_name) case MAKE_WORD_INTO_INT(#flag_name): return x87CONTROLWORD_FLAG_##flag_name;
 
 /**
 \brief Gets the x87 control word flag AND value from a string.
@@ -460,25 +366,19 @@ bool valx87statuswordflagfromstring(duint statusword, const char* string)
 */
 static unsigned int getx87controlwordflagfromstring(const char* string)
 {
-    static FLAG_NAME_VALUE_TABLE_t controlwordflagtable[] =
+    switch(read_string_4char_ucase(string))
     {
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(IM),
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(DM),
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(ZM),
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(OM),
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(UM),
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(PM),
-        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(IEM),
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(IM)
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(DM)
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(ZM)
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(OM)
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(UM)
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(PM)
+        X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(IEM)
         X87CONTROLWORD_NAME_FLAG_TABLE_ENTRY(IC)
-    };
-
-    for(int i = 0; i < (sizeof(controlwordflagtable) / sizeof(*controlwordflagtable)); i++)
-    {
-        if(scmp(string, controlwordflagtable[i].name))
-            return controlwordflagtable[i].flag;
+    default:
+        return 0;
     }
-
-    return 0;
 }
 
 /**
@@ -521,7 +421,6 @@ unsigned short valx87statuswordfieldfromstring(duint statusword, const char* str
 {
     if(scmp(string, "TOP"))
         return ((statusword & 0x3800) >> 11);
-
     return 0;
 }
 
@@ -533,12 +432,15 @@ unsigned short valx87statuswordfieldfromstring(duint statusword, const char* str
 */
 unsigned short valx87controlwordfieldfromstring(duint controlword, const char* string)
 {
-    if(scmp(string, "PC"))
+    switch(read_string_4char_ucase(string))
+    {
+    case MAKE_WORD_INTO_INT(PC):
         return ((controlword & 0x300) >> 8);
-    if(scmp(string, "RC"))
+    case MAKE_WORD_INTO_INT(RC):
         return ((controlword & 0xC00) >> 10);
-
-    return 0;
+    default:
+        return 0;
+    }
 }
 
 /**
@@ -549,37 +451,41 @@ unsigned short valx87controlwordfieldfromstring(duint controlword, const char* s
 */
 bool valflagfromstring(duint eflags, const char* string)
 {
-    if(scmp(string, "cf"))
+    switch(read_string_4char_ucase(string))
+    {
+    case MAKE_WORD_INTO_INT(CF):
         return (bool)((int)(eflags & 0x1) != 0);
-    if(scmp(string, "pf"))
+    case MAKE_WORD_INTO_INT(PF):
         return (bool)((int)(eflags & 0x4) != 0);
-    if(scmp(string, "af"))
+    case MAKE_WORD_INTO_INT(AF):
         return (bool)((int)(eflags & 0x10) != 0);
-    if(scmp(string, "zf"))
+    case MAKE_WORD_INTO_INT(ZF):
         return (bool)((int)(eflags & 0x40) != 0);
-    if(scmp(string, "sf"))
+    case MAKE_WORD_INTO_INT(SF):
         return (bool)((int)(eflags & 0x80) != 0);
-    if(scmp(string, "tf"))
+    case MAKE_WORD_INTO_INT(TF):
         return (bool)((int)(eflags & 0x100) != 0);
-    if(scmp(string, "if"))
+    case MAKE_WORD_INTO_INT(IF):
         return (bool)((int)(eflags & 0x200) != 0);
-    if(scmp(string, "df"))
+    case MAKE_WORD_INTO_INT(DF):
         return (bool)((int)(eflags & 0x400) != 0);
-    if(scmp(string, "of"))
+    case MAKE_WORD_INTO_INT(OF):
         return (bool)((int)(eflags & 0x800) != 0);
-    if(scmp(string, "rf"))
+    case MAKE_WORD_INTO_INT(RF):
         return (bool)((int)(eflags & 0x10000) != 0);
-    if(scmp(string, "vm"))
+    case MAKE_WORD_INTO_INT(VM):
         return (bool)((int)(eflags & 0x20000) != 0);
-    if(scmp(string, "ac"))
+    case MAKE_WORD_INTO_INT(AC):
         return (bool)((int)(eflags & 0x40000) != 0);
-    if(scmp(string, "vif"))
+    case MAKE_WORD_INTO_INT(VIF):
         return (bool)((int)(eflags & 0x80000) != 0);
-    if(scmp(string, "vip"))
+    case MAKE_WORD_INTO_INT(VIP):
         return (bool)((int)(eflags & 0x100000) != 0);
-    if(scmp(string, "id"))
+    case MAKE_WORD_INTO_INT(ID):
         return (bool)((int)(eflags & 0x200000) != 0);
-    return false;
+    default:
+        return false;
+    }
 }
 
 /**
@@ -590,39 +496,58 @@ bool valflagfromstring(duint eflags, const char* string)
 */
 bool setflag(const char* string, bool set)
 {
-    duint eflags = GetContextDataEx(hActiveThread, UE_CFLAGS);
-    duint xorval = 0;
     duint flag = 0;
-    if(scmp(string, "cf"))
+    switch(read_string_4char_ucase(string))
+    {
+    case MAKE_WORD_INTO_INT(CF):
         flag = 0x1;
-    else if(scmp(string, "pf"))
+        break;
+    case MAKE_WORD_INTO_INT(PF):
         flag = 0x4;
-    else if(scmp(string, "af"))
+        break;
+    case MAKE_WORD_INTO_INT(AF):
         flag = 0x10;
-    else if(scmp(string, "zf"))
+        break;
+    case MAKE_WORD_INTO_INT(ZF):
         flag = 0x40;
-    else if(scmp(string, "sf"))
+        break;
+    case MAKE_WORD_INTO_INT(SF):
         flag = 0x80;
-    else if(scmp(string, "tf"))
+        break;
+    case MAKE_WORD_INTO_INT(TF):
         flag = 0x100;
-    else if(scmp(string, "if"))
+        break;
+    case MAKE_WORD_INTO_INT(IF):
         flag = 0x200;
-    else if(scmp(string, "df"))
+        break;
+    case MAKE_WORD_INTO_INT(DF):
         flag = 0x400;
-    else if(scmp(string, "of"))
+        break;
+    case MAKE_WORD_INTO_INT(OF):
         flag = 0x800;
-    else if(scmp(string, "rf"))
+        break;
+    case MAKE_WORD_INTO_INT(RF):
         flag = 0x10000;
-    else if(scmp(string, "vm"))
+        break;
+    case MAKE_WORD_INTO_INT(VM):
         flag = 0x20000;
-    else if(scmp(string, "ac"))
+        break;
+    case MAKE_WORD_INTO_INT(AC):
         flag = 0x40000;
-    else if(scmp(string, "vif"))
+        break;
+    case MAKE_WORD_INTO_INT(VIF):
         flag = 0x80000;
-    else if(scmp(string, "vip"))
+        break;
+    case MAKE_WORD_INTO_INT(VIP):
         flag = 0x100000;
-    else if(scmp(string, "id"))
+        break;
+    case MAKE_WORD_INTO_INT(ID):
         flag = 0x200000;
+        break;
+    default:
+        return false;
+    }
+    duint eflags = GetContextDataEx(hActiveThread, UE_CFLAGS);
     if(set)
         eflags |= flag;
     else
@@ -640,71 +565,63 @@ duint getregister(int* size, const char* string)
 {
     if(size)
         *size = 4;
-    if(scmp(string, "eax"))
+    TitanRegister TitanIndex = UE_XMM0; // Tian register index with UE_XMM0 as invalid marker
+    int string_int = read_string_4char_ucase(string);
+    switch(string_int)
     {
-        return GetContextDataEx(hActiveThread, UE_EAX);
+    case MAKE_WORD_INTO_INT(EAX):
+        TitanIndex = UE_EAX;
+        break;
+    case MAKE_WORD_INTO_INT(EBX):
+        TitanIndex = UE_EBX;
+        break;
+    case MAKE_WORD_INTO_INT(ECX):
+        TitanIndex = UE_ECX;
+        break;
+    case MAKE_WORD_INTO_INT(EDX):
+        TitanIndex = UE_EDX;
+        break;
+    case MAKE_WORD_INTO_INT(EDI):
+        TitanIndex = UE_EDI;
+        break;
+    case MAKE_WORD_INTO_INT(ESI):
+        TitanIndex = UE_ESI;
+        break;
+    case MAKE_WORD_INTO_INT(EBP):
+        TitanIndex = UE_EBP;
+        break;
+    case MAKE_WORD_INTO_INT(ESP):
+        TitanIndex = UE_ESP;
+        break;
+    case MAKE_WORD_INTO_INT(EIP):
+        TitanIndex = UE_EIP;
+        break;
+    case MAKE_WORD_INTO_INT(GS):
+        TitanIndex = UE_SEG_GS;
+        break;
+    case MAKE_WORD_INTO_INT(FS):
+        TitanIndex = UE_SEG_FS;
+        break;
+    case MAKE_WORD_INTO_INT(ES):
+        TitanIndex = UE_SEG_ES;
+        break;
+    case MAKE_WORD_INTO_INT(DS):
+        TitanIndex = UE_SEG_DS;
+        break;
+    case MAKE_WORD_INTO_INT(CS):
+        TitanIndex = UE_SEG_CS;
+        break;
+    case MAKE_WORD_INTO_INT(SS):
+        TitanIndex = UE_SEG_SS;
+        break;
+    default:
+        if(scmp(string, "eflags"))
+            TitanIndex = UE_EFLAGS;
+        else
+            TitanIndex = UE_XMM0;  // Invalid marker
     }
-    if(scmp(string, "ebx"))
-    {
-        return GetContextDataEx(hActiveThread, UE_EBX);
-    }
-    if(scmp(string, "ecx"))
-    {
-        return GetContextDataEx(hActiveThread, UE_ECX);
-    }
-    if(scmp(string, "edx"))
-    {
-        return GetContextDataEx(hActiveThread, UE_EDX);
-    }
-    if(scmp(string, "edi"))
-    {
-        return GetContextDataEx(hActiveThread, UE_EDI);
-    }
-    if(scmp(string, "esi"))
-    {
-        return GetContextDataEx(hActiveThread, UE_ESI);
-    }
-    if(scmp(string, "ebp"))
-    {
-        return GetContextDataEx(hActiveThread, UE_EBP);
-    }
-    if(scmp(string, "esp"))
-    {
-        return GetContextDataEx(hActiveThread, UE_ESP);
-    }
-    if(scmp(string, "eip"))
-    {
-        return GetContextDataEx(hActiveThread, UE_EIP);
-    }
-    if(scmp(string, "eflags"))
-    {
-        return GetContextDataEx(hActiveThread, UE_EFLAGS);
-    }
-
-    if(scmp(string, "gs"))
-    {
-        return GetContextDataEx(hActiveThread, UE_SEG_GS);
-    }
-    if(scmp(string, "fs"))
-    {
-        return GetContextDataEx(hActiveThread, UE_SEG_FS);
-    }
-    if(scmp(string, "es"))
-    {
-        return GetContextDataEx(hActiveThread, UE_SEG_ES);
-    }
-    if(scmp(string, "ds"))
-    {
-        return GetContextDataEx(hActiveThread, UE_SEG_DS);
-    }
-    if(scmp(string, "cs"))
-    {
-        return GetContextDataEx(hActiveThread, UE_SEG_CS);
-    }
-    if(scmp(string, "ss"))
-    {
-        return GetContextDataEx(hActiveThread, UE_SEG_SS);
-    }
+    if(TitanIndex != UE_XMM0)
+        return GetContextDataEx(hActiveThread, TitanIndex);
 
     if(scmp(string, "lasterror"))
     {
@@ -722,391 +639,319 @@ duint getregister(int* size, const char* string)
 
     if(size)
         *size = 2;
-    if(scmp(string, "ax"))
+    switch(string_int)
     {
-        duint val = GetContextDataEx(hActiveThread, UE_EAX);
-        return val & 0xFFFF;
+    case MAKE_WORD_INTO_INT(AX):
+        TitanIndex = UE_EAX;
+        break;
+    case MAKE_WORD_INTO_INT(BX):
+        TitanIndex = UE_EBX;
+        break;
+    case MAKE_WORD_INTO_INT(CX):
+        TitanIndex = UE_ECX;
+        break;
+    case MAKE_WORD_INTO_INT(DX):
+        TitanIndex = UE_EDX;
+        break;
+    case MAKE_WORD_INTO_INT(SI):
+        TitanIndex = UE_ESI;
+        break;
+    case MAKE_WORD_INTO_INT(DI):
+        TitanIndex = UE_EDI;
+        break;
+    case MAKE_WORD_INTO_INT(BP):
+        TitanIndex = UE_EBP;
+        break;
+    case MAKE_WORD_INTO_INT(SP):
+        TitanIndex = UE_ESP;
+        break;
+    case MAKE_WORD_INTO_INT(IP):
+        TitanIndex = UE_EIP;
+        break;
+    default:
+        TitanIndex = UE_XMM0; // Invalid marker
     }
-    if(scmp(string, "bx"))
+    if(TitanIndex != UE_XMM0)
     {
-        duint val = GetContextDataEx(hActiveThread, UE_EBX);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "cx"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ECX);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "dx"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EDX);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "si"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ESI);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "di"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EDI);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "bp"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EBP);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "sp"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ESP);
-        return val & 0xFFFF;
-    }
-    if(scmp(string, "ip"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EIP);
-        return val & 0xFFFF;
+        return GetContextDataEx(hActiveThread, TitanIndex) & 0xFFFF;
     }
 
     if(size)
         *size = 1;
-    if(scmp(string, "ah"))
+    switch(string_int)
     {
-        duint val = GetContextDataEx(hActiveThread, UE_EAX);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "al"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EAX);
-        return val & 0xFF;
-    }
-    if(scmp(string, "bh"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EBX);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "bl"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EBX);
-        return val & 0xFF;
-    }
-    if(scmp(string, "ch"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ECX);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "cl"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ECX);
-        return val & 0xFF;
-    }
-    if(scmp(string, "dh"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EDX);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "dl"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EDX);
-        return val & 0xFF;
-    }
-    if(scmp(string, "sih"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ESI);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "sil"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ESI);
-        return val & 0xFF;
-    }
-    if(scmp(string, "dih"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EDI);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "dil"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EDI);
-        return val & 0xFF;
-    }
-    if(scmp(string, "bph"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EBP);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "bpl"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EBP);
-        return val & 0xFF;
-    }
-    if(scmp(string, "sph"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ESP);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "spl"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_ESP);
-        return val & 0xFF;
-    }
-    if(scmp(string, "iph"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EIP);
-        return (val >> 8) & 0xFF;
-    }
-    if(scmp(string, "ipl"))
-    {
-        duint val = GetContextDataEx(hActiveThread, UE_EIP);
-        return val & 0xFF;
+    case MAKE_WORD_INTO_INT(AH):
+        return (GetContextDataEx(hActiveThread, UE_EAX) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(AL):
+        return GetContextDataEx(hActiveThread, UE_EAX) & 0xFF;
+    case MAKE_WORD_INTO_INT(BH):
+        return (GetContextDataEx(hActiveThread, UE_EBX) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(BL):
+        return GetContextDataEx(hActiveThread, UE_EBX) & 0xFF;
+    case MAKE_WORD_INTO_INT(CH):
+        return (GetContextDataEx(hActiveThread, UE_ECX) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(CL):
+        return GetContextDataEx(hActiveThread, UE_ECX) & 0xFF;
+    case MAKE_WORD_INTO_INT(DH):
+        return (GetContextDataEx(hActiveThread, UE_EDX) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(DL):
+        return GetContextDataEx(hActiveThread, UE_EDX) & 0xFF;
+    case MAKE_WORD_INTO_INT(SIH):
+        return (GetContextDataEx(hActiveThread, UE_ESI) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(SIL):
+        return GetContextDataEx(hActiveThread, UE_ESI) & 0xFF;
+    case MAKE_WORD_INTO_INT(DIH):
+        return (GetContextDataEx(hActiveThread, UE_EDI) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(DIL):
+        return GetContextDataEx(hActiveThread, UE_EDI) & 0xFF;
+    case MAKE_WORD_INTO_INT(BPH):
+        return (GetContextDataEx(hActiveThread, UE_EBP) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(BPL):
+        return GetContextDataEx(hActiveThread, UE_EBP) & 0xFF;
+    case MAKE_WORD_INTO_INT(SPH):
+        return (GetContextDataEx(hActiveThread, UE_ESP) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(SPL):
+        return GetContextDataEx(hActiveThread, UE_ESP) & 0xFF;
+    case MAKE_WORD_INTO_INT(IPH):
+        return (GetContextDataEx(hActiveThread, UE_EIP) >> 8) & 0xFF;
+    case MAKE_WORD_INTO_INT(IPL):
+        return GetContextDataEx(hActiveThread, UE_EIP) & 0xFF;
     }
 
     if(size)
         *size = sizeof(duint);
-    if(scmp(string, "dr0"))
+    switch(string_int)
     {
-        return GetContextDataEx(hActiveThread, UE_DR0);
+    case MAKE_WORD_INTO_INT(DR0):
+        TitanIndex = UE_DR0;
+        break;
+    case MAKE_WORD_INTO_INT(DR1):
+        TitanIndex = UE_DR1;
+        break;
+    case MAKE_WORD_INTO_INT(DR2):
+        TitanIndex = UE_DR2;
+        break;
+    case MAKE_WORD_INTO_INT(DR3):
+        TitanIndex = UE_DR3;
+        break;
+    case MAKE_WORD_INTO_INT(DR4):
+    case MAKE_WORD_INTO_INT(DR6):
+        TitanIndex = UE_DR6;
+        break;
+    case MAKE_WORD_INTO_INT(DR5):
+    case MAKE_WORD_INTO_INT(DR7):
+        TitanIndex = UE_DR7;
+        break;
+    case MAKE_WORD_INTO_INT(CAX):
+        TitanIndex = ArchValue(UE_EAX, UE_RAX);
+        break;
+    case MAKE_WORD_INTO_INT(CBX):
+        TitanIndex = ArchValue(UE_EBX, UE_RBX);
+        break;
+    case MAKE_WORD_INTO_INT(CCX):
+        TitanIndex = ArchValue(UE_ECX, UE_RCX);
+        break;
+    case MAKE_WORD_INTO_INT(CDX):
+        TitanIndex = ArchValue(UE_EDX, UE_RDX);
+        break;
+    case MAKE_WORD_INTO_INT(CSI):
+        TitanIndex = ArchValue(UE_ESI, UE_RSI);
+        break;
+    case MAKE_WORD_INTO_INT(CDI):
+        TitanIndex = ArchValue(UE_EDI, UE_RDI);
+        break;
+    case MAKE_WORD_INTO_INT(CIP):
+        TitanIndex = UE_CIP;
+        break;
+    case MAKE_WORD_INTO_INT(CSP):
+        TitanIndex = UE_CSP;
+        break;
+    case MAKE_WORD_INTO_INT(CBP):
+        TitanIndex = ArchValue(UE_EBP, UE_RBP);
+        break;
+    default:
+        if(scmp(string, "cflags"))
+            TitanIndex = UE_CFLAGS;
+        else
+            TitanIndex = UE_XMM0; // Invalid marker
     }
-    if(scmp(string, "dr1"))
+    if(TitanIndex != UE_XMM0)
     {
-        return GetContextDataEx(hActiveThread, UE_DR1);
-    }
-    if(scmp(string, "dr2"))
-    {
-        return GetContextDataEx(hActiveThread, UE_DR2);
-    }
-    if(scmp(string, "dr3"))
-    {
-        return GetContextDataEx(hActiveThread, UE_DR3);
-    }
-    if(scmp(string, "dr6") || scmp(string, "dr4"))
-    {
-        return GetContextDataEx(hActiveThread, UE_DR6);
-    }
-    if(scmp(string, "dr7") || scmp(string, "dr5"))
-    {
-        return GetContextDataEx(hActiveThread, UE_DR7);
-    }
-    if(scmp(string, "cax"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_EAX, UE_RAX));
-    }
-    if(scmp(string, "cbx"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_EBX, UE_RBX));
-    }
-    if(scmp(string, "ccx"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_ECX, UE_RCX));
-    }
-    if(scmp(string, "cdx"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_EDX, UE_RDX));
-    }
-    if(scmp(string, "csi"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_ESI, UE_RSI));
-    }
-    if(scmp(string, "cdi"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_EDI, UE_RDI));
-    }
-    if(scmp(string, "cip"))
-    {
-        return GetContextDataEx(hActiveThread, UE_CIP);
-    }
-    if(scmp(string, "csp"))
-    {
-        return GetContextDataEx(hActiveThread, UE_CSP);
-    }
-    if(scmp(string, "cbp"))
-    {
-        return GetContextDataEx(hActiveThread, ArchValue(UE_EBP, UE_RBP));
-    }
-    if(scmp(string, "cflags"))
-    {
-        return GetContextDataEx(hActiveThread, UE_CFLAGS);
+        return GetContextDataEx(hActiveThread, TitanIndex);
     }
 
 #ifdef _WIN64
     if(size)
         *size = 8;
-    if(scmp(string, "rax"))
+    switch(string_int)
     {
-        return GetContextDataEx(hActiveThread, UE_RAX);
+    case MAKE_WORD_INTO_INT(RAX):
+        TitanIndex = UE_RAX;
+        break;
+    case MAKE_WORD_INTO_INT(RBX):
+        TitanIndex = UE_RBX;
+        break;
+    case MAKE_WORD_INTO_INT(RCX):
+        TitanIndex = UE_RCX;
+        break;
+    case MAKE_WORD_INTO_INT(RDX):
+        TitanIndex = UE_RDX;
+        break;
+    case MAKE_WORD_INTO_INT(RDI):
+        TitanIndex = UE_RDI;
+        break;
+    case MAKE_WORD_INTO_INT(RSI):
+        TitanIndex = UE_RSI;
+        break;
+    case MAKE_WORD_INTO_INT(RBP):
+        TitanIndex = UE_RBP;
+        break;
+    case MAKE_WORD_INTO_INT(RSP):
+        TitanIndex = UE_RSP;
+        break;
+    case MAKE_WORD_INTO_INT(RIP):
+        TitanIndex = UE_RIP;
+        break;
+    case MAKE_WORD_INTO_INT(R8):
+        TitanIndex = UE_R8;
+        break;
+    case MAKE_WORD_INTO_INT(R9):
+        TitanIndex = UE_R9;
+        break;
+    case MAKE_WORD_INTO_INT(R10):
+        TitanIndex = UE_R10;
+        break;
+    case MAKE_WORD_INTO_INT(R11):
+        TitanIndex = UE_R11;
+        break;
+    case MAKE_WORD_INTO_INT(R12):
+        TitanIndex = UE_R12;
+        break;
+    case MAKE_WORD_INTO_INT(R13):
+        TitanIndex = UE_R13;
+        break;
+    case MAKE_WORD_INTO_INT(R14):
+        TitanIndex = UE_R14;
+        break;
+    case MAKE_WORD_INTO_INT(R15):
+        TitanIndex = UE_R15;
+        break;
+    default:
+        if(scmp(string, "rflags"))
+            TitanIndex = UE_RFLAGS;
+        else
+            TitanIndex = UE_XMM0; // Invalid marker
+        break;
     }
-    if(scmp(string, "rbx"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RBX);
-    }
-    if(scmp(string, "rcx"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RCX);
-    }
-    if(scmp(string, "rdx"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RDX);
-    }
-    if(scmp(string, "rdi"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RDI);
-    }
-    if(scmp(string, "rsi"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RSI);
-    }
-    if(scmp(string, "rbp"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RBP);
-    }
-    if(scmp(string, "rsp"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RSP);
-    }
-    if(scmp(string, "rip"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RIP);
-    }
-    if(scmp(string, "rflags"))
-    {
-        return GetContextDataEx(hActiveThread, UE_RFLAGS);
-    }
-    if(scmp(string, "r8"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R8);
-    }
-    if(scmp(string, "r9"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R9);
-    }
-    if(scmp(string, "r10"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R10);
-    }
-    if(scmp(string, "r11"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R11);
-    }
-    if(scmp(string, "r12"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R12);
-    }
-    if(scmp(string, "r13"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R13);
-    }
-    if(scmp(string, "r14"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R14);
-    }
-    if(scmp(string, "r15"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R15);
-    }
+    if(TitanIndex != UE_XMM0)
+        return GetContextDataEx(hActiveThread, TitanIndex);
 
     if(size)
         *size = 4;
-    if(scmp(string, "r8d"))
+    switch(string_int)
     {
-        return GetContextDataEx(hActiveThread, UE_R8) & 0xFFFFFFFF;
+    case MAKE_WORD_INTO_INT(R8D):
+        TitanIndex = UE_R8;
+        break;
+    case MAKE_WORD_INTO_INT(R9D):
+        TitanIndex = UE_R9;
+        break;
+    case MAKE_WORD_INTO_INT(R10D):
+        TitanIndex = UE_R10;
+        break;
+    case MAKE_WORD_INTO_INT(R11D):
+        TitanIndex = UE_R11;
+        break;
+    case MAKE_WORD_INTO_INT(R12D):
+        TitanIndex = UE_R12;
+        break;
+    case MAKE_WORD_INTO_INT(R13D):
+        TitanIndex = UE_R13;
+        break;
+    case MAKE_WORD_INTO_INT(R14D):
+        TitanIndex = UE_R14;
+        break;
+    case MAKE_WORD_INTO_INT(R15D):
+        TitanIndex = UE_R15;
+        break;
+    default:
+        TitanIndex = UE_XMM0;
     }
-    if(scmp(string, "r9d"))
+    if(TitanIndex != UE_XMM0)
     {
-        return GetContextDataEx(hActiveThread, UE_R9) & 0xFFFFFFFF;
-    }
-    if(scmp(string, "r10d"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R10) & 0xFFFFFFFF;
-    }
-    if(scmp(string, "r11d"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R11) & 0xFFFFFFFF;
-    }
-    if(scmp(string, "r12d"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R12) & 0xFFFFFFFF;
-    }
-    if(scmp(string, "r13d"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R13) & 0xFFFFFFFF;
-    }
-    if(scmp(string, "r14d"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R14) & 0xFFFFFFFF;
-    }
-    if(scmp(string, "r15d"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R15) & 0xFFFFFFFF;
+        return GetContextDataEx(hActiveThread, TitanIndex) & 0xFFFFFFFF;
     }
 
     if(size)
         *size = 2;
-    if(scmp(string, "r8w"))
+    switch(string_int)
     {
-        return GetContextDataEx(hActiveThread, UE_R8) & 0xFFFF;
+    case MAKE_WORD_INTO_INT(R8W):
+        TitanIndex = UE_R8;
+        break;
+    case MAKE_WORD_INTO_INT(R9W):
+        TitanIndex = UE_R9;
+        break;
+    case MAKE_WORD_INTO_INT(R10W):
+        TitanIndex = UE_R10;
+        break;
+    case MAKE_WORD_INTO_INT(R11W):
+        TitanIndex = UE_R11;
+        break;
+    case MAKE_WORD_INTO_INT(R12W):
+        TitanIndex = UE_R12;
+        break;
+    case MAKE_WORD_INTO_INT(R13W):
+        TitanIndex = UE_R13;
+        break;
+    case MAKE_WORD_INTO_INT(R14W):
+        TitanIndex = UE_R14;
+        break;
+    case MAKE_WORD_INTO_INT(R15W):
+        TitanIndex = UE_R15;
+        break;
+    default:
+        TitanIndex = UE_XMM0;
     }
-    if(scmp(string, "r9w"))
+    if(TitanIndex != UE_XMM0)
     {
-        return GetContextDataEx(hActiveThread, UE_R9) & 0xFFFF;
-    }
-    if(scmp(string, "r10w"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R10) & 0xFFFF;
-    }
-    if(scmp(string, "r11w"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R11) & 0xFFFF;
-    }
-    if(scmp(string, "r12w"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R12) & 0xFFFF;
-    }
-    if(scmp(string, "r13w"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R13) & 0xFFFF;
-    }
-    if(scmp(string, "r14w"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R14) & 0xFFFF;
-    }
-    if(scmp(string, "r15w"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R15) & 0xFFFF;
+        return GetContextDataEx(hActiveThread, TitanIndex) & 0xFFFF;
     }
 
     if(size)
         *size = 1;
-    if(scmp(string, "r8b"))
+    switch(string_int)
     {
-        return GetContextDataEx(hActiveThread, UE_R8) & 0xFF;
+    case MAKE_WORD_INTO_INT(R8B):
+        TitanIndex = UE_R8;
+        break;
+    case MAKE_WORD_INTO_INT(R9B):
+        TitanIndex = UE_R9;
+        break;
+    case MAKE_WORD_INTO_INT(R10B):
+        TitanIndex = UE_R10;
+        break;
+    case MAKE_WORD_INTO_INT(R11B):
+        TitanIndex = UE_R11;
+        break;
+    case MAKE_WORD_INTO_INT(R12B):
+        TitanIndex = UE_R12;
+        break;
+    case MAKE_WORD_INTO_INT(R13B):
+        TitanIndex = UE_R13;
+        break;
+    case MAKE_WORD_INTO_INT(R14B):
+        TitanIndex = UE_R14;
+        break;
+    case MAKE_WORD_INTO_INT(R15B):
+        TitanIndex = UE_R15;
+        break;
+    default:
+        TitanIndex = UE_XMM0;
     }
-    if(scmp(string, "r9b"))
+    if(TitanIndex != UE_XMM0)
     {
-        return GetContextDataEx(hActiveThread, UE_R9) & 0xFF;
-    }
-    if(scmp(string, "r10b"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R10) & 0xFF;
-    }
-    if(scmp(string, "r11b"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R11) & 0xFF;
-    }
-    if(scmp(string, "r12b"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R12) & 0xFF;
-    }
-    if(scmp(string, "r13b"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R13) & 0xFF;
-    }
-    if(scmp(string, "r14b"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R14) & 0xFF;
-    }
-    if(scmp(string, "r15b"))
-    {
-        return GetContextDataEx(hActiveThread, UE_R15) & 0xFF;
+        return GetContextDataEx(hActiveThread, TitanIndex) & 0xFF;
     }
 #endif //_WIN64
 

--- a/src/dbg/value.h
+++ b/src/dbg/value.h
@@ -9,6 +9,7 @@ void valuesetsignedcalc(bool a);
 bool valapifromstring(const char* name, duint* value, bool silent);
 bool convertNumber(const char* str, duint & result, int radix);
 bool convertLongLongNumber(const char* str, unsigned long long & result, int radix);
+int valfromstring_noexpr_isvar(const char* string);
 bool valfromstring_noexpr(const char* string, duint* value, bool silent = true, bool baseonly = false, int* value_size = nullptr, bool* isvar = nullptr, bool* hexonly = nullptr);
 bool valfromstring(const char* string, duint* value, bool silent = true, bool baseonly = false, int* value_size = nullptr, bool* isvar = nullptr, bool* hexonly = nullptr, bool allowassign = false);
 bool valflagfromstring(duint eflags, const char* string);


### PR DESCRIPTION
There wasn't an optimization in place for evaluating constants `0` and `1` in tracing, like conditional breakpoints. This patch added an optimized path for constant evaluation. This leads to about 10% more events per second in tracing but more testing is needed.