### PR TITLE
Update btparser submodule to cross-platform branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,10 @@ set(btparser_SOURCES
 	"src/dbg/btparser/btparser/lexer.cpp"
 	"src/dbg/btparser/btparser/lexer.h"
 	"src/dbg/btparser/btparser/operators.h"
-	"src/dbg/btparser/btparser/parser.cpp"
-	"src/dbg/btparser/btparser/parser.h"
+	"src/dbg/btparser/btparser/preprocessor.cpp"
 	"src/dbg/btparser/btparser/testfiles.h"
+	"src/dbg/btparser/btparser/types.cpp"
+	"src/dbg/btparser/btparser/typesparser.cpp"
 )
 
 add_library(btparser STATIC)

--- a/cmake.toml
+++ b/cmake.toml
@@ -49,13 +49,14 @@ x64.OUTPUT_NAME = "x64bridge"
 type = "static"
 sources = [
     "src/dbg/btparser/btparser/lexer.cpp",
-    "src/dbg/btparser/btparser/parser.cpp",
+    "src/dbg/btparser/btparser/preprocessor.cpp",
+    "src/dbg/btparser/btparser/types.cpp",
+    "src/dbg/btparser/btparser/typesparser.cpp",
     "src/dbg/btparser/btparser/ast.h",
     "src/dbg/btparser/btparser/helpers.h",
     "src/dbg/btparser/btparser/keywords.h",
     "src/dbg/btparser/btparser/lexer.h",
     "src/dbg/btparser/btparser/operators.h",
-    "src/dbg/btparser/btparser/parser.h",
     "src/dbg/btparser/btparser/testfiles.h",
 ]
 include-directories = [


### PR DESCRIPTION
- Fixes C4477 format string warning (sprintf_s %d vs size_t)

- Submodule: src/dbg/btparser

- Commit: 6daea14 -> da5f499 (origin/cross-platform)

- Resolves: Compiler warning at btparser/lexer.cpp:92

- Benefits: Cross-platform compatibility improvements

- Updated cmake.toml to match new btparser file structure

Validated:

- Build succeeds with 0 warnings (was 1)

- btparser and dbg libraries compile and link successfully

- Replaced parser.cpp with preprocessor.cpp, types.cpp, typesparser.cpp