### PR TITLE
Fix UI and crash issues in TraceFileReader when parsing trace files containing user-defined blocks.

### DIFF
--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -457,14 +457,11 @@ void TraceFileParser::readFileHeader(TraceFileReader* that)
     }
 }
 
-static bool readBlock(QFile & traceFile)
+static bool readBlock(QFile & traceFile, unsigned char blockType)
 {
     if(!traceFile.isReadable())
         throw std::wstring(L"File is not readable");
-    unsigned char blockType;
     unsigned char changedCountFlags[3]; //reg changed count, mem accessed count, flags
-    if(traceFile.read((char*)&blockType, 1) != 1)
-        throw std::wstring(L"Read block type failed");
     if(blockType == 0)
     {
         if(traceFile.read((char*)&changedCountFlags, 3) != 3)
@@ -525,7 +522,10 @@ void TraceFileParser::run()
         while(!that->traceFile.atEnd())
         {
             quint64 blockStart = that->traceFile.pos();
-            bool isPageBoundary = readBlock(that->traceFile);
+            unsigned char blockType;
+            if(that->traceFile.read((char*)&blockType, 1) != 1)
+                throw std::wstring(L"Read block type failed");
+            bool isPageBoundary = readBlock(that->traceFile, blockType);
             if(isPageBoundary)
             {
                 if(lastIndex != 0)
@@ -539,7 +539,9 @@ void TraceFileParser::run()
                 if(this->isInterruptionRequested() && !that->traceFile.atEnd()) //Cancel loading
                     throw std::wstring(L"Canceled");
             }
-            index++;
+            //Increase the index only if the block is an instruction block(0), not a user-defined block(0x80 or higher)
+            if(blockType == 0)
+                index++;
         }
         if(index > 0)
             that->fileIndex.back().second.second = index - (lastIndex - 1);
@@ -591,7 +593,10 @@ void TraceFileReader::purgeLastPage()
         while(!traceFile.atEnd())
         {
             quint64 blockStart = traceFile.pos();
-            bool isPageBoundary = readBlock(traceFile);
+            unsigned char blockType;
+            if(traceFile.read((char*)&blockType, 1) != 1)
+                throw std::wstring(L"Read block type failed");
+            bool isPageBoundary = readBlock(traceFile, blockType);
             if(isPageBoundary)
             {
                 if(lastIndex != 0)
@@ -600,7 +605,9 @@ void TraceFileReader::purgeLastPage()
                 lastIndex = index + 1;
                 isBlockExist = true;
             }
-            index++;
+            //Increase the index only if the block is an instruction block(0), not a user-defined block(0x80 or higher)
+            if(blockType == 0)
+                index++;
         }
         if(isBlockExist)
             fileIndex.back().second.second = index - (lastIndex - 1);

--- a/src/gui/Src/Tracer/TraceFileReader.cpp
+++ b/src/gui/Src/Tracer/TraceFileReader.cpp
@@ -526,22 +526,23 @@ void TraceFileParser::run()
             if(that->traceFile.read((char*)&blockType, 1) != 1)
                 throw std::wstring(L"Read block type failed");
             bool isPageBoundary = readBlock(that->traceFile, blockType);
-            if(isPageBoundary)
+            if(blockType < 0x80) //Check whether it is a non-user block
             {
-                if(lastIndex != 0)
-                    that->fileIndex.back().second.second = index - (lastIndex - 1);
-                that->fileIndex.push_back(std::make_pair(index, TraceFileReader::Range(blockStart, 0)));
-                lastIndex = index + 1;
-                //Update progress
-                that->progress.store(that->traceFile.pos() * 100 / filesize);
-                if(that->progress == 100)
-                    that->progress = 99;
-                if(this->isInterruptionRequested() && !that->traceFile.atEnd()) //Cancel loading
-                    throw std::wstring(L"Canceled");
-            }
-            //Increase the index only if the block is an instruction block(0), not a user-defined block(0x80 or higher)
-            if(blockType == 0)
+                if(isPageBoundary)
+                {
+                    if(lastIndex != 0)
+                        that->fileIndex.back().second.second = index - (lastIndex - 1);
+                    that->fileIndex.push_back(std::make_pair(index, TraceFileReader::Range(blockStart, 0)));
+                    lastIndex = index + 1;
+                    //Update progress
+                    that->progress.store(that->traceFile.pos() * 100 / filesize);
+                    if(that->progress == 100)
+                        that->progress = 99;
+                    if(this->isInterruptionRequested() && !that->traceFile.atEnd()) //Cancel loading
+                        throw std::wstring(L"Canceled");
+                }
                 index++;
+            }
         }
         if(index > 0)
             that->fileIndex.back().second.second = index - (lastIndex - 1);
@@ -597,17 +598,18 @@ void TraceFileReader::purgeLastPage()
             if(traceFile.read((char*)&blockType, 1) != 1)
                 throw std::wstring(L"Read block type failed");
             bool isPageBoundary = readBlock(traceFile, blockType);
-            if(isPageBoundary)
+            if(blockType < 0x80) //Check whether it is a non-user block
             {
-                if(lastIndex != 0)
-                    fileIndex.back().second.second = index - (lastIndex - 1);
-                fileIndex.push_back(std::make_pair(index, TraceFileReader::Range(blockStart, 0)));
-                lastIndex = index + 1;
-                isBlockExist = true;
-            }
-            //Increase the index only if the block is an instruction block(0), not a user-defined block(0x80 or higher)
-            if(blockType == 0)
+                if(isPageBoundary)
+                {
+                    if(lastIndex != 0)
+                        fileIndex.back().second.second = index - (lastIndex - 1);
+                    fileIndex.push_back(std::make_pair(index, TraceFileReader::Range(blockStart, 0)));
+                    lastIndex = index + 1;
+                    isBlockExist = true;
+                }
                 index++;
+            }
         }
         if(isBlockExist)
             fileIndex.back().second.second = index - (lastIndex - 1);


### PR DESCRIPTION
TraceFileReader may cause UI display anomalies and application crashes when parsing trace files with user-defined blocks due to incorrect index updates.

<img width="1469" height="1034" alt="image" src="https://github.com/user-attachments/assets/ae70cdff-1ca7-4569-af66-041865261143" />


Based on investigation, the issue lies in index updates. Before incrementing the index after calling readBlock(), the current block must be checked: only increment the index if the block is an instruction block; do not increment for user-defined blocks.