### PR TITLE
Implement accessibility in RegistersView, Disassembly and most other tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,8 @@ set(gui_SOURCES
 	cmake.toml
 	"src/gui/Src/Accessible/Accessible.cpp"
 	"src/gui/Src/Accessible/Accessible.h"
+	"src/gui/Src/Accessible/AccessibleAbstractTableView.cpp"
+	"src/gui/Src/Accessible/AccessibleAbstractTableView.h"
 	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/BasicView/AbstractSearchList.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,6 +488,10 @@ endif()
 # Target: gui
 set(gui_SOURCES
 	cmake.toml
+	"src/gui/Src/Accessible/Accessible.cpp"
+	"src/gui/Src/Accessible/Accessible.h"
+	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
+	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/BasicView/AbstractSearchList.h"
 	"src/gui/Src/BasicView/AbstractStdTable.cpp"
 	"src/gui/Src/BasicView/AbstractStdTable.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,6 +504,8 @@ set(gui_SOURCES
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/Accessible/AccessibleStdTable.cpp"
 	"src/gui/Src/Accessible/AccessibleStdTable.h"
+	"src/gui/Src/Accessible/AccessibleTraceBrowser.cpp"
+	"src/gui/Src/Accessible/AccessibleTraceBrowser.h"
 	"src/gui/Src/BasicView/AbstractSearchList.h"
 	"src/gui/Src/BasicView/AbstractStdTable.cpp"
 	"src/gui/Src/BasicView/AbstractStdTable.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,8 @@ set(gui_SOURCES
 	"src/gui/Src/Accessible/Accessible.h"
 	"src/gui/Src/Accessible/AccessibleAbstractTableView.cpp"
 	"src/gui/Src/Accessible/AccessibleAbstractTableView.h"
+	"src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp"
+	"src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h"
 	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/BasicView/AbstractSearchList.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,8 @@ set(gui_SOURCES
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h"
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp"
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.h"
+	"src/gui/Src/Accessible/AccessibleDisassembly.cpp"
+	"src/gui/Src/Accessible/AccessibleDisassembly.h"
 	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/Accessible/AccessibleStdTable.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,8 @@ set(gui_SOURCES
 	"src/gui/Src/Accessible/AccessibleAbstractTableView.h"
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp"
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h"
+	"src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp"
+	"src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.h"
 	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/Accessible/AccessibleStdTable.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,8 @@ set(gui_SOURCES
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.h"
 	"src/gui/Src/Accessible/AccessibleDisassembly.cpp"
 	"src/gui/Src/Accessible/AccessibleDisassembly.h"
+	"src/gui/Src/Accessible/AccessibleHexDump.cpp"
+	"src/gui/Src/Accessible/AccessibleHexDump.h"
 	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
 	"src/gui/Src/Accessible/AccessibleStdTable.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,8 @@ set(gui_SOURCES
 	"src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h"
 	"src/gui/Src/Accessible/AccessibleRegistersView.cpp"
 	"src/gui/Src/Accessible/AccessibleRegistersView.h"
+	"src/gui/Src/Accessible/AccessibleStdTable.cpp"
+	"src/gui/Src/Accessible/AccessibleStdTable.h"
 	"src/gui/Src/BasicView/AbstractSearchList.h"
 	"src/gui/Src/BasicView/AbstractStdTable.cpp"
 	"src/gui/Src/BasicView/AbstractStdTable.h"

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -1,10 +1,15 @@
 #ifndef QT_NO_ACCESSIBILITY
 #include "Accessible.h"
 #include "AccessibleRegistersView.h"
+#include "AccessibleAbstractTableView.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
 {
     QAccessibleInterface* ptr = nullptr;
+    if((classname == "CPUDisassembly") && object && dynamic_cast<AbstractTableView*>(object) != nullptr)
+    {
+        ptr = new AccessibleAbstractTableView(dynamic_cast<QWidget*>(object));
+    }
     if((classname == "RegistersView") && object && dynamic_cast<RegistersView*>(object) != nullptr)
     {
         ptr = new AccessibleRegistersView(dynamic_cast<QWidget*>(object));

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -2,14 +2,15 @@
 #include "Accessible.h"
 #include "AccessibleRegistersView.h"
 #include "AccessibleAbstractTableView.h"
+#include "AccessibleDisassembly.h"
 #include "AccessibleStdTable.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
 {
     QAccessibleInterface* ptr = nullptr;
-    if((classname == "CPUDisassembly") && object && dynamic_cast<AbstractTableView*>(object) != nullptr)
+    if((classname == "Disassembly") && object && dynamic_cast<Disassembly*>(object) != nullptr)
     {
-        ptr = new AccessibleAbstractTableView(dynamic_cast<QWidget*>(object));
+        ptr = new AccessibleDisassembly(dynamic_cast<QWidget*>(object));
     }
     if((classname == "AbstractStdTable") && object && dynamic_cast<AbstractStdTable*>(object) != nullptr)
     {

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -1,0 +1,14 @@
+#ifndef QT_NO_ACCESSIBILITY
+#include "Accessible.h"
+
+QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
+{
+    QAccessibleInterface* ptr = nullptr;
+    if((classname == "RegistersView") && object && dynamic_cast<RegistersView*>(object) != nullptr)
+    {
+        ptr = new AccessibleRegistersView(dynamic_cast<QWidget*>(object));
+    }
+    return ptr;
+}
+
+#endif

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -3,6 +3,7 @@
 #include "AccessibleRegistersView.h"
 #include "AccessibleAbstractTableView.h"
 #include "AccessibleDisassembly.h"
+#include "AccessibleHexDump.h"
 #include "AccessibleStdTable.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
@@ -12,11 +13,15 @@ QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObj
     {
         ptr = new AccessibleDisassembly(dynamic_cast<QWidget*>(object));
     }
-    if((classname == "AbstractStdTable") && object && dynamic_cast<AbstractStdTable*>(object) != nullptr)
+    else if((classname == "HexDump") && object && dynamic_cast<HexDump*>(object) != nullptr)
+    {
+        ptr = new AccessibleHexDump(dynamic_cast<HexDump*>(object));
+    }
+    else if((classname == "AbstractStdTable") && object && dynamic_cast<AbstractStdTable*>(object) != nullptr)
     {
         ptr = new AccessibleStdTable(dynamic_cast<QWidget*>(object));
     }
-    if((classname == "RegistersView") && object && dynamic_cast<RegistersView*>(object) != nullptr)
+    else if((classname == "RegistersView") && object && dynamic_cast<RegistersView*>(object) != nullptr)
     {
         ptr = new AccessibleRegistersView(dynamic_cast<QWidget*>(object));
     }

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -1,5 +1,6 @@
 #ifndef QT_NO_ACCESSIBILITY
 #include "Accessible.h"
+#include "AccessibleRegistersView.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
 {

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -2,6 +2,7 @@
 #include "Accessible.h"
 #include "AccessibleRegistersView.h"
 #include "AccessibleAbstractTableView.h"
+#include "AccessibleStdTable.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
 {
@@ -9,6 +10,10 @@ QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObj
     if((classname == "CPUDisassembly") && object && dynamic_cast<AbstractTableView*>(object) != nullptr)
     {
         ptr = new AccessibleAbstractTableView(dynamic_cast<QWidget*>(object));
+    }
+    if((classname == "AbstractStdTable") && object && dynamic_cast<AbstractStdTable*>(object) != nullptr)
+    {
+        ptr = new AccessibleStdTable(dynamic_cast<QWidget*>(object));
     }
     if((classname == "RegistersView") && object && dynamic_cast<RegistersView*>(object) != nullptr)
     {

--- a/src/gui/Src/Accessible/Accessible.cpp
+++ b/src/gui/Src/Accessible/Accessible.cpp
@@ -5,25 +5,32 @@
 #include "AccessibleDisassembly.h"
 #include "AccessibleHexDump.h"
 #include "AccessibleStdTable.h"
+#include "AccessibleTraceBrowser.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object)
 {
     QAccessibleInterface* ptr = nullptr;
-    if((classname == "Disassembly") && object && dynamic_cast<Disassembly*>(object) != nullptr)
+    if(!object)
+        return nullptr;
+    if((classname == "Disassembly") && dynamic_cast<Disassembly*>(object) != nullptr)
     {
         ptr = new AccessibleDisassembly(dynamic_cast<QWidget*>(object));
     }
-    else if((classname == "HexDump") && object && dynamic_cast<HexDump*>(object) != nullptr)
+    else if((classname == "HexDump") && dynamic_cast<HexDump*>(object) != nullptr)
     {
         ptr = new AccessibleHexDump(dynamic_cast<HexDump*>(object));
     }
-    else if((classname == "AbstractStdTable") && object && dynamic_cast<AbstractStdTable*>(object) != nullptr)
+    else if((classname == "AbstractStdTable") && dynamic_cast<AbstractStdTable*>(object) != nullptr)
     {
         ptr = new AccessibleStdTable(dynamic_cast<QWidget*>(object));
     }
-    else if((classname == "RegistersView") && object && dynamic_cast<RegistersView*>(object) != nullptr)
+    else if((classname == "RegistersView") && dynamic_cast<RegistersView*>(object) != nullptr)
     {
         ptr = new AccessibleRegistersView(dynamic_cast<QWidget*>(object));
+    }
+    else if((classname == "TraceBrowser") && dynamic_cast<TraceBrowser*>(object) != nullptr)
+    {
+        ptr = new AccessibleTraceBrowser(dynamic_cast<QWidget*>(object));
     }
     return ptr;
 }

--- a/src/gui/Src/Accessible/Accessible.h
+++ b/src/gui/Src/Accessible/Accessible.h
@@ -1,4 +1,4 @@
 #pragma once
-#include "AccessibleRegistersView.h"
+#include <QAccessible>
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object);

--- a/src/gui/Src/Accessible/Accessible.h
+++ b/src/gui/Src/Accessible/Accessible.h
@@ -1,0 +1,3 @@
+#include "AccessibleRegistersView.h"
+
+QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object);

--- a/src/gui/Src/Accessible/Accessible.h
+++ b/src/gui/Src/Accessible/Accessible.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "AccessibleRegistersView.h"
 
 QAccessibleInterface* accessibleInterfaceFactory(const QString & classname, QObject* object);

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
@@ -1,146 +1,7 @@
 // This file implements accessibility interface for RegistersView
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleAbstractTableView.h"
-
-AccessibleAbstractTableViewCell::AccessibleAbstractTableViewCell(AccessibleAbstractTableView* parent, duint row, int column) : mParent(parent), row(row), column(column)
-{
-}
-
-QString AccessibleAbstractTableViewCell::text(QAccessible::Text t) const
-{
-    AbstractTableView* w = mParent->m_tableView;
-    switch(t)
-    {
-    case QAccessible::Name:
-    case QAccessible::Value:
-        return QString("Example Table Cell %1 row %2 column").arg(row).arg(column);
-    default:
-        return QString();
-    }
-}
-
-QColor AccessibleAbstractTableViewCell::foregroundColor() const
-{
-    return mParent->m_tableView->mTextColor;
-}
-
-int AccessibleAbstractTableViewCell::childCount() const
-{
-    return 0;
-}
-
-QWindow* AccessibleAbstractTableViewCell::window() const
-{
-    return mParent->window();
-}
-
-QAccessibleInterface* AccessibleAbstractTableViewCell::parent() const
-{
-    return dynamic_cast<QAccessibleInterface*>(mParent);
-}
-
-QAccessibleInterface* AccessibleAbstractTableViewCell::child(int index) const
-{
-    return nullptr;
-}
-
-int AccessibleAbstractTableViewCell::indexOfChild(const QAccessibleInterface* child) const
-{
-    return -1;
-}
-
-QAccessible::Role AccessibleAbstractTableViewCell::role() const
-{
-    return QAccessible::Cell;
-}
-
-QAccessible::State AccessibleAbstractTableViewCell::state() const
-{
-    QAccessible::State state;
-    state.focusable = mParent->m_tableView->getRowCount() > 0;
-    state.active = state.focusable;
-    state.selectable = state.focusable;
-    state.selected = false;
-    state.focused = false;
-    return state;
-}
-
-QAccessibleInterface* AccessibleAbstractTableViewCell::childAt(int x, int y) const
-{
-    return nullptr;
-}
-
-QObject* AccessibleAbstractTableViewCell::object() const
-{
-    return nullptr;
-}
-
-void AccessibleAbstractTableViewCell::setText(QAccessible::Text t, const QString & text)
-{
-}
-
-QRect AccessibleAbstractTableViewCell::rect() const
-{
-    const auto & table = mParent->m_tableView;
-    int height = table->getRowHeight();
-    auto & actualColumn = table->mColumnOrder[column];
-    QPoint pos(table->getColumnPosition(column), table->getHeaderHeight() + row * height);
-    pos = table->mapToGlobal(pos);
-    return QRect(pos, QSize(table->getColumnWidth(actualColumn), height));
-}
-
-bool AccessibleAbstractTableViewCell::isValid() const
-{
-    return true;
-}
-
-void* AccessibleAbstractTableViewCell::interface_cast(QAccessible::InterfaceType type)
-{
-    if(type == QAccessible::TableCellInterface)
-        return static_cast<QAccessibleTableCellInterface*>(this);
-    else
-        return nullptr;
-}
-
-bool AccessibleAbstractTableViewCell::isSelected() const
-{
-    return false;
-}
-
-QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::columnHeaderCells() const
-{
-    return QList<QAccessibleInterface*>();
-}
-
-QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::rowHeaderCells() const
-{
-    return QList<QAccessibleInterface*>();
-}
-
-int AccessibleAbstractTableViewCell::columnIndex() const
-{
-    return column;
-}
-
-int AccessibleAbstractTableViewCell::rowIndex() const
-{
-    return row;
-}
-
-int AccessibleAbstractTableViewCell::columnExtent() const
-{
-    return 1;
-}
-
-int AccessibleAbstractTableViewCell::rowExtent() const
-{
-    return 1;
-}
-
-QAccessibleInterface* AccessibleAbstractTableViewCell::table() const
-{
-    return static_cast<QAccessibleInterface*>(mParent);
-}
+#include "AccessibleAbstractTableViewCell.h"
 
 AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessibleWidget(w, QAccessible::Table, dynamic_cast<AbstractTableView*>(w)->accessibleName())
 {
@@ -157,6 +18,13 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
     if(rows > 0 && cols > 0)
     {
         cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
+        for(auto i = 0; i < rows; i++)
+        {
+            for(int j = 0; j < cols; j++)
+            {
+                cellArray(i, j) = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCell(this, i, j));
+            }
+        }
     }
     else
     {
@@ -167,16 +35,23 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
 
 AccessibleAbstractTableView::~AccessibleAbstractTableView()
 {
-    for(auto & i : cellInterfaces)
-    {
-        if(i != 0)
-        {
-            QAccessible::deleteAccessibleInterface(i);
-        }
-    }
+    std::for_each(cellInterfaces.cbegin(), cellInterfaces.cend(), QAccessible::deleteAccessibleInterface);
 }
 
-QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column) const
+QString AccessibleAbstractTableView::getCellContent(int row, int column) const
+{
+    //return QString();
+    return QString("Row %1 Column %2").arg(row).arg(column);
+}
+
+QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column)
+{
+    if(row < 0 || column < 0 || row >= rows || column >= cols)
+        throw std::out_of_range("");
+    return cellInterfaces.at(row * cols + column);
+}
+
+const QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column) const
 {
     if(row < 0 || column < 0 || row >= rows || column >= cols)
         throw std::out_of_range("");
@@ -185,45 +60,19 @@ QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column) co
 
 int AccessibleAbstractTableView::childCount() const
 {
-    return rows * cols;
+    return cellInterfaces.size();
 }
 
 QAccessibleInterface* AccessibleAbstractTableView::child(int index) const
 {
     if(index >= 0 && index < childCount())
     {
-        if(cellInterfaces[index] != 0)
-        {
-            return QAccessible::accessibleInterface(cellInterfaces[index]);
-        }
-        else
-        {
-            int row = index / cols;
-            int column = index % cols;
-            auto child = new AccessibleAbstractTableViewCell((AccessibleAbstractTableView*)this, row, column);
-            cellInterfaces[index] = QAccessible::registerAccessibleInterface(child);
-            return child;
-        }
+        return QAccessible::accessibleInterface(cellInterfaces[index]);
     }
     else
-        return nullptr;
-}
-
-int AccessibleAbstractTableView::indexOfChild(const QAccessibleInterface* child) const
-{
-    for(int i = 0; i < cellInterfaces.size(); i++)
     {
-        unsigned int id = cellInterfaces[i];
-        if(id != 0)
-        {
-            QAccessibleInterface* a = QAccessible::accessibleInterface(id);
-            if(a == child)
-            {
-                return i;
-            }
-        }
+        return nullptr;
     }
-    return -1;
 }
 
 QAccessibleInterface* AccessibleAbstractTableView::childAt(int x, int y) const
@@ -232,22 +81,26 @@ QAccessibleInterface* AccessibleAbstractTableView::childAt(int x, int y) const
     {
         int col = m_tableView->getColumnIndexFromX(x);
         auto row = m_tableView->getIndexOffsetFromY(m_tableView->transY(y));
-        QAccessible::Id & id = cellArray(row, col);
-        if(id != 0)
-        {
-            return QAccessible::accessibleInterface(id);
-        }
-        else
-        {
-            auto child = new AccessibleAbstractTableViewCell((AccessibleAbstractTableView*)this, row, col);
-            id = QAccessible::registerAccessibleInterface(child);
-            return child;
-        }
+        const QAccessible::Id & id = cellArray(row, col);
+        return QAccessible::accessibleInterface(id);
     }
     catch(std::out_of_range)
     {
         return nullptr;
     }
+}
+
+int AccessibleAbstractTableView::indexOfChild(const QAccessibleInterface* child) const
+{
+    for(int i = 0; i < childCount(); i++)
+    {
+        const QAccessibleInterface* a = this->child(i);
+        if(a == child)
+        {
+            return i;
+        }
+    }
+    return -1;
 }
 
 QAccessibleInterface* AccessibleAbstractTableView::focusChild() const
@@ -258,11 +111,6 @@ QAccessibleInterface* AccessibleAbstractTableView::focusChild() const
 bool AccessibleAbstractTableView::isValid() const
 {
     return true;
-}
-
-QAccessible::Role AccessibleAbstractTableView::role() const
-{
-    return QAccessible::Table;
 }
 
 QAccessible::State AccessibleAbstractTableView::state() const
@@ -297,16 +145,7 @@ QAccessibleInterface* AccessibleAbstractTableView::cellAt(int row, int column) c
     try
     {
         auto & id = cellArray(row, column);
-        if(id == 0)
-        {
-            AccessibleAbstractTableViewCell* cell = new AccessibleAbstractTableViewCell((AccessibleAbstractTableView*)this, row, column);
-            id = QAccessible::registerAccessibleInterface(cell);
-            return cell;
-        }
-        else
-        {
-            return QAccessible::accessibleInterface(id);
-        }
+        return QAccessible::accessibleInterface(id);
     }
     catch(std::out_of_range)
     {
@@ -321,7 +160,7 @@ int AccessibleAbstractTableView::columnCount() const
 
 QString AccessibleAbstractTableView::columnDescription(int column) const
 {
-    return QString();
+    return m_tableView->getColTitle(column);
 }
 
 bool AccessibleAbstractTableView::isColumnSelected(int column) const
@@ -341,8 +180,7 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
     int hiddenCols = 0;
     for(int i = 0; i < cols; i++)
     {
-        if(m_tableView->getColumnHidden(i))
-            hiddenCols++;
+        hiddenCols += (m_tableView->getColumnHidden(i)) ? 1 : 0;
     }
     newCols -= hiddenCols;
     // Resize array
@@ -352,11 +190,7 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
         {
             for(int i = newRows * cols; i < rows * cols; i++)
             {
-                auto & id = cellInterfaces.at(i);
-                if(id != 0)
-                {
-                    QAccessible::deleteAccessibleInterface(id);
-                }
+                QAccessible::deleteAccessibleInterface(cellInterfaces.at(i));
             }
         }
         if(newRows != rows)
@@ -365,20 +199,26 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
         }
         if(newRows > rows)
         {
-            memset(&cellInterfaces.at(rows * cols), 0, sizeof(QAccessible::Id) * (newRows - rows) * cols);
+            for(auto i = rows; i < newRows; i++)
+            {
+                for(int j = 0; j < newCols; j++)
+                {
+                    cellArray(i, j) = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCell(this, i, j));
+                }
+            }
         }
     }
     else
     {
-        for(int i = 0; i < rows * cols; i++)
+        std::for_each(cellInterfaces.cbegin(), cellInterfaces.cend(), QAccessible::deleteAccessibleInterface);
+        cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
+        for(auto i = 0; i < newRows; i++)
         {
-            auto & id = cellInterfaces.at(i);
-            if(id != 0)
+            for(int j = 0; j < newCols; j++)
             {
-                QAccessible::deleteAccessibleInterface(id);
+                cellArray(i, j) = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCell(this, i, j));
             }
         }
-        cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
     }
     rows = newRows;
     cols = newCols;
@@ -391,7 +231,11 @@ int AccessibleAbstractTableView::rowCount() const
 
 QString AccessibleAbstractTableView::rowDescription(int row) const
 {
-    return QString();
+    auto cell = cellAt(row, 0);
+    if(cell)
+        return cell->text(QAccessible::Value);
+    else
+        return QString();
 }
 
 bool AccessibleAbstractTableView::selectColumn(int column)

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
@@ -3,11 +3,21 @@
 #include "AccessibleAbstractTableView.h"
 #include "AccessibleAbstractTableViewCell.h"
 
-AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessibleWidget(w, QAccessible::Table, dynamic_cast<AbstractTableView*>(w)->accessibleName())
+AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessibleWidget(w, QAccessible::Table, dynamic_cast<AbstractTableView*>(w)->accessibleName()), cellInterfaces()
 {
     m_tableView = dynamic_cast<AbstractTableView*>(w);
-    rows = m_tableView->getViewableRowsCount();
+    assert(m_tableView);
+    rows = std::min(m_tableView->getViewableRowsCount(), m_tableView->getRowCount());
     cols = m_tableView->getColumnCount();
+    assert(rows < 10000 && cols < 1000 && rows >= 0 && cols >= 0);
+    if(rows >= 10000)
+        rows = 10000;
+    if(rows < 0)
+        rows = 0;
+    if(cols >= 1000)
+        cols = 1000;
+    if(cols < 0)
+        cols = 0;
     int hiddenCols = 0;
     for(int i = 0; i < cols; i++)
     {
@@ -17,7 +27,7 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
     cols -= hiddenCols;
     if(rows > 0 && cols > 0)
     {
-        cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
+        cellInterfaces.resize(rows * cols, 0);
         for(auto i = 0; i < rows; i++)
         {
             for(int j = 0; j < cols; j++)
@@ -26,11 +36,7 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
             }
         }
     }
-    else
-    {
-        rows = 0;
-        cols = 0;
-    }
+    assert(cellInterfaces.size() == rows * cols);
 }
 
 AccessibleAbstractTableView::~AccessibleAbstractTableView()
@@ -40,21 +46,20 @@ AccessibleAbstractTableView::~AccessibleAbstractTableView()
 
 QString AccessibleAbstractTableView::getCellContent(int row, int column) const
 {
-    //return QString();
     return QString("Row %1 Column %2").arg(row).arg(column);
 }
 
 QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column)
 {
     if(row < 0 || column < 0 || row >= rows || column >= cols)
-        throw std::out_of_range("");
+        throw std::out_of_range("Table cell row or column out of range");
     return cellInterfaces.at(row * cols + column);
 }
 
 const QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column) const
 {
     if(row < 0 || column < 0 || row >= rows || column >= cols)
-        throw std::out_of_range("");
+        throw std::out_of_range("Table cell row or column out of range");
     return cellInterfaces.at(row * cols + column);
 }
 
@@ -77,10 +82,13 @@ QAccessibleInterface* AccessibleAbstractTableView::child(int index) const
 
 QAccessibleInterface* AccessibleAbstractTableView::childAt(int x, int y) const
 {
+    y = m_tableView->transY(y);
+    if(y < 0 || x < 0)
+        return nullptr;
     try
     {
         int col = m_tableView->getColumnIndexFromX(x);
-        auto row = m_tableView->getIndexOffsetFromY(m_tableView->transY(y));
+        auto row = m_tableView->getIndexOffsetFromY(y);
         const QAccessible::Id & id = cellArray(row, col);
         return QAccessible::accessibleInterface(id);
     }
@@ -165,7 +173,7 @@ QString AccessibleAbstractTableView::columnDescription(int column) const
 
 bool AccessibleAbstractTableView::isColumnSelected(int column) const
 {
-    return false;
+    return m_tableView->accessibilitySelectedColumn == column;
 }
 
 bool AccessibleAbstractTableView::isRowSelected(int row) const
@@ -175,31 +183,60 @@ bool AccessibleAbstractTableView::isRowSelected(int row) const
 
 void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* event)
 {
-    int newRows = m_tableView->getViewableRowsCount();
+    int newRows = std::min(m_tableView->getViewableRowsCount(), m_tableView->getRowCount());
     int newCols = m_tableView->getColumnCount();
     int hiddenCols = 0;
-    for(int i = 0; i < cols; i++)
+    assert(!(newRows < 0 || newCols < 0 || newRows > 10000 || newCols > 1000));
+    if(newRows > 10000)
+        newRows = 10000;
+    if(newCols > 1000)
+        newCols = 1000;
+    for(int i = 0; i < newCols; i++)
     {
         hiddenCols += (m_tableView->getColumnHidden(i)) ? 1 : 0;
     }
     newCols -= hiddenCols;
     // Resize array
-    if(newCols == cols)
+    try
     {
-        if(newRows < rows)
+        if(newCols == cols)
         {
-            for(int i = newRows * cols; i < rows * cols; i++)
+            if(newRows < rows)
             {
-                QAccessible::deleteAccessibleInterface(cellInterfaces.at(i));
+                for(int i = newRows * cols; i < rows * cols; i++)
+                {
+                    QAccessible::deleteAccessibleInterface(cellInterfaces.at(i));
+                }
+            }
+            if(newRows != rows)
+            {
+                cellInterfaces.resize(newRows * newCols, 0);
+            }
+            if(newRows < rows)
+            {
+                rows = newRows;
+            }
+            if(newRows > rows)
+            {
+                int oldRows = rows;
+                rows = newRows;
+                for(auto i = oldRows; i < newRows; i++)
+                {
+                    for(int j = 0; j < newCols; j++)
+                    {
+                        cellArray(i, j) = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCell(this, i, j));
+                    }
+                }
             }
         }
-        if(newRows != rows)
+        else
         {
-            cellInterfaces.resize(newRows * newCols);
-        }
-        if(newRows > rows)
-        {
-            for(auto i = rows; i < newRows; i++)
+            std::for_each(cellInterfaces.cbegin(), cellInterfaces.cend(), QAccessible::deleteAccessibleInterface);
+            cellInterfaces = std::vector<QAccessible::Id>();
+            rows = newRows;
+            cols = newCols;
+            cellInterfaces.resize(rows * cols, 0);
+            for(auto i = 0; i < newRows; i++)
             {
                 for(int j = 0; j < newCols; j++)
                 {
@@ -208,20 +245,11 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
             }
         }
     }
-    else
+    catch(std::out_of_range)
     {
-        std::for_each(cellInterfaces.cbegin(), cellInterfaces.cend(), QAccessible::deleteAccessibleInterface);
-        cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
-        for(auto i = 0; i < newRows; i++)
-        {
-            for(int j = 0; j < newCols; j++)
-            {
-                cellArray(i, j) = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCell(this, i, j));
-            }
-        }
+        __debugbreak();
     }
-    rows = newRows;
-    cols = newCols;
+    assert(cellInterfaces.size() == rows * cols);
 }
 
 int AccessibleAbstractTableView::rowCount() const

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
@@ -42,6 +42,7 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
     {
         columnTitleInterfaces[i] = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCellTitle(this, i));
     }
+    updateVisibleColumns();
     assert(cellInterfaces.size() == rows * cols);
     assert(columnTitleInterfaces.size() == cols);
 }
@@ -56,6 +57,11 @@ QString AccessibleAbstractTableView::getCellContent(int row, int column) const
     return QString("Row %1 Column %2").arg(row).arg(column);
 }
 
+AbstractTableView* AccessibleAbstractTableView::getTable() const
+{
+    return m_tableView;
+}
+
 QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column)
 {
     if(row < 0 || column < 0 || row >= rows || column >= cols)
@@ -68,6 +74,26 @@ const QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int colu
     if(row < 0 || column < 0 || row >= rows || column >= cols)
         throw std::out_of_range("Table cell row or column out of range");
     return cellInterfaces.at(row * cols + column);
+}
+
+void AccessibleAbstractTableView::updateVisibleColumns()
+{
+    duint c = 0;
+    m_visibleColumns.clear();
+    m_visibleColumns.reserve(cols);
+    for(duint j = 0; j < m_tableView->getColumnCount(); j++)
+    {
+        duint i = m_tableView->mColumnOrder[j];
+        if(m_tableView->getColumnHidden(i))
+            continue;
+        m_visibleColumns.push_back(i);
+    }
+    assert(m_visibleColumns.size() == cols);
+}
+
+duint AccessibleAbstractTableView::logicalColumn(int physicalColumn) const
+{
+    return m_visibleColumns.at(physicalColumn);
 }
 
 int AccessibleAbstractTableView::childCount() const
@@ -194,7 +220,7 @@ int AccessibleAbstractTableView::columnCount() const
 
 QString AccessibleAbstractTableView::columnDescription(int column) const
 {
-    return m_tableView->getColTitle(column);
+    return m_tableView->getColTitle(logicalColumn(column));
 }
 
 bool AccessibleAbstractTableView::isColumnSelected(int column) const
@@ -281,6 +307,7 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
                 }
             }
         }
+        updateVisibleColumns();
     }
     catch(std::out_of_range)
     {
@@ -329,12 +356,12 @@ QList<QAccessibleInterface*> AccessibleAbstractTableView::selectedCells() const
 
 int AccessibleAbstractTableView::selectedColumnCount() const
 {
-    return 0;
+    return 1;
 }
 
 QList<int> AccessibleAbstractTableView::selectedColumns() const
 {
-    return QList<int>();
+    return QList<int>({m_tableView->accessibilitySelectedColumn});
 }
 
 int AccessibleAbstractTableView::selectedRowCount() const

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
@@ -1,0 +1,452 @@
+// This file implements accessibility interface for RegistersView
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleAbstractTableView.h"
+
+AccessibleAbstractTableViewCell::AccessibleAbstractTableViewCell(AccessibleAbstractTableView* parent, duint row, int column) : mParent(parent), row(row), column(column)
+{
+}
+
+QString AccessibleAbstractTableViewCell::text(QAccessible::Text t) const
+{
+    AbstractTableView* w = mParent->m_tableView;
+    switch(t)
+    {
+    case QAccessible::Name:
+    case QAccessible::Value:
+        return QString("Example Table Cell %1 row %2 column").arg(row).arg(column);
+    default:
+        return QString();
+    }
+}
+
+QColor AccessibleAbstractTableViewCell::foregroundColor() const
+{
+    return mParent->m_tableView->mTextColor;
+}
+
+int AccessibleAbstractTableViewCell::childCount() const
+{
+    return 0;
+}
+
+QWindow* AccessibleAbstractTableViewCell::window() const
+{
+    return mParent->window();
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::parent() const
+{
+    return dynamic_cast<QAccessibleInterface*>(mParent);
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::child(int index) const
+{
+    return nullptr;
+}
+
+int AccessibleAbstractTableViewCell::indexOfChild(const QAccessibleInterface* child) const
+{
+    return -1;
+}
+
+QAccessible::Role AccessibleAbstractTableViewCell::role() const
+{
+    return QAccessible::Cell;
+}
+
+QAccessible::State AccessibleAbstractTableViewCell::state() const
+{
+    QAccessible::State state;
+    state.focusable = mParent->m_tableView->getRowCount() > 0;
+    state.active = state.focusable;
+    state.selectable = state.focusable;
+    state.selected = false;
+    state.focused = false;
+    return state;
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::childAt(int x, int y) const
+{
+    return nullptr;
+}
+
+QObject* AccessibleAbstractTableViewCell::object() const
+{
+    return nullptr;
+}
+
+void AccessibleAbstractTableViewCell::setText(QAccessible::Text t, const QString & text)
+{
+}
+
+QRect AccessibleAbstractTableViewCell::rect() const
+{
+    const auto & table = mParent->m_tableView;
+    int height = table->getRowHeight();
+    auto & actualColumn = table->mColumnOrder[column];
+    QPoint pos(table->getColumnPosition(column), table->getHeaderHeight() + row * height);
+    pos = table->mapToGlobal(pos);
+    return QRect(pos, QSize(table->getColumnWidth(actualColumn), height));
+}
+
+bool AccessibleAbstractTableViewCell::isValid() const
+{
+    return true;
+}
+
+void* AccessibleAbstractTableViewCell::interface_cast(QAccessible::InterfaceType type)
+{
+    if(type == QAccessible::TableCellInterface)
+        return static_cast<QAccessibleTableCellInterface*>(this);
+    else
+        return nullptr;
+}
+
+bool AccessibleAbstractTableViewCell::isSelected() const
+{
+    return false;
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::columnHeaderCells() const
+{
+    return QList<QAccessibleInterface*>();
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::rowHeaderCells() const
+{
+    return QList<QAccessibleInterface*>();
+}
+
+int AccessibleAbstractTableViewCell::columnIndex() const
+{
+    return column;
+}
+
+int AccessibleAbstractTableViewCell::rowIndex() const
+{
+    return row;
+}
+
+int AccessibleAbstractTableViewCell::columnExtent() const
+{
+    return 1;
+}
+
+int AccessibleAbstractTableViewCell::rowExtent() const
+{
+    return 1;
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::table() const
+{
+    return static_cast<QAccessibleInterface*>(mParent);
+}
+
+AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessibleWidget(w, QAccessible::Table, dynamic_cast<AbstractTableView*>(w)->accessibleName())
+{
+    m_tableView = dynamic_cast<AbstractTableView*>(w);
+    rows = m_tableView->getViewableRowsCount();
+    cols = m_tableView->getColumnCount();
+    int hiddenCols = 0;
+    for(int i = 0; i < cols; i++)
+    {
+        if(m_tableView->getColumnHidden(i))
+            hiddenCols++;
+    }
+    cols -= hiddenCols;
+    if(rows > 0 && cols > 0)
+    {
+        cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
+    }
+    else
+    {
+        rows = 0;
+        cols = 0;
+    }
+}
+
+AccessibleAbstractTableView::~AccessibleAbstractTableView()
+{
+    for(auto & i : cellInterfaces)
+    {
+        if(i != 0)
+        {
+            QAccessible::deleteAccessibleInterface(i);
+        }
+    }
+}
+
+QAccessible::Id & AccessibleAbstractTableView::cellArray(int row, int column) const
+{
+    if(row < 0 || column < 0 || row >= rows || column >= cols)
+        throw std::out_of_range("");
+    return cellInterfaces.at(row * cols + column);
+}
+
+int AccessibleAbstractTableView::childCount() const
+{
+    return rows * cols;
+}
+
+QAccessibleInterface* AccessibleAbstractTableView::child(int index) const
+{
+    if(index >= 0 && index < childCount())
+    {
+        if(cellInterfaces[index] != 0)
+        {
+            return QAccessible::accessibleInterface(cellInterfaces[index]);
+        }
+        else
+        {
+            int row = index / cols;
+            int column = index % cols;
+            auto child = new AccessibleAbstractTableViewCell((AccessibleAbstractTableView*)this, row, column);
+            cellInterfaces[index] = QAccessible::registerAccessibleInterface(child);
+            return child;
+        }
+    }
+    else
+        return nullptr;
+}
+
+int AccessibleAbstractTableView::indexOfChild(const QAccessibleInterface* child) const
+{
+    for(int i = 0; i < cellInterfaces.size(); i++)
+    {
+        unsigned int id = cellInterfaces[i];
+        if(id != 0)
+        {
+            QAccessibleInterface* a = QAccessible::accessibleInterface(id);
+            if(a == child)
+            {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+QAccessibleInterface* AccessibleAbstractTableView::childAt(int x, int y) const
+{
+    try
+    {
+        int col = m_tableView->getColumnIndexFromX(x);
+        auto row = m_tableView->getIndexOffsetFromY(m_tableView->transY(y));
+        QAccessible::Id & id = cellArray(row, col);
+        if(id != 0)
+        {
+            return QAccessible::accessibleInterface(id);
+        }
+        else
+        {
+            auto child = new AccessibleAbstractTableViewCell((AccessibleAbstractTableView*)this, row, col);
+            id = QAccessible::registerAccessibleInterface(child);
+            return child;
+        }
+    }
+    catch(std::out_of_range)
+    {
+        return nullptr;
+    }
+}
+
+QAccessibleInterface* AccessibleAbstractTableView::focusChild() const
+{
+    return nullptr;
+}
+
+bool AccessibleAbstractTableView::isValid() const
+{
+    return true;
+}
+
+QAccessible::Role AccessibleAbstractTableView::role() const
+{
+    return QAccessible::Table;
+}
+
+QAccessible::State AccessibleAbstractTableView::state() const
+{
+    QAccessible::State state;
+    state.focusable = true;
+    if(m_tableView->hasFocus())
+        state.focused = true;
+    state.active = m_tableView->isEnabled();
+    state.multiLine = true;
+    state.multiSelectable = false;
+    state.disabled = !m_tableView->isEnabled();
+    state.hasPopup = true;
+    return state;
+}
+
+void* AccessibleAbstractTableView::interface_cast(QAccessible::InterfaceType type)
+{
+    if(type == QAccessible::TableInterface)
+        return static_cast<QAccessibleTableInterface*>(this);
+    else
+        return nullptr;
+}
+
+QAccessibleInterface* AccessibleAbstractTableView::caption() const
+{
+    return nullptr;
+}
+
+QAccessibleInterface* AccessibleAbstractTableView::cellAt(int row, int column) const
+{
+    try
+    {
+        auto & id = cellArray(row, column);
+        if(id == 0)
+        {
+            AccessibleAbstractTableViewCell* cell = new AccessibleAbstractTableViewCell((AccessibleAbstractTableView*)this, row, column);
+            id = QAccessible::registerAccessibleInterface(cell);
+            return cell;
+        }
+        else
+        {
+            return QAccessible::accessibleInterface(id);
+        }
+    }
+    catch(std::out_of_range)
+    {
+        return nullptr;
+    }
+}
+
+int AccessibleAbstractTableView::columnCount() const
+{
+    return cols;
+}
+
+QString AccessibleAbstractTableView::columnDescription(int column) const
+{
+    return QString();
+}
+
+bool AccessibleAbstractTableView::isColumnSelected(int column) const
+{
+    return false;
+}
+
+bool AccessibleAbstractTableView::isRowSelected(int row) const
+{
+    return false;
+}
+
+void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* event)
+{
+    int newRows = m_tableView->getViewableRowsCount();
+    int newCols = m_tableView->getColumnCount();
+    int hiddenCols = 0;
+    for(int i = 0; i < cols; i++)
+    {
+        if(m_tableView->getColumnHidden(i))
+            hiddenCols++;
+    }
+    newCols -= hiddenCols;
+    // Resize array
+    if(newCols == cols)
+    {
+        if(newRows < rows)
+        {
+            for(int i = newRows * cols; i < rows * cols; i++)
+            {
+                auto & id = cellInterfaces.at(i);
+                if(id != 0)
+                {
+                    QAccessible::deleteAccessibleInterface(id);
+                }
+            }
+        }
+        if(newRows != rows)
+        {
+            cellInterfaces.resize(newRows * newCols);
+        }
+        if(newRows > rows)
+        {
+            memset(&cellInterfaces.at(rows * cols), 0, sizeof(QAccessible::Id) * (newRows - rows) * cols);
+        }
+    }
+    else
+    {
+        for(int i = 0; i < rows * cols; i++)
+        {
+            auto & id = cellInterfaces.at(i);
+            if(id != 0)
+            {
+                QAccessible::deleteAccessibleInterface(id);
+            }
+        }
+        cellInterfaces = std::vector<QAccessible::Id>((size_t)(rows * cols), (QAccessible::Id)0);
+    }
+    rows = newRows;
+    cols = newCols;
+}
+
+int AccessibleAbstractTableView::rowCount() const
+{
+    return rows;
+}
+
+QString AccessibleAbstractTableView::rowDescription(int row) const
+{
+    return QString();
+}
+
+bool AccessibleAbstractTableView::selectColumn(int column)
+{
+    return false;
+}
+
+bool AccessibleAbstractTableView::selectRow(int row)
+{
+    return false;
+}
+
+int AccessibleAbstractTableView::selectedCellCount() const
+{
+    return 0;
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableView::selectedCells() const
+{
+    return QList<QAccessibleInterface*>();
+}
+
+int AccessibleAbstractTableView::selectedColumnCount() const
+{
+    return 0;
+}
+
+QList<int> AccessibleAbstractTableView::selectedColumns() const
+{
+    return QList<int>();
+}
+
+int AccessibleAbstractTableView::selectedRowCount() const
+{
+    return 0;
+}
+
+QList<int> AccessibleAbstractTableView::selectedRows() const
+{
+    return QList<int>();
+}
+
+QAccessibleInterface* AccessibleAbstractTableView::summary() const
+{
+    return nullptr;
+}
+
+bool AccessibleAbstractTableView::unselectColumn(int column)
+{
+    return false;
+}
+
+bool AccessibleAbstractTableView::unselectRow(int row)
+{
+    return false;
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
@@ -1,4 +1,4 @@
-// This file implements accessibility interface for RegistersView
+// This file implements accessibility interface for AbstractTableView
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleAbstractTableView.h"
 #include "AccessibleAbstractTableViewCell.h"
@@ -49,6 +49,7 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
 
 AccessibleAbstractTableView::~AccessibleAbstractTableView()
 {
+    std::for_each(columnTitleInterfaces.cbegin(), columnTitleInterfaces.cend(), QAccessible::deleteAccessibleInterface);
     std::for_each(cellInterfaces.cbegin(), cellInterfaces.cend(), QAccessible::deleteAccessibleInterface);
 }
 
@@ -243,6 +244,10 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
         newRows = 10000;
     if(newCols > 1000)
         newCols = 1000;
+    if(newRows < 0)
+        newRows = 0;
+    if(newCols < 0)
+        newCols = 0;
     for(int i = 0; i < newCols; i++)
     {
         hiddenCols += (m_tableView->getColumnHidden(i)) ? 1 : 0;
@@ -327,7 +332,7 @@ QString AccessibleAbstractTableView::rowDescription(int row) const
 {
     if(row == 0)  // title row
         return QString();
-    auto cell = cellAt(row + 1, 0);
+    auto cell = cellAt(row, 0);
     if(cell)
         return cell->text(QAccessible::Value);
     else

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.cpp
@@ -2,8 +2,9 @@
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleAbstractTableView.h"
 #include "AccessibleAbstractTableViewCell.h"
+#include "AccessibleAbstractTableViewCellTitle.h"
 
-AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessibleWidget(w, QAccessible::Table, dynamic_cast<AbstractTableView*>(w)->accessibleName()), cellInterfaces()
+AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessibleWidget(w, QAccessible::Table, dynamic_cast<AbstractTableView*>(w)->accessibleName())
 {
     m_tableView = dynamic_cast<AbstractTableView*>(w);
     assert(m_tableView);
@@ -36,7 +37,13 @@ AccessibleAbstractTableView::AccessibleAbstractTableView(QWidget* w) : QAccessib
             }
         }
     }
+    columnTitleInterfaces = std::vector<QAccessible::Id>(cols);
+    for(int i = 0; i < cols; i++)
+    {
+        columnTitleInterfaces[i] = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCellTitle(this, i));
+    }
     assert(cellInterfaces.size() == rows * cols);
+    assert(columnTitleInterfaces.size() == cols);
 }
 
 AccessibleAbstractTableView::~AccessibleAbstractTableView()
@@ -70,9 +77,13 @@ int AccessibleAbstractTableView::childCount() const
 
 QAccessibleInterface* AccessibleAbstractTableView::child(int index) const
 {
-    if(index >= 0 && index < childCount())
+    if(index >= cols && index < cols + childCount())
     {
-        return QAccessible::accessibleInterface(cellInterfaces[index]);
+        return QAccessible::accessibleInterface(cellInterfaces[index - cols]);
+    }
+    else if(index >= 0 && index < cols)
+    {
+        return QAccessible::accessibleInterface(columnTitleInterfaces[index]);
     }
     else
     {
@@ -82,12 +93,17 @@ QAccessibleInterface* AccessibleAbstractTableView::child(int index) const
 
 QAccessibleInterface* AccessibleAbstractTableView::childAt(int x, int y) const
 {
-    y = m_tableView->transY(y);
-    if(y < 0 || x < 0)
-        return nullptr;
+    int col = m_tableView->getColumnIndexFromX(x);
     try
     {
-        int col = m_tableView->getColumnIndexFromX(x);
+        if(y < 0 || x < 0)
+            return nullptr;
+        if(y < m_tableView->getHeaderHeight())
+        {
+            const QAccessible::Id & id = columnTitleInterfaces.at(col);
+            return QAccessible::accessibleInterface(id);
+        }
+        y = m_tableView->transY(y);
         auto row = m_tableView->getIndexOffsetFromY(y);
         const QAccessible::Id & id = cellArray(row, col);
         return QAccessible::accessibleInterface(id);
@@ -152,7 +168,17 @@ QAccessibleInterface* AccessibleAbstractTableView::cellAt(int row, int column) c
 {
     try
     {
-        auto & id = cellArray(row, column);
+        QAccessible::Id id;
+        if(row > 0)
+        {
+            id = cellArray(row - 1, column);
+        }
+        else if(row == 0)
+        {
+            id = columnTitleInterfaces.at(column);
+        }
+        else
+            return nullptr;
         return QAccessible::accessibleInterface(id);
     }
     catch(std::out_of_range)
@@ -231,6 +257,17 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
         }
         else
         {
+            // column titles
+            for(int i = newCols; i < cols; i++)
+            {
+                QAccessible::deleteAccessibleInterface(columnTitleInterfaces.at(i));
+            }
+            columnTitleInterfaces.resize(newCols);
+            for(int i = cols; i < newCols; i++)
+            {
+                columnTitleInterfaces.at(i) = QAccessible::registerAccessibleInterface(new AccessibleAbstractTableViewCellTitle(this, i));
+            }
+            // rows
             std::for_each(cellInterfaces.cbegin(), cellInterfaces.cend(), QAccessible::deleteAccessibleInterface);
             cellInterfaces = std::vector<QAccessible::Id>();
             rows = newRows;
@@ -250,16 +287,20 @@ void AccessibleAbstractTableView::modelChange(QAccessibleTableModelChangeEvent* 
         __debugbreak();
     }
     assert(cellInterfaces.size() == rows * cols);
+    assert(columnTitleInterfaces.size() == cols);
 }
 
 int AccessibleAbstractTableView::rowCount() const
 {
-    return rows;
+    // returned row includes title
+    return rows + 1;
 }
 
 QString AccessibleAbstractTableView::rowDescription(int row) const
 {
-    auto cell = cellAt(row, 0);
+    if(row == 0)  // title row
+        return QString();
+    auto cell = cellAt(row + 1, 0);
     if(cell)
         return cell->text(QAccessible::Value);
     else

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.h
@@ -14,9 +14,14 @@ class AccessibleAbstractTableView : public QAccessibleWidget, public QAccessible
     int rows, cols;
     friend class AccessibleAbstractTableViewCell;
     friend class AccessibleAbstractTableViewCellTitle;
+    std::vector<duint> m_visibleColumns;
 public:
     AccessibleAbstractTableView(QWidget* w);
     ~AccessibleAbstractTableView();
+
+    AbstractTableView* getTable() const;
+    // Convert from displayed column to raw column (not reordered)
+    duint logicalColumn(int physicalColumn) const;
     // QAccessibleInterface
     int childCount() const override;
     QAccessibleInterface* child(int index) const override;
@@ -53,6 +58,7 @@ protected:
 private:
     QAccessible::Id & cellArray(int row, int col); // Get reference of accessible id, throws std::out_of_range exception
     const QAccessible::Id & cellArray(int row, int col) const;
+    void updateVisibleColumns();
 };
 
 #endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.h
@@ -3,45 +3,9 @@
 #include <QAccessibleWidget>
 #include "../BasicView/AbstractTableView.h"
 
-class AccessibleAbstractTableView;
-
-class AccessibleAbstractTableViewCell : public QAccessibleInterface, QAccessibleTableCellInterface
-{
-    duint row;
-    int column;
-    AccessibleAbstractTableView* mParent;
-public:
-    AccessibleAbstractTableViewCell(AccessibleAbstractTableView* parent, duint row, int column);
-    // QAccessibleInterface
-    QString text(QAccessible::Text t) const override;
-    QColor foregroundColor() const override;
-    QWindow* window() const override;
-    QAccessibleInterface* parent() const override;
-    QAccessibleInterface* child(int index) const override;
-    QAccessibleInterface* childAt(int x, int y) const override;
-    QObject* object() const override;
-    void setText(QAccessible::Text t, const QString & text) override;
-    QRect rect() const override;
-    int indexOfChild(const QAccessibleInterface* child) const override;
-    QAccessible::Role role() const override;
-    QAccessible::State state() const override;
-    int childCount() const override;
-    bool isValid() const override;
-    void* interface_cast(QAccessible::InterfaceType type) override;
-    // QAccessibleTableCellInterface
-    bool isSelected() const override;
-    QList<QAccessibleInterface*> columnHeaderCells() const override;
-    QList<QAccessibleInterface*> rowHeaderCells() const override;
-    int columnIndex() const override;
-    int rowIndex() const override;
-    int columnExtent() const override;
-    int rowExtent() const override;
-    QAccessibleInterface* table() const override;
-};
-
 class AccessibleAbstractTableView : public QAccessibleWidget, public QAccessibleTableInterface
 {
-    mutable std::vector<QAccessible::Id> cellInterfaces;
+    std::vector<QAccessible::Id> cellInterfaces;
     int rows, cols;
     friend class AccessibleAbstractTableViewCell;
     AbstractTableView* m_tableView;
@@ -51,11 +15,10 @@ public:
     // QAccessibleInterface
     int childCount() const override;
     QAccessibleInterface* child(int index) const override;
-    int indexOfChild(const QAccessibleInterface*) const override;
     QAccessibleInterface* QAccessibleInterface::childAt(int x, int y) const override;
+    int indexOfChild(const QAccessibleInterface* child) const override;
     QAccessibleInterface* focusChild() const override;
     bool isValid() const override;
-    QAccessible::Role role() const override;
     QAccessible::State state() const override;
     void* interface_cast(QAccessible::InterfaceType type) override;
     // QAccessibleTableInterface
@@ -80,7 +43,9 @@ public:
     bool unselectColumn(int column) override;
     bool unselectRow(int row) override;
 private:
-    QAccessible::Id & cellArray(int row, int col) const; // throws std::out_of_range exception
+    QAccessible::Id & cellArray(int row, int col); // Get reference of accessible id, throws std::out_of_range exception
+    const QAccessible::Id & cellArray(int row, int col) const;
+    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
 };
 
 #endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.h
@@ -8,7 +8,6 @@ class AccessibleAbstractTableView : public QAccessibleWidget, public QAccessible
     std::vector<QAccessible::Id> cellInterfaces;
     int rows, cols;
     friend class AccessibleAbstractTableViewCell;
-    AbstractTableView* m_tableView;
 public:
     AccessibleAbstractTableView(QWidget* w);
     ~AccessibleAbstractTableView();
@@ -42,10 +41,12 @@ public:
     QAccessibleInterface* summary() const override;
     bool unselectColumn(int column) override;
     bool unselectRow(int row) override;
+protected:
+    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
+    AbstractTableView* m_tableView;
 private:
     QAccessible::Id & cellArray(int row, int col); // Get reference of accessible id, throws std::out_of_range exception
     const QAccessible::Id & cellArray(int row, int col) const;
-    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
 };
 
 #endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.h
@@ -1,0 +1,86 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "../BasicView/AbstractTableView.h"
+
+class AccessibleAbstractTableView;
+
+class AccessibleAbstractTableViewCell : public QAccessibleInterface, QAccessibleTableCellInterface
+{
+    duint row;
+    int column;
+    AccessibleAbstractTableView* mParent;
+public:
+    AccessibleAbstractTableViewCell(AccessibleAbstractTableView* parent, duint row, int column);
+    // QAccessibleInterface
+    QString text(QAccessible::Text t) const override;
+    QColor foregroundColor() const override;
+    QWindow* window() const override;
+    QAccessibleInterface* parent() const override;
+    QAccessibleInterface* child(int index) const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
+    QObject* object() const override;
+    void setText(QAccessible::Text t, const QString & text) override;
+    QRect rect() const override;
+    int indexOfChild(const QAccessibleInterface* child) const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+    int childCount() const override;
+    bool isValid() const override;
+    void* interface_cast(QAccessible::InterfaceType type) override;
+    // QAccessibleTableCellInterface
+    bool isSelected() const override;
+    QList<QAccessibleInterface*> columnHeaderCells() const override;
+    QList<QAccessibleInterface*> rowHeaderCells() const override;
+    int columnIndex() const override;
+    int rowIndex() const override;
+    int columnExtent() const override;
+    int rowExtent() const override;
+    QAccessibleInterface* table() const override;
+};
+
+class AccessibleAbstractTableView : public QAccessibleWidget, public QAccessibleTableInterface
+{
+    mutable std::vector<QAccessible::Id> cellInterfaces;
+    int rows, cols;
+    friend class AccessibleAbstractTableViewCell;
+    AbstractTableView* m_tableView;
+public:
+    AccessibleAbstractTableView(QWidget* w);
+    ~AccessibleAbstractTableView();
+    // QAccessibleInterface
+    int childCount() const override;
+    QAccessibleInterface* child(int index) const override;
+    int indexOfChild(const QAccessibleInterface*) const override;
+    QAccessibleInterface* QAccessibleInterface::childAt(int x, int y) const override;
+    QAccessibleInterface* focusChild() const override;
+    bool isValid() const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+    void* interface_cast(QAccessible::InterfaceType type) override;
+    // QAccessibleTableInterface
+    QAccessibleInterface* caption() const override;
+    QAccessibleInterface* cellAt(int row, int column) const override;
+    int columnCount() const override;
+    QString columnDescription(int column) const override;
+    bool isColumnSelected(int column) const override;
+    bool isRowSelected(int row) const override;
+    void modelChange(QAccessibleTableModelChangeEvent* event) override;
+    int rowCount() const override;
+    QString rowDescription(int row) const override;
+    bool selectColumn(int column) override;
+    bool selectRow(int row) override;
+    int selectedCellCount() const override;
+    QList<QAccessibleInterface*> selectedCells() const override;
+    int selectedColumnCount() const override;
+    QList<int> selectedColumns() const override;
+    int selectedRowCount() const override;
+    QList<int> selectedRows() const override;
+    QAccessibleInterface* summary() const override;
+    bool unselectColumn(int column) override;
+    bool unselectRow(int row) override;
+private:
+    QAccessible::Id & cellArray(int row, int col) const; // throws std::out_of_range exception
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.h
@@ -25,7 +25,7 @@ public:
     // QAccessibleInterface
     int childCount() const override;
     QAccessibleInterface* child(int index) const override;
-    QAccessibleInterface* QAccessibleInterface::childAt(int x, int y) const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
     int indexOfChild(const QAccessibleInterface* child) const override;
     QAccessibleInterface* focusChild() const override;
     bool isValid() const override;

--- a/src/gui/Src/Accessible/AccessibleAbstractTableView.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableView.h
@@ -3,11 +3,17 @@
 #include <QAccessibleWidget>
 #include "../BasicView/AbstractTableView.h"
 
+/**
+* Accessible interface for AbstractTableView.
+* This accessibility interface only exposes what is visible on the screen because the data scale of underlying AbstractTableView is uncontrollable.
+*/
 class AccessibleAbstractTableView : public QAccessibleWidget, public QAccessibleTableInterface
 {
     std::vector<QAccessible::Id> cellInterfaces;
+    std::vector<QAccessible::Id> columnTitleInterfaces;
     int rows, cols;
     friend class AccessibleAbstractTableViewCell;
+    friend class AccessibleAbstractTableViewCellTitle;
 public:
     AccessibleAbstractTableView(QWidget* w);
     ~AccessibleAbstractTableView();

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
@@ -12,8 +12,6 @@ QString AccessibleAbstractTableViewCell::text(QAccessible::Text t) const
     AbstractTableView* w = mParent->m_tableView;
     switch(t)
     {
-    case QAccessible::Name:
-        return QString("Row %1 Column %2").arg(row).arg(column);
     case QAccessible::Value:
         return mParent->getCellContent(row, column);
     default:
@@ -62,7 +60,7 @@ QAccessible::State AccessibleAbstractTableViewCell::state() const
     state.focusable = mParent->m_tableView->getRowCount() > 0;
     state.active = state.focusable;
     state.selectable = state.focusable;
-    state.selected = mParent->isRowSelected(row);
+    state.selected = mParent->isRowSelected(row + 1);
     state.focused = state.selected && mParent->isColumnSelected(column);
     state.readOnly = true;
     return state;
@@ -112,12 +110,12 @@ bool AccessibleAbstractTableViewCell::isSelected() const
 
 QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::columnHeaderCells() const
 {
-    return QList<QAccessibleInterface*>();
+    return QList<QAccessibleInterface*>({ mParent->cellAt(0, column) });
 }
 
 QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::rowHeaderCells() const
 {
-    return QList<QAccessibleInterface*>({ mParent->cellAt(row, 0) });
+    return QList<QAccessibleInterface*>({ mParent->cellAt(row + 1, 0) });
 }
 
 int AccessibleAbstractTableViewCell::columnIndex() const
@@ -127,7 +125,7 @@ int AccessibleAbstractTableViewCell::columnIndex() const
 
 int AccessibleAbstractTableViewCell::rowIndex() const
 {
-    return row;
+    return row + 1;
 }
 
 int AccessibleAbstractTableViewCell::columnExtent() const

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
@@ -1,0 +1,148 @@
+// This file implements accessibility interface for RegistersView
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleAbstractTableViewCell.h"
+#include "AccessibleAbstractTableView.h"
+
+AccessibleAbstractTableViewCell::AccessibleAbstractTableViewCell(AccessibleAbstractTableView* parent, duint row, int column) : mParent(parent), row(row), column(column)
+{
+}
+
+QString AccessibleAbstractTableViewCell::text(QAccessible::Text t) const
+{
+    AbstractTableView* w = mParent->m_tableView;
+    switch(t)
+    {
+    case QAccessible::Name:
+        return QString("Row %1 Column %2").arg(row).arg(column);
+    case QAccessible::Value:
+        return mParent->getCellContent(row, column);
+    default:
+        return QString();
+    }
+}
+
+QColor AccessibleAbstractTableViewCell::foregroundColor() const
+{
+    return mParent->m_tableView->mTextColor;
+}
+
+int AccessibleAbstractTableViewCell::childCount() const
+{
+    return 0;
+}
+
+QWindow* AccessibleAbstractTableViewCell::window() const
+{
+    return mParent->window();
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::parent() const
+{
+    return dynamic_cast<QAccessibleInterface*>(mParent);
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::child(int index) const
+{
+    return nullptr;
+}
+
+int AccessibleAbstractTableViewCell::indexOfChild(const QAccessibleInterface* child) const
+{
+    return -1;
+}
+
+QAccessible::Role AccessibleAbstractTableViewCell::role() const
+{
+    return QAccessible::Cell;
+}
+
+QAccessible::State AccessibleAbstractTableViewCell::state() const
+{
+    QAccessible::State state;
+    state.focusable = mParent->m_tableView->getRowCount() > 0;
+    state.active = state.focusable;
+    state.selectable = state.focusable;
+    state.selected = false;
+    state.focused = false;
+    state.readOnly = true;
+    return state;
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::childAt(int x, int y) const
+{
+    return nullptr;
+}
+
+QObject* AccessibleAbstractTableViewCell::object() const
+{
+    return nullptr;
+}
+
+void AccessibleAbstractTableViewCell::setText(QAccessible::Text t, const QString & text)
+{
+}
+
+QRect AccessibleAbstractTableViewCell::rect() const
+{
+    const auto & table = mParent->m_tableView;
+    int height = table->getRowHeight();
+    auto & actualColumn = table->mColumnOrder[column];
+    QPoint pos(table->getColumnPosition(column), table->getHeaderHeight() + row * height);
+    pos = table->mapToGlobal(pos);
+    return QRect(pos, QSize(table->getColumnWidth(actualColumn), height));
+}
+
+bool AccessibleAbstractTableViewCell::isValid() const
+{
+    return true;
+}
+
+void* AccessibleAbstractTableViewCell::interface_cast(QAccessible::InterfaceType type)
+{
+    if(type == QAccessible::TableCellInterface)
+        return static_cast<QAccessibleTableCellInterface*>(this);
+    else
+        return nullptr;
+}
+
+bool AccessibleAbstractTableViewCell::isSelected() const
+{
+    return false;
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::columnHeaderCells() const
+{
+    return QList<QAccessibleInterface*>();
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableViewCell::rowHeaderCells() const
+{
+    return QList<QAccessibleInterface*>({ mParent->cellAt(row, 0) });
+}
+
+int AccessibleAbstractTableViewCell::columnIndex() const
+{
+    return column;
+}
+
+int AccessibleAbstractTableViewCell::rowIndex() const
+{
+    return row;
+}
+
+int AccessibleAbstractTableViewCell::columnExtent() const
+{
+    return 1;
+}
+
+int AccessibleAbstractTableViewCell::rowExtent() const
+{
+    return 1;
+}
+
+QAccessibleInterface* AccessibleAbstractTableViewCell::table() const
+{
+    return static_cast<QAccessibleInterface*>(mParent);
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
@@ -62,8 +62,8 @@ QAccessible::State AccessibleAbstractTableViewCell::state() const
     state.focusable = mParent->m_tableView->getRowCount() > 0;
     state.active = state.focusable;
     state.selectable = state.focusable;
-    state.selected = false;
-    state.focused = false;
+    state.selected = mParent->isRowSelected(row);
+    state.focused = state.selected && mParent->isColumnSelected(column);
     state.readOnly = true;
     return state;
 }

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
@@ -9,11 +9,11 @@ AccessibleAbstractTableViewCell::AccessibleAbstractTableViewCell(AccessibleAbstr
 
 QString AccessibleAbstractTableViewCell::text(QAccessible::Text t) const
 {
-    AbstractTableView* w = mParent->m_tableView;
+    AbstractTableView* w = mParent->getTable();
     switch(t)
     {
     case QAccessible::Value:
-        return mParent->getCellContent(row, column);
+        return mParent->getCellContent(row, mParent->logicalColumn(column));
     default:
         return QString();
     }
@@ -21,7 +21,7 @@ QString AccessibleAbstractTableViewCell::text(QAccessible::Text t) const
 
 QColor AccessibleAbstractTableViewCell::foregroundColor() const
 {
-    return mParent->m_tableView->mTextColor;
+    return mParent->getTable()->mTextColor;
 }
 
 int AccessibleAbstractTableViewCell::childCount() const
@@ -57,7 +57,7 @@ QAccessible::Role AccessibleAbstractTableViewCell::role() const
 QAccessible::State AccessibleAbstractTableViewCell::state() const
 {
     QAccessible::State state;
-    state.focusable = mParent->m_tableView->getRowCount() > 0;
+    state.focusable = mParent->getTable()->getRowCount() > 0;
     state.active = state.focusable;
     state.selectable = state.focusable;
     state.selected = mParent->isRowSelected(row + 1);
@@ -82,12 +82,11 @@ void AccessibleAbstractTableViewCell::setText(QAccessible::Text t, const QString
 
 QRect AccessibleAbstractTableViewCell::rect() const
 {
-    const auto & table = mParent->m_tableView;
+    const auto table = mParent->getTable();
     int height = table->getRowHeight();
-    auto & actualColumn = table->mColumnOrder[column];
     QPoint pos(table->getColumnPosition(column), table->getHeaderHeight() + row * height);
     pos = table->mapToGlobal(pos);
-    return QRect(pos, QSize(table->getColumnWidth(actualColumn), height));
+    return QRect(pos, QSize(table->getColumnWidth(mParent->logicalColumn(column)), height));
 }
 
 bool AccessibleAbstractTableViewCell::isValid() const

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.cpp
@@ -1,4 +1,4 @@
-// This file implements accessibility interface for RegistersView
+// This file implements accessibility interface for table cells of TableViewCell
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleAbstractTableViewCell.h"
 #include "AccessibleAbstractTableView.h"

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h
@@ -7,7 +7,8 @@ class AccessibleAbstractTableView;
 
 class AccessibleAbstractTableViewCell : public QAccessibleInterface, QAccessibleTableCellInterface
 {
-    duint row;
+protected:
+    duint row; // The first visible row is index 0. Off by 1 compared with AccessibleAbstractTableView row due to column titles.
     int column;
     AccessibleAbstractTableView* mParent;
 public:

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCell.h
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "../BasicView/AbstractTableView.h"
+
+class AccessibleAbstractTableView;
+
+class AccessibleAbstractTableViewCell : public QAccessibleInterface, QAccessibleTableCellInterface
+{
+    duint row;
+    int column;
+    AccessibleAbstractTableView* mParent;
+public:
+    AccessibleAbstractTableViewCell(AccessibleAbstractTableView* parent, duint row, int column);
+    // QAccessibleInterface
+    QString text(QAccessible::Text t) const override;
+    QColor foregroundColor() const override;
+    QWindow* window() const override;
+    QAccessibleInterface* parent() const override;
+    QAccessibleInterface* child(int index) const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
+    QObject* object() const override;
+    void setText(QAccessible::Text t, const QString & text) override;
+    QRect rect() const override;
+    int indexOfChild(const QAccessibleInterface* child) const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+    int childCount() const override;
+    bool isValid() const override;
+    void* interface_cast(QAccessible::InterfaceType type) override;
+    // QAccessibleTableCellInterface
+    bool isSelected() const override;
+    QList<QAccessibleInterface*> columnHeaderCells() const override;
+    QList<QAccessibleInterface*> rowHeaderCells() const override;
+    int columnIndex() const override;
+    int rowIndex() const override;
+    int columnExtent() const override;
+    int rowExtent() const override;
+    QAccessibleInterface* table() const override;
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
@@ -1,4 +1,4 @@
-// This file implements accessibility interface for RegistersView
+// This file implements accessibility interface for title row of AbstractTableView
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleAbstractTableViewCellTitle.h"
 #include "AccessibleAbstractTableView.h"

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
@@ -9,30 +9,28 @@ AccessibleAbstractTableViewCellTitle::AccessibleAbstractTableViewCellTitle(Acces
 
 QString AccessibleAbstractTableViewCellTitle::text(QAccessible::Text t) const
 {
-    AbstractTableView* w = mParent->m_tableView;
-    switch(t)
+    AbstractTableView* w = mParent->getTable();
+    if(t == QAccessible::Value)
     {
-    case QAccessible::Value:
-        return w->getColTitle(column);
-    default:
-        return QString();
+        return w->getColTitle(mParent->logicalColumn(column));
     }
+    return QString();
 }
 
 QColor AccessibleAbstractTableViewCellTitle::foregroundColor() const
 {
-    return mParent->m_tableView->mHeaderTextColor;
+    return mParent->getTable()->mHeaderTextColor;
 }
 
 QColor AccessibleAbstractTableViewCellTitle::backgroundColor() const
 {
-    return mParent->m_tableView->mHeaderBackgroundColor;
+    return mParent->getTable()->mHeaderBackgroundColor;
 }
 
 QAccessible::State AccessibleAbstractTableViewCellTitle::state() const
 {
     QAccessible::State state;
-    state.focusable = mParent->m_tableView->getRowCount() > 0;
+    state.focusable = mParent->getTable()->getRowCount() > 0;
     state.active = state.focusable;
     state.selectable = false;
     state.selected = false;
@@ -43,12 +41,11 @@ QAccessible::State AccessibleAbstractTableViewCellTitle::state() const
 
 QRect AccessibleAbstractTableViewCellTitle::rect() const
 {
-    const auto & table = mParent->m_tableView;
+    const auto table = mParent->getTable();
     int height = table->getHeaderHeight();
-    auto & actualColumn = table->mColumnOrder[column];
     QPoint pos(table->getColumnPosition(column), 0);
     pos = table->mapToGlobal(pos);
-    return QRect(pos, QSize(table->getColumnWidth(actualColumn), height));
+    return QRect(pos, QSize(table->getColumnWidth(mParent->logicalColumn(column)), height));
 }
 
 QList<QAccessibleInterface*> AccessibleAbstractTableViewCellTitle::rowHeaderCells() const

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
@@ -1,0 +1,64 @@
+// This file implements accessibility interface for RegistersView
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleAbstractTableViewCellTitle.h"
+#include "AccessibleAbstractTableView.h"
+
+AccessibleAbstractTableViewCellTitle::AccessibleAbstractTableViewCellTitle(AccessibleAbstractTableView* parent, int column) : AccessibleAbstractTableViewCell(parent, 0, column)
+{
+}
+
+QString AccessibleAbstractTableViewCellTitle::text(QAccessible::Text t) const
+{
+    AbstractTableView* w = mParent->m_tableView;
+    switch(t)
+    {
+    case QAccessible::Value:
+        return w->getColTitle(column);
+    default:
+        return QString();
+    }
+}
+
+QColor AccessibleAbstractTableViewCellTitle::foregroundColor() const
+{
+    return mParent->m_tableView->mHeaderTextColor;
+}
+
+QColor AccessibleAbstractTableViewCellTitle::backgroundColor() const
+{
+    return mParent->m_tableView->mHeaderBackgroundColor;
+}
+
+QAccessible::State AccessibleAbstractTableViewCellTitle::state() const
+{
+    QAccessible::State state;
+    state.focusable = mParent->m_tableView->getRowCount() > 0;
+    state.active = state.focusable;
+    state.selectable = false;
+    state.selected = false;
+    state.focused = false;
+    state.readOnly = true;
+    return state;
+}
+
+QRect AccessibleAbstractTableViewCellTitle::rect() const
+{
+    const auto & table = mParent->m_tableView;
+    int height = table->getHeaderHeight();
+    auto & actualColumn = table->mColumnOrder[column];
+    QPoint pos(table->getColumnPosition(column), 0);
+    pos = table->mapToGlobal(pos);
+    return QRect(pos, QSize(table->getColumnWidth(actualColumn), height));
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableViewCellTitle::rowHeaderCells() const
+{
+    return QList<QAccessibleInterface*>();
+}
+
+QList<QAccessibleInterface*> AccessibleAbstractTableViewCellTitle::columnHeaderCells() const
+{
+    return QList<QAccessibleInterface*>({(QAccessibleInterface*)this});
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.cpp
@@ -36,6 +36,7 @@ QAccessible::State AccessibleAbstractTableViewCellTitle::state() const
     state.selected = false;
     state.focused = false;
     state.readOnly = true;
+    state.invisible = mParent->getTable()->getHeaderHeight() == 0;
     return state;
 }
 

--- a/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.h
+++ b/src/gui/Src/Accessible/AccessibleAbstractTableViewCellTitle.h
@@ -1,0 +1,22 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "AccessibleAbstractTableViewCell.h"
+
+class AccessibleAbstractTableView;
+
+class AccessibleAbstractTableViewCellTitle : public AccessibleAbstractTableViewCell
+{
+public:
+    AccessibleAbstractTableViewCellTitle(AccessibleAbstractTableView* parent, int column);
+    // QAccessibleInterface
+    QString text(QAccessible::Text t) const override;
+    QColor foregroundColor() const override;
+    QColor backgroundColor() const override;
+    QAccessible::State state() const override;
+    QList<QAccessibleInterface*> rowHeaderCells() const override;
+    QList<QAccessibleInterface*> columnHeaderCells() const override;
+    QRect rect() const override;
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleDisassembly.cpp
+++ b/src/gui/Src/Accessible/AccessibleDisassembly.cpp
@@ -1,0 +1,166 @@
+// This file implements accessibility interface for Disassembly
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleDisassembly.h"
+#include "Disassembly.h"
+#include "Bridge.h"
+
+AccessibleDisassembly::AccessibleDisassembly(QWidget* w) : AccessibleAbstractTableView(w)
+{
+}
+
+AccessibleDisassembly::~AccessibleDisassembly()
+{
+}
+
+Disassembly* AccessibleDisassembly::dis() const
+{
+    return dynamic_cast<Disassembly*>(m_tableView);
+}
+
+bool AccessibleDisassembly::isRowSelected(int row) const
+{
+    // row includes title
+    auto dis = this->dis();
+    try
+    {
+        return dis->getInitialSelection() == dis->mInstBuffer.at(row - 1).rva;
+    }
+    catch(std::out_of_range)
+    {
+        return false;
+    }
+}
+
+// TODO: multi-selection
+int AccessibleDisassembly::selectedRowCount() const
+{
+    // row includes title
+    auto dis = this->dis();
+    const auto & inst = dis->mInstBuffer;
+    auto sel = dis->getInitialSelection();
+    if(sel >= inst.first().rva && sel <= inst.back().rva)
+        return 1;
+    else
+        return 0;
+}
+
+static int findFirstSelection(duint sel, const QList<Instruction_t> & inst)
+{
+    if(sel >= inst.first().rva && sel <= inst.back().rva)
+    {
+        for(int i = 0; i < inst.size(); i++)
+        {
+            if(inst[i].rva == sel)
+            {
+                return i + 1;
+            }
+        }
+    }
+    return -1;
+}
+
+QList<int> AccessibleDisassembly::selectedRows() const
+{
+    auto dis = this->dis();
+    int selectedRow = findFirstSelection(dis->getInitialSelection(), dis->mInstBuffer);
+    if(selectedRow != -1)
+        return QList<int>({ selectedRow });
+    else
+        return QList<int>();
+}
+
+int AccessibleDisassembly::selectedCellCount() const
+{
+    return selectedRowCount();
+}
+
+QList<QAccessibleInterface*> AccessibleDisassembly::selectedCells() const
+{
+    auto dis = this->dis();
+    int selectedRow = findFirstSelection(dis->getInitialSelection(), dis->mInstBuffer);
+    if(selectedRow != -1)
+        return QList<QAccessibleInterface*>({ cellAt(selectedRow, selectedColumns().first()) });
+    else
+        return QList<QAccessibleInterface*>();
+}
+
+static QString getDisassemblyMnemonicBrief(const Instruction_t & inst)
+{
+    char brief[MAX_STRING_SIZE] = "";
+    QString mnem;
+    for(const ZydisTokenizer::SingleToken & token : inst.tokens.tokens)
+    {
+        if(token.type != ZydisTokenizer::TokenType::Space && token.type != ZydisTokenizer::TokenType::Prefix)
+        {
+            mnem = token.text;
+            break;
+        }
+    }
+    if(mnem.isEmpty())
+        mnem = inst.instStr;
+
+    int index = mnem.indexOf(' ');
+    if(index != -1)
+        mnem.truncate(index);
+    DbgFunctions()->GetMnemonicBrief(mnem.toUtf8().constData(), MAX_STRING_SIZE, brief);
+    return QString::fromUtf8(brief);
+}
+
+QString AccessibleDisassembly::getCellContent(int row, int col) const
+{
+    const Disassembly & d = *dis();
+    const Instruction_t & inst = d.mInstBuffer.at(row);
+    duint cur_addr = d.rvaToVa(inst.rva);
+    switch(col)
+    {
+    case Disassembly::ColAddress:
+    {
+        QString label;
+        return d.getAddrText(cur_addr, label, true);
+    }
+    case Disassembly::ColBytes:
+    {
+        QString bytes;
+        RichTextPainter::htmlRichText(d.getRichBytes(inst, false), nullptr, bytes);
+        return bytes;
+    }
+    case Disassembly::ColDisassembly:
+    {
+        QString disassembly;
+        for(const auto & token : inst.tokens.tokens)
+            disassembly += token.text;
+        return disassembly;
+    }
+    case Disassembly::ColMnemonicBrief:
+    {
+        RichTextPainter::List richText;
+        if(d.mShowMnemonicBrief)
+            return getDisassemblyMnemonicBrief(inst);
+        else
+            return QString();
+    }
+    case Disassembly::ColComment:
+    {
+        QString comment;
+        bool autocomment;
+        GetCommentFormat(cur_addr, comment, &autocomment);
+        if(autocomment || comment.isEmpty())  // prefer label over auto-comment
+        {
+            char label[MAX_LABEL_SIZE];
+            if(DbgGetLabelAt(cur_addr, SEG_DEFAULT, label))
+            {
+                comment = QString::fromUtf8(label);
+            }
+        }
+        if(d.mShowMnemonicBrief && d.getColumnHidden(Disassembly::ColMnemonicBrief))
+        {
+            comment += ' ' + getDisassemblyMnemonicBrief(inst);
+        }
+        return comment;
+    }
+    default:
+        return QString();
+    }
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleDisassembly.cpp
+++ b/src/gui/Src/Accessible/AccessibleDisassembly.cpp
@@ -133,7 +133,6 @@ QString AccessibleDisassembly::getCellContent(int row, int col) const
     }
     case Disassembly::ColMnemonicBrief:
     {
-        RichTextPainter::List richText;
         if(d.mShowMnemonicBrief)
             return getDisassemblyMnemonicBrief(inst);
         else

--- a/src/gui/Src/Accessible/AccessibleDisassembly.h
+++ b/src/gui/Src/Accessible/AccessibleDisassembly.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "AccessibleAbstractTableView.h"
+#include "Disassembly.h"
+
+class AccessibleDisassembly : public AccessibleAbstractTableView
+{
+public:
+    AccessibleDisassembly(QWidget* w);
+    ~AccessibleDisassembly();
+
+    bool isRowSelected(int row) const override;
+    QList<int> selectedRows() const override;
+    int selectedRowCount() const override;
+    int selectedCellCount() const override;
+    QList<QAccessibleInterface*> selectedCells() const override;
+private:
+    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
+    Disassembly* dis() const;
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleHexDump.cpp
+++ b/src/gui/Src/Accessible/AccessibleHexDump.cpp
@@ -1,0 +1,85 @@
+// This file implements accessibility interface for HexDump
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleHexDump.h"
+#include "HexDump.h"
+#include "Bridge.h"
+
+AccessibleHexDump::AccessibleHexDump(QWidget* w) : AccessibleAbstractTableView(w)
+{
+}
+
+AccessibleHexDump::~AccessibleHexDump()
+{
+}
+
+HexDump* AccessibleHexDump::dump() const
+{
+    return dynamic_cast<HexDump*>(m_tableView);
+}
+
+static int findFirstSelection(HexDump* dump)
+{
+    auto sel = dump->getInitialSelection();
+    if(sel >= dump->getTableOffsetRva() && sel <= dump->getTableOffsetRva() + dump->getViewableRowsCount() * dump->getBytePerRowCount())
+        return (dump->getInitialSelection() - dump->getTableOffsetRva()) / dump->getBytePerRowCount();
+    else
+        return -1;
+}
+
+bool AccessibleHexDump::isRowSelected(int row) const
+{
+    // row includes title
+    return row - 1 == findFirstSelection(dump());
+}
+
+// TODO: multi-selection
+int AccessibleHexDump::selectedRowCount() const
+{
+    // row includes title
+    auto dump = this->dump();
+    auto sel = dump->getInitialSelection();
+    if(sel >= dump->getTableOffsetRva() && sel <= dump->getTableOffsetRva() + dump->getViewableRowsCount() * dump->getBytePerRowCount())
+        return 1;
+    else
+        return 0;
+}
+
+QList<int> AccessibleHexDump::selectedRows() const
+{
+    int selectedRow = findFirstSelection(dump());
+    if(selectedRow != -1)
+        return QList<int>({ selectedRow });
+    else
+        return QList<int>();
+}
+
+int AccessibleHexDump::selectedCellCount() const
+{
+    return selectedRowCount();
+}
+
+QList<QAccessibleInterface*> AccessibleHexDump::selectedCells() const
+{
+    int selectedRow = findFirstSelection(dump());
+    if(selectedRow != -1)
+        return QList<QAccessibleInterface*>({ cellAt(selectedRow, selectedColumns().first()) });
+    else
+        return QList<QAccessibleInterface*>();
+}
+
+QString AccessibleHexDump::getCellContent(int row, int col) const
+{
+    const HexDump & dump = *this->dump();
+    RichTextPainter::List richText;
+    // Compute RVA
+    duint rva = row * dump.getBytePerRowCount() + dump.getTableOffsetRva();
+    dump.getColumnRichText(col, rva, richText);
+    QString str;
+    for(const auto & i : richText)
+    {
+        str += i.text + ' ';
+    }
+    return str;
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleHexDump.h
+++ b/src/gui/Src/Accessible/AccessibleHexDump.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "AccessibleAbstractTableView.h"
+#include "HexDump.h"
+
+class AccessibleHexDump : public AccessibleAbstractTableView
+{
+public:
+    AccessibleHexDump(QWidget* w);
+    ~AccessibleHexDump();
+
+    bool isRowSelected(int row) const override;
+    QList<int> selectedRows() const override;
+    int selectedRowCount() const override;
+    int selectedCellCount() const override;
+    QList<QAccessibleInterface*> selectedCells() const override;
+private:
+    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
+    HexDump* dump() const;
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -2,14 +2,8 @@
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleRegistersView.h"
 
-AccessibleRegistersViewItem::AccessibleRegistersViewItem() : mParent(nullptr), id(RegistersView::REGISTER_NAME::CAX)
+AccessibleRegistersViewItem::AccessibleRegistersViewItem(AccessibleRegistersView* parent, RegistersView::REGISTER_NAME id) : mParent(parent), id(id)
 {
-}
-
-void AccessibleRegistersViewItem::setRegistersView(AccessibleRegistersView* parent, int id)
-{
-    this->mParent = parent;
-    this->id = (RegistersView::REGISTER_NAME)id;
 }
 
 QString AccessibleRegistersViewItem::text(QAccessible::Text t) const
@@ -20,8 +14,8 @@ QString AccessibleRegistersViewItem::text(QAccessible::Text t) const
     case QAccessible::Name:
     case QAccessible::Value:
         if(w->mLABELDISPLAY.contains(id))
-            return QString(w->mRegisterMapping[id]) + " = " + w->GetRegStringValueFromValue(w->mSelected, w->registerValue(&w->mRegDumpStruct, w->mSelected)) + ' ' + w->getRegisterLabel(id);
-        return QString(w->mRegisterMapping[id]) + " = " + w->GetRegStringValueFromValue(w->mSelected, w->registerValue(&w->mRegDumpStruct, w->mSelected));
+            return QString(w->mRegisterMapping[id]) + " = " + w->GetRegStringValueFromValue(id, w->registerValue(&w->mRegDumpStruct, id)) + ' ' + w->getRegisterLabel(id);
+        return QString(w->mRegisterMapping[id]) + " = " + w->GetRegStringValueFromValue(id, w->registerValue(&w->mRegDumpStruct, id));
     case QAccessible::Help:
         return w->helpRegister(id);
     default:
@@ -53,7 +47,7 @@ QWindow* AccessibleRegistersViewItem::window() const
 
 QAccessibleInterface* AccessibleRegistersViewItem::parent() const
 {
-    return dynamic_cast<QAccessibleInterface*>(mParent);
+    return mParent;
 }
 
 QAccessibleInterface* AccessibleRegistersViewItem::child(int index) const
@@ -142,8 +136,7 @@ QAccessibleInterface* AccessibleRegistersView::child(int index) const
         }
         else
         {
-            auto child = new AccessibleRegistersViewItem();
-            child->setRegistersView(const_cast<AccessibleRegistersView*>(this), index);
+            auto child = new AccessibleRegistersViewItem(const_cast<AccessibleRegistersView*>(this), (RegistersView::REGISTER_NAME)index);
             interfaces[index] = QAccessible::registerAccessibleInterface(child);
             return child;
         }
@@ -164,7 +157,10 @@ QAccessibleInterface* AccessibleRegistersView::childAt(int x, int y) const
 
 QAccessibleInterface* AccessibleRegistersView::focusChild() const
 {
-    return child(m_registersView->mSelected);
+    if(m_registersView->mSelected < RegistersView::UNKNOWN)
+        return child(m_registersView->mSelected);
+    else
+        return (QAccessibleInterface*)this;
 }
 
 bool AccessibleRegistersView::isValid() const

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -181,7 +181,24 @@ QAccessibleInterface* AccessibleRegistersView::childAt(int x, int y) const
     if(m_registersView->identifyRegister((local.y() - m_registersView->yTopSpacing) / (double)m_registersView->mRowHeight, local.x() / (double)m_registersView->mCharWidth, &clickedReg))
         if(clickedReg < RegistersView::UNKNOWN)
             return child(static_cast<int>(clickedReg));
-    return (QAccessibleInterface*)this;
+    return nullptr;
+}
+
+int AccessibleRegistersView::indexOfChild(const QAccessibleInterface* child) const
+{
+    for(int i = 0; i < interfaces.size(); i++)
+    {
+        unsigned int id = interfaces[i];
+        if(id != 0)
+        {
+            QAccessibleInterface* a = QAccessible::accessibleInterface(id);
+            if(a == child)
+            {
+                return i;
+            }
+        }
+    }
+    return -1;
 }
 
 QAccessibleInterface* AccessibleRegistersView::focusChild() const

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -69,13 +69,14 @@ QAccessible::Role AccessibleRegistersViewItem::role() const
 QAccessible::State AccessibleRegistersViewItem::state() const
 {
     QAccessible::State state;
-    state.focusable = mParent->m_registersView->isActive;
-    state.active = mParent->m_registersView->isActive;
-    state.selectable = mParent->m_registersView->isActive;
-    if(mParent->m_registersView->mSelected == id)
+    const RegistersView* parent = mParent->m_registersView;
+    state.focusable = parent->isActive;
+    state.active = parent->isActive;
+    state.selectable = parent->isActive;
+    if(parent->mSelected == id)
     {
         state.selected = true;
-        if(mParent->m_registersView->hasFocus())
+        if(parent->hasFocus())
             state.focused = true;
     }
     return state;

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -1,6 +1,7 @@
 // This file implements accessibility interface for RegistersView
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleRegistersView.h"
+#include "StringUtil.h"
 
 AccessibleRegistersViewItem::AccessibleRegistersViewItem(AccessibleRegistersView* parent, RegistersView::REGISTER_NAME id) : mParent(parent), id(id)
 {
@@ -96,7 +97,35 @@ void AccessibleRegistersViewItem::setText(QAccessible::Text t, const QString & t
 
 QRect AccessibleRegistersViewItem::rect() const
 {
-    return QRect();
+    QRect rect;
+    const RegistersView* parent = mParent->m_registersView;
+    const auto & it = parent->mRegisterPlaces.constFind(id);
+    if(it == parent->mRegisterPlaces.cend())
+    {
+        return rect;
+    }
+    int top, bottom, left, right;
+    top = it.value().line * parent->mRowHeight + parent->yTopSpacing;
+    bottom = top + parent->mRowHeight;
+    // These registers occupy a whole line
+    if(it.key() >= RegistersView::CAX && it.key() <= RegistersView::EFLAGS
+            || it.key() >= RegistersView::MM0 && it.key() <= RegistersView::MM7
+            || it.key() >= RegistersView::DR0 && it.key() <= RegistersView::DR7
+            || it.key() >= RegistersView::K0 && it.key() <= RegistersView::K7
+            || it.key() >= RegistersView::XMM0 && it.key() <= ArchValue(RegistersView::XMM7, RegistersView::XMM31))
+    {
+        const QScrollArea* upperScrollArea = (const QScrollArea*)parent->parentWidget()->parentWidget();
+        left = 0;
+        right = upperScrollArea->width();
+    }
+    else
+    {
+        left = (1 + it.value().start) * parent->mCharWidth;
+        right = left + ((it.value().labelwidth + it.value().valuesize) * parent->mCharWidth);
+    }
+    const QPoint TL = parent->mapToGlobal(QPoint(left, top));
+    const QPoint BR = parent->mapToGlobal(QPoint(right, bottom));
+    return QRect(TL, BR);
 }
 
 bool AccessibleRegistersViewItem::isValid() const
@@ -149,7 +178,7 @@ QAccessibleInterface* AccessibleRegistersView::childAt(int x, int y) const
 {
     RegistersView::REGISTER_NAME clickedReg;
     QPoint local = m_registersView->mapFromGlobal(QPoint(x, y));
-    if(m_registersView->identifyRegister(local.y(), local.x(), &clickedReg))
+    if(m_registersView->identifyRegister((local.y() - m_registersView->yTopSpacing) / (double)m_registersView->mRowHeight, local.x() / (double)m_registersView->mCharWidth, &clickedReg))
         if(clickedReg < RegistersView::UNKNOWN)
             return child(static_cast<int>(clickedReg));
     return (QAccessibleInterface*)this;
@@ -185,5 +214,19 @@ QAccessible::State AccessibleRegistersView::state() const
     state.disabled = !m_registersView->isActive;
     state.hasPopup = true;
     return state;
+}
+
+QRect AccessibleRegistersView::rect() const
+{
+    QRect rect;
+    const QScrollArea* upperScrollArea = (const QScrollArea*)m_registersView->parentWidget()->parentWidget();
+    int top, bottom, left, right;
+    top = 0;
+    bottom = upperScrollArea->height();
+    left = 0;
+    right = upperScrollArea->width();
+    const QPoint TL = upperScrollArea->mapToGlobal(QPoint(left, top));
+    const QPoint BR = upperScrollArea->mapToGlobal(QPoint(right, bottom));
+    return QRect(TL, BR);
 }
 #endif

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -114,7 +114,7 @@ QRect AccessibleRegistersViewItem::rect() const
             || it.key() >= RegistersView::K0 && it.key() <= RegistersView::K7
             || it.key() >= RegistersView::XMM0 && it.key() <= ArchValue(RegistersView::XMM7, RegistersView::XMM31))
     {
-        const QScrollArea* upperScrollArea = (const QScrollArea*)parent->parentWidget()->parentWidget();
+        const QWidget* upperScrollArea = (const QWidget*)parent->parentWidget()->parentWidget();
         left = 0;
         right = upperScrollArea->width();
     }

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -150,7 +150,7 @@ AccessibleRegistersView::~AccessibleRegistersView()
 int AccessibleRegistersView::childCount() const
 {
     // TODO: interact with showFPU
-    return m_registersView->mAVX512RegistersShown ? RegistersView::REGISTER_NAME::UNKNOWN : RegistersView::REGISTER_NAME::XMM16;
+    return m_registersView->mAVX512RegistersShown ? RegistersView::REGISTER_NAME::UNKNOWN : ArchValue(RegistersView::REGISTER_NAME::XMM7, RegistersView::REGISTER_NAME::XMM16);
 }
 
 QAccessibleInterface* AccessibleRegistersView::child(int index) const

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -1,0 +1,193 @@
+// This file implements accessibility interface for RegistersView
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleRegistersView.h"
+
+AccessibleRegistersViewItem::AccessibleRegistersViewItem() : mParent(nullptr), id(RegistersView::REGISTER_NAME::CAX)
+{
+}
+
+void AccessibleRegistersViewItem::setRegistersView(AccessibleRegistersView* parent, int id)
+{
+    this->mParent = parent;
+    this->id = (RegistersView::REGISTER_NAME)id;
+}
+
+QString AccessibleRegistersViewItem::text(QAccessible::Text t) const
+{
+    RegistersView* w = mParent->m_registersView;
+    switch(t)
+    {
+    case QAccessible::Name:
+    case QAccessible::Value:
+        if(w->mLABELDISPLAY.contains(id))
+            return QString(w->mRegisterMapping[id]) + " = " + w->GetRegStringValueFromValue(w->mSelected, w->registerValue(&w->mRegDumpStruct, w->mSelected)) + ' ' + w->getRegisterLabel(id);
+        return QString(w->mRegisterMapping[id]) + " = " + w->GetRegStringValueFromValue(w->mSelected, w->registerValue(&w->mRegDumpStruct, w->mSelected));
+    case QAccessible::Help:
+        return w->helpRegister(id);
+    default:
+        return QString();
+    }
+}
+
+QColor AccessibleRegistersViewItem::foregroundColor() const
+{
+    if(mParent->m_registersView->mRegisterUpdates.contains(id))
+    {
+        return ConfigColor("RegistersModifiedColor");
+    }
+    else
+    {
+        return ConfigColor("RegistersColor");
+    }
+}
+
+int AccessibleRegistersViewItem::childCount() const
+{
+    return 0;
+}
+
+QWindow* AccessibleRegistersViewItem::window() const
+{
+    return mParent->window();
+}
+
+QAccessibleInterface* AccessibleRegistersViewItem::parent() const
+{
+    return dynamic_cast<QAccessibleInterface*>(mParent);
+}
+
+QAccessibleInterface* AccessibleRegistersViewItem::child(int index) const
+{
+    return nullptr;
+}
+
+int AccessibleRegistersViewItem::indexOfChild(const QAccessibleInterface* child) const
+{
+    return -1;
+}
+
+QAccessible::Role AccessibleRegistersViewItem::role() const
+{
+    return QAccessible::ListItem;
+}
+
+QAccessible::State AccessibleRegistersViewItem::state() const
+{
+    QAccessible::State state;
+    state.focusable = mParent->m_registersView->isActive;
+    state.active = mParent->m_registersView->isActive;
+    state.selectable = mParent->m_registersView->isActive;
+    if(mParent->m_registersView->mSelected == id)
+    {
+        state.selected = true;
+        if(mParent->m_registersView->hasFocus())
+            state.focused = true;
+    }
+    return state;
+}
+
+QAccessibleInterface* AccessibleRegistersViewItem::childAt(int x, int y) const
+{
+    return nullptr;
+}
+
+QObject* AccessibleRegistersViewItem::object() const
+{
+    return nullptr;
+}
+
+void AccessibleRegistersViewItem::setText(QAccessible::Text t, const QString & text)
+{
+}
+
+QRect AccessibleRegistersViewItem::rect() const
+{
+    return QRect();
+}
+
+bool AccessibleRegistersViewItem::isValid() const
+{
+    return mParent->m_registersView->isActive;
+}
+
+AccessibleRegistersView::AccessibleRegistersView(QWidget* w) : QAccessibleWidget(w, QAccessible::List, dynamic_cast<RegistersView*>(w)->accessibleName())
+{
+    m_registersView = dynamic_cast<RegistersView*>(w);
+    interfaces.fill(0);
+}
+
+AccessibleRegistersView::~AccessibleRegistersView()
+{
+    for(auto & i : interfaces)
+    {
+        if(i != 0)
+        {
+            QAccessible::deleteAccessibleInterface(i);
+        }
+    }
+}
+
+int AccessibleRegistersView::childCount() const
+{
+    return RegistersView::REGISTER_NAME::UNKNOWN;
+}
+
+QAccessibleInterface* AccessibleRegistersView::child(int index) const
+{
+    if(index >= 0 && index < childCount())
+    {
+        if(interfaces[index] != 0)
+        {
+            return QAccessible::accessibleInterface(interfaces[index]);
+        }
+        else
+        {
+            auto child = new AccessibleRegistersViewItem();
+            child->setRegistersView(const_cast<AccessibleRegistersView*>(this), index);
+            interfaces[index] = QAccessible::registerAccessibleInterface(child);
+            return child;
+        }
+    }
+    else
+        return nullptr;
+}
+
+QAccessibleInterface* AccessibleRegistersView::childAt(int x, int y) const
+{
+    RegistersView::REGISTER_NAME clickedReg;
+    QPoint local = m_registersView->mapFromGlobal(QPoint(x, y));
+    if(m_registersView->identifyRegister(local.y(), local.x(), &clickedReg))
+        if(clickedReg < RegistersView::UNKNOWN)
+            return child(static_cast<int>(clickedReg));
+    return (QAccessibleInterface*)this;
+}
+
+QAccessibleInterface* AccessibleRegistersView::focusChild() const
+{
+    return child(m_registersView->mSelected);
+}
+
+bool AccessibleRegistersView::isValid() const
+{
+    return m_registersView->isActive;
+}
+
+QAccessible::Role AccessibleRegistersView::role() const
+{
+    return QAccessible::List;
+}
+
+QAccessible::State AccessibleRegistersView::state() const
+{
+    QAccessible::State state;
+    state.focusable = true;
+    if(m_registersView->hasFocus())
+        state.focused = true;
+    state.active = m_registersView->isActive;
+    state.multiLine = true;
+    state.multiSelectable = false;
+    state.disabled = !m_registersView->isActive;
+    state.hasPopup = true;
+    return state;
+}
+#endif

--- a/src/gui/Src/Accessible/AccessibleRegistersView.cpp
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.cpp
@@ -136,39 +136,28 @@ bool AccessibleRegistersViewItem::isValid() const
 AccessibleRegistersView::AccessibleRegistersView(QWidget* w) : QAccessibleWidget(w, QAccessible::List, dynamic_cast<RegistersView*>(w)->accessibleName())
 {
     m_registersView = dynamic_cast<RegistersView*>(w);
-    interfaces.fill(0);
+    for(int i = 0; i < interfaces.size(); i++)
+    {
+        interfaces[i] = QAccessible::registerAccessibleInterface(new AccessibleRegistersViewItem(this, (RegistersView::REGISTER_NAME)i));
+    }
 }
 
 AccessibleRegistersView::~AccessibleRegistersView()
 {
-    for(auto & i : interfaces)
-    {
-        if(i != 0)
-        {
-            QAccessible::deleteAccessibleInterface(i);
-        }
-    }
+    std::for_each(interfaces.cbegin(), interfaces.cend(), QAccessible::deleteAccessibleInterface);
 }
 
 int AccessibleRegistersView::childCount() const
 {
-    return RegistersView::REGISTER_NAME::UNKNOWN;
+    // TODO: interact with showFPU
+    return m_registersView->mAVX512RegistersShown ? RegistersView::REGISTER_NAME::UNKNOWN : RegistersView::REGISTER_NAME::XMM16;
 }
 
 QAccessibleInterface* AccessibleRegistersView::child(int index) const
 {
     if(index >= 0 && index < childCount())
     {
-        if(interfaces[index] != 0)
-        {
-            return QAccessible::accessibleInterface(interfaces[index]);
-        }
-        else
-        {
-            auto child = new AccessibleRegistersViewItem(const_cast<AccessibleRegistersView*>(this), (RegistersView::REGISTER_NAME)index);
-            interfaces[index] = QAccessible::registerAccessibleInterface(child);
-            return child;
-        }
+        return QAccessible::accessibleInterface(interfaces[index]);
     }
     else
         return nullptr;
@@ -186,16 +175,12 @@ QAccessibleInterface* AccessibleRegistersView::childAt(int x, int y) const
 
 int AccessibleRegistersView::indexOfChild(const QAccessibleInterface* child) const
 {
-    for(int i = 0; i < interfaces.size(); i++)
+    for(int i = 0; i < childCount(); i++)
     {
-        unsigned int id = interfaces[i];
-        if(id != 0)
+        const QAccessibleInterface* a = this->child(i);
+        if(a == child)
         {
-            QAccessibleInterface* a = QAccessible::accessibleInterface(id);
-            if(a == child)
-            {
-                return i;
-            }
+            return i;
         }
     }
     return -1;
@@ -212,11 +197,6 @@ QAccessibleInterface* AccessibleRegistersView::focusChild() const
 bool AccessibleRegistersView::isValid() const
 {
     return m_registersView->isActive;
-}
-
-QAccessible::Role AccessibleRegistersView::role() const
-{
-    return QAccessible::List;
 }
 
 QAccessible::State AccessibleRegistersView::state() const

--- a/src/gui/Src/Accessible/AccessibleRegistersView.h
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.h
@@ -40,6 +40,7 @@ public:
     int childCount() const override;
     QAccessibleInterface* child(int index) const override;
     QAccessibleInterface* childAt(int x, int y) const override;
+    int indexOfChild(const QAccessibleInterface* child) const override;
     QAccessibleInterface* focusChild() const override;
     bool isValid() const override;
     QAccessible::Role role() const override;

--- a/src/gui/Src/Accessible/AccessibleRegistersView.h
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.h
@@ -1,0 +1,50 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <array>
+#include <QAccessibleWidget>
+#include "../Gui/RegistersView.h"
+
+class AccessibleRegistersView;
+
+class AccessibleRegistersViewItem : public QAccessibleInterface
+{
+    RegistersView::REGISTER_NAME id;
+    AccessibleRegistersView* mParent;
+public:
+    AccessibleRegistersViewItem();
+    void setRegistersView(AccessibleRegistersView* parent, int id);
+
+    QString text(QAccessible::Text t) const override;
+    QColor foregroundColor() const override;
+    QWindow* window() const override;
+    QAccessibleInterface* parent() const override;
+    QAccessibleInterface* child(int index) const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
+    QObject* object() const override;
+    void setText(QAccessible::Text t, const QString & text) override;
+    QRect rect() const override;
+    int indexOfChild(const QAccessibleInterface* child) const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+    int childCount() const override;
+    bool isValid() const override;
+};
+
+class AccessibleRegistersView : public QAccessibleWidget
+{
+    mutable std::array<QAccessible::Id, (size_t)RegistersView::UNKNOWN> interfaces;
+    friend class AccessibleRegistersViewItem;
+    RegistersView* m_registersView;
+public:
+    AccessibleRegistersView(QWidget* w);
+    ~AccessibleRegistersView();
+    int childCount() const override;
+    QAccessibleInterface* child(int index) const override;
+    QAccessibleInterface* QAccessibleInterface::childAt(int x, int y) const override;
+    QAccessibleInterface* focusChild() const override;
+    bool isValid() const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleRegistersView.h
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.h
@@ -44,6 +44,7 @@ public:
     bool isValid() const override;
     QAccessible::Role role() const override;
     QAccessible::State state() const override;
+    QRect rect() const override;
 };
 
 #endif

--- a/src/gui/Src/Accessible/AccessibleRegistersView.h
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.h
@@ -2,7 +2,7 @@
 #ifndef QT_NO_ACCESSIBILITY
 #include <array>
 #include <QAccessibleWidget>
-#include "../Gui/RegistersView.h"
+#include "Gui/RegistersView.h"
 
 class AccessibleRegistersView;
 
@@ -11,8 +11,7 @@ class AccessibleRegistersViewItem : public QAccessibleInterface
     RegistersView::REGISTER_NAME id;
     AccessibleRegistersView* mParent;
 public:
-    AccessibleRegistersViewItem();
-    void setRegistersView(AccessibleRegistersView* parent, int id);
+    AccessibleRegistersViewItem(AccessibleRegistersView* parent, RegistersView::REGISTER_NAME id);
 
     QString text(QAccessible::Text t) const override;
     QColor foregroundColor() const override;
@@ -40,7 +39,7 @@ public:
     ~AccessibleRegistersView();
     int childCount() const override;
     QAccessibleInterface* child(int index) const override;
-    QAccessibleInterface* QAccessibleInterface::childAt(int x, int y) const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
     QAccessibleInterface* focusChild() const override;
     bool isValid() const override;
     QAccessible::Role role() const override;

--- a/src/gui/Src/Accessible/AccessibleRegistersView.h
+++ b/src/gui/Src/Accessible/AccessibleRegistersView.h
@@ -43,7 +43,6 @@ public:
     int indexOfChild(const QAccessibleInterface* child) const override;
     QAccessibleInterface* focusChild() const override;
     bool isValid() const override;
-    QAccessible::Role role() const override;
     QAccessible::State state() const override;
     QRect rect() const override;
 };

--- a/src/gui/Src/Accessible/AccessibleStdTable.cpp
+++ b/src/gui/Src/Accessible/AccessibleStdTable.cpp
@@ -1,0 +1,52 @@
+// This file implements accessibility interface for RegistersView
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleStdTable.h"
+#include "StdTable.h"
+
+AccessibleStdTable::AccessibleStdTable(QWidget* w) : AccessibleAbstractTableView(w)
+{
+}
+
+AccessibleStdTable::~AccessibleStdTable()
+{
+}
+
+bool AccessibleStdTable::isRowSelected(int row) const
+{
+    auto table = this->table();
+    return table->getInitialSelection() == row + table->getTableOffset();
+}
+
+QString AccessibleStdTable::getCellContent(int row, int column) const
+{
+    auto table = this->table();
+    return table->getCellContent(table->getTableOffset() + row, column);
+}
+
+AbstractStdTable* AccessibleStdTable::table() const
+{
+    return dynamic_cast<AbstractStdTable*>(m_tableView);
+}
+
+// TODO: multi-selection
+int AccessibleStdTable::selectedRowCount() const
+{
+    auto table = this->table();
+    dsint r = table->getInitialSelection() - table->getTableOffset();
+    if(r >= 0 && r <= rowCount())
+        return 1;
+    else
+        return 0;
+}
+
+QList<int> AccessibleStdTable::selectedRows() const
+{
+    auto table = this->table();
+    dsint r = table->getInitialSelection() - table->getTableOffset();
+    if(r >= 0 && r <= rowCount())
+        return QList<int>({ (int)r });
+    else
+        return QList<int>();
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleStdTable.cpp
+++ b/src/gui/Src/Accessible/AccessibleStdTable.cpp
@@ -1,4 +1,4 @@
-// This file implements accessibility interface for RegistersView
+// This file implements accessibility interface for AccessibleStdTable
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleStdTable.h"
 #include "StdTable.h"
@@ -51,4 +51,23 @@ QList<int> AccessibleStdTable::selectedRows() const
         return QList<int>();
 }
 
+int AccessibleStdTable::selectedCellCount() const
+{
+    auto table = this->table();
+    dsint r = table->getInitialSelection() - table->getTableOffset();
+    if(r >= 0 && r <= rowCount() - 1)
+        return 1;
+    else
+        return 0;
+}
+
+QList<QAccessibleInterface*> AccessibleStdTable::selectedCells() const
+{
+    auto table = this->table();
+    dsint r = table->getInitialSelection() - table->getTableOffset();
+    if(r >= 0 && r <= rowCount() - 1)
+        return QList<QAccessibleInterface*>({ cellAt(r + 1, selectedColumns().first())});
+    else
+        return QList<QAccessibleInterface*>();
+}
 #endif

--- a/src/gui/Src/Accessible/AccessibleStdTable.cpp
+++ b/src/gui/Src/Accessible/AccessibleStdTable.cpp
@@ -1,4 +1,4 @@
-// This file implements accessibility interface for AccessibleStdTable
+// This file implements accessibility interface for StdTable
 #ifndef QT_NO_ACCESSIBILITY
 #include "AccessibleStdTable.h"
 #include "StdTable.h"

--- a/src/gui/Src/Accessible/AccessibleStdTable.cpp
+++ b/src/gui/Src/Accessible/AccessibleStdTable.cpp
@@ -13,12 +13,14 @@ AccessibleStdTable::~AccessibleStdTable()
 
 bool AccessibleStdTable::isRowSelected(int row) const
 {
+    // row includes title
     auto table = this->table();
-    return table->getInitialSelection() == row + table->getTableOffset();
+    return table->getInitialSelection() == row + table->getTableOffset() - 1;
 }
 
 QString AccessibleStdTable::getCellContent(int row, int column) const
 {
+    // row excludes title
     auto table = this->table();
     return table->getCellContent(table->getTableOffset() + row, column);
 }
@@ -33,7 +35,7 @@ int AccessibleStdTable::selectedRowCount() const
 {
     auto table = this->table();
     dsint r = table->getInitialSelection() - table->getTableOffset();
-    if(r >= 0 && r <= rowCount())
+    if(r >= 0 && r <= rowCount() - 1)
         return 1;
     else
         return 0;
@@ -43,7 +45,7 @@ QList<int> AccessibleStdTable::selectedRows() const
 {
     auto table = this->table();
     dsint r = table->getInitialSelection() - table->getTableOffset();
-    if(r >= 0 && r <= rowCount())
+    if(r >= 0 && r <= rowCount() - 1)
         return QList<int>({ (int)r });
     else
         return QList<int>();

--- a/src/gui/Src/Accessible/AccessibleStdTable.h
+++ b/src/gui/Src/Accessible/AccessibleStdTable.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "AccessibleAbstractTableView.h"
+#include "AbstractStdTable.h"
+
+class AccessibleStdTable : public AccessibleAbstractTableView
+{
+public:
+    AccessibleStdTable(QWidget* w);
+    ~AccessibleStdTable();
+
+    bool isRowSelected(int row) const override;
+    QList<int> selectedRows() const override;
+    int selectedRowCount() const override;
+private:
+    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
+    AbstractStdTable* table() const;
+};
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleStdTable.h
+++ b/src/gui/Src/Accessible/AccessibleStdTable.h
@@ -13,6 +13,8 @@ public:
     bool isRowSelected(int row) const override;
     QList<int> selectedRows() const override;
     int selectedRowCount() const override;
+    int selectedCellCount() const override;
+    QList<QAccessibleInterface*> selectedCells() const override;
 private:
     virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
     AbstractStdTable* table() const;

--- a/src/gui/Src/Accessible/AccessibleTraceBrowser.cpp
+++ b/src/gui/Src/Accessible/AccessibleTraceBrowser.cpp
@@ -1,0 +1,152 @@
+// This file implements accessibility interface for Disassembly
+#ifndef QT_NO_ACCESSIBILITY
+#include "AccessibleTraceBrowser.h"
+#include "Tracer/TraceBrowser.h"
+#include "Bridge.h"
+
+AccessibleTraceBrowser::AccessibleTraceBrowser(QWidget* w) : AccessibleAbstractTableView(w)
+{
+}
+
+AccessibleTraceBrowser::~AccessibleTraceBrowser()
+{
+}
+
+TraceBrowser* AccessibleTraceBrowser::dis() const
+{
+    return dynamic_cast<TraceBrowser*>(m_tableView);
+}
+
+bool AccessibleTraceBrowser::isRowSelected(int row) const
+{
+    // row includes title
+    if(row == 0)
+        return false;
+    auto dis = this->dis();
+    return dis->accessibilitySelectedRow() == row - 1;
+}
+
+// TODO: multi-selection
+int AccessibleTraceBrowser::selectedRowCount() const
+{
+    // row includes title
+    auto dis = this->dis();
+    dsint sel = dis->getInitialSelection() - dis->getTableOffset();
+    if(sel >= 0 && sel <= dis->getViewableRowsCount())
+        return 1;
+    else
+        return 0;
+}
+
+QList<int> AccessibleTraceBrowser::selectedRows() const
+{
+    auto dis = this->dis();
+    int selectedRow = dis->accessibilitySelectedRow();
+    if(selectedRow != -1)
+        return QList<int>({ selectedRow });
+    else
+        return QList<int>();
+}
+
+int AccessibleTraceBrowser::selectedCellCount() const
+{
+    return selectedRowCount();
+}
+
+QList<QAccessibleInterface*> AccessibleTraceBrowser::selectedCells() const
+{
+    auto dis = this->dis();
+    int selectedRow = dis->accessibilitySelectedRow();
+    if(selectedRow != -1)
+        return QList<QAccessibleInterface*>({ cellAt(selectedRow, selectedColumns().first()) });
+    else
+        return QList<QAccessibleInterface*>();
+}
+
+static QString getDisassemblyMnemonicBrief(const Instruction_t & inst)
+{
+    char brief[MAX_STRING_SIZE] = "";
+    QString mnem;
+    for(const ZydisTokenizer::SingleToken & token : inst.tokens.tokens)
+    {
+        if(token.type != ZydisTokenizer::TokenType::Space && token.type != ZydisTokenizer::TokenType::Prefix)
+        {
+            mnem = token.text;
+            break;
+        }
+    }
+    if(mnem.isEmpty())
+        mnem = inst.instStr;
+
+    int index = mnem.indexOf(' ');
+    if(index != -1)
+        mnem.truncate(index);
+    DbgFunctions()->GetMnemonicBrief(mnem.toUtf8().constData(), MAX_STRING_SIZE, brief);
+    return QString::fromUtf8(brief);
+}
+
+QString AccessibleTraceBrowser::getCellContent(int row, int col) const
+{
+    TraceBrowser & d = *dis();
+    TRACEINDEX index = row + d.getTableOffset();
+    QString reason;
+    auto & traceFile = *d.mTraceFile;
+    Instruction_t inst = traceFile.Instruction(index);
+    REGDUMP reg;
+    reg = traceFile.Registers(index);
+    duint cur_addr = reg.regcontext.cip;
+    if(traceFile.isError(reason))
+    {
+        return QString();
+    }
+    switch(col)
+    {
+    case TraceBrowser::TableColumnIndex::Index:
+        return traceFile.getIndexText(index);
+    case TraceBrowser::TableColumnIndex::Address:
+    {
+        return d.getAddrText(cur_addr, nullptr, true);
+    }
+    case TraceBrowser::TableColumnIndex::Opcode:
+    {
+        QString bytes;
+        RichTextPainter::htmlRichText(d.getRichBytes(inst), nullptr, bytes);
+        return bytes;
+    }
+    case TraceBrowser::TableColumnIndex::Disassembly:
+    {
+        return inst.tokens.toString();
+    }
+    case TraceBrowser::TableColumnIndex::Registers:
+    {
+        return d.registersTokens(index).toString();
+    }
+    case TraceBrowser::TableColumnIndex::Memory:
+    {
+        return d.memoryTokens(index).toString();
+    }
+    case TraceBrowser::TableColumnIndex::Comments:
+    {
+        QString comment;
+        bool autocomment;
+        GetCommentFormat(cur_addr, comment, &autocomment);
+        if(autocomment || comment.isEmpty())  // prefer label over auto-comment
+        {
+            char label[MAX_LABEL_SIZE];
+            if(DbgGetLabelAt(cur_addr, SEG_DEFAULT, label))
+            {
+                comment = QString::fromUtf8(label);
+            }
+        }
+        if(d.mShowMnemonicBrief)
+        {
+            comment += ' ' + getDisassemblyMnemonicBrief(inst);
+        }
+        return comment;
+    }
+    default:
+        return QString();
+    }
+}
+
+#endif

--- a/src/gui/Src/Accessible/AccessibleTraceBrowser.h
+++ b/src/gui/Src/Accessible/AccessibleTraceBrowser.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef QT_NO_ACCESSIBILITY
+#include <QAccessibleWidget>
+#include "AccessibleAbstractTableView.h"
+#include "Tracer/TraceBrowser.h"
+
+class AccessibleTraceBrowser : public AccessibleAbstractTableView
+{
+public:
+    AccessibleTraceBrowser(QWidget* w);
+    ~AccessibleTraceBrowser();
+
+    bool isRowSelected(int row) const override;
+    QList<int> selectedRows() const override;
+    int selectedRowCount() const override;
+    int selectedCellCount() const override;
+    QList<QAccessibleInterface*> selectedCells() const override;
+private:
+    virtual QString getCellContent(int row, int col) const; // Get plain text of a cell
+    TraceBrowser* dis() const;
+};
+
+#endif

--- a/src/gui/Src/BasicView/AbstractStdTable.cpp
+++ b/src/gui/Src/BasicView/AbstractStdTable.cpp
@@ -1,3 +1,4 @@
+#include <QAccessible>
 #include "AbstractStdTable.h"
 #include "Bridge.h"
 #include <Utils/RichTextPainter.h>
@@ -387,6 +388,7 @@ void AbstractStdTable::mousePressEvent(QMouseEvent* event)
 
                     // TODO: only update if the selection actually changed
                     updateViewport();
+                    accessibilityMousePressSetColumn(event);
 
                     accept = true;
                 }
@@ -538,12 +540,14 @@ void AbstractStdTable::expandSelectionUpTo(duint to)
         mSelection.fromIndex = to;
         mSelection.toIndex = mSelection.firstSelectedIndex;
         emit selectionChanged(to);
+        accessibilitySelectionChanged();
     }
     else if(to > mSelection.firstSelectedIndex)
     {
         mSelection.fromIndex = mSelection.firstSelectedIndex;
         mSelection.toIndex = to;
         emit selectionChanged(to);
+        accessibilitySelectionChanged();
     }
     else if(to == mSelection.firstSelectedIndex)
     {
@@ -569,6 +573,7 @@ void AbstractStdTable::expandUp()
         }
 
         emit selectionChanged(rowIndex);
+        accessibilitySelectionChanged();
     }
 }
 
@@ -593,6 +598,7 @@ void AbstractStdTable::expandDown()
 
 
         emit selectionChanged(rowIndex);
+        accessibilitySelectionChanged();
     }
 }
 
@@ -619,6 +625,7 @@ void AbstractStdTable::setSingleSelection(duint index)
     mSelection.fromIndex = index;
     mSelection.toIndex = index;
     emit selectionChanged(index);
+    accessibilitySelectionChanged();
 }
 
 duint AbstractStdTable::getInitialSelection() const
@@ -1077,4 +1084,9 @@ duint AbstractStdTable::getAddressForPosition(int x, int y)
     }
     else
         return 0;
+}
+
+int AbstractStdTable::accessibilitySelectedRow() const
+{
+    return getInitialSelection() - getTableOffset();
 }

--- a/src/gui/Src/BasicView/AbstractStdTable.cpp
+++ b/src/gui/Src/BasicView/AbstractStdTable.cpp
@@ -1,4 +1,3 @@
-#include <QAccessible>
 #include "AbstractStdTable.h"
 #include "Bridge.h"
 #include <Utils/RichTextPainter.h>

--- a/src/gui/Src/BasicView/AbstractStdTable.h
+++ b/src/gui/Src/BasicView/AbstractStdTable.h
@@ -151,4 +151,5 @@ protected:
     QAction* mCopyTableToLog;
     QAction* mCopyTableResizeToLog;
     QAction* mExportTableCSV;
+    int accessibilitySelectedRow() const override;
 };

--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -1,4 +1,5 @@
 #include "AbstractTableView.h"
+#include <QAccessible>
 #include <QStyleOptionButton>
 #include <cinttypes>
 #include "Configuration.h"
@@ -67,6 +68,7 @@ void AbstractTableView::Initialize()
     // of VTable changes
     //
     // Init all other updates once
+    accessibilitySelectedColumn = 0;
     updateColors();
     updateFonts();
     updateShortcuts();
@@ -467,6 +469,7 @@ void AbstractTableView::mousePressEvent(QMouseEvent* event)
                 updateViewport();
             }
         }
+        accessibilityMousePressSetColumn(event);
     }
     else //right/middle click
     {
@@ -685,6 +688,7 @@ void AbstractTableView::resizeEvent(QResizeEvent* event)
     {
         emit viewableRowsChanged(getViewableRowsCount());
         mShouldReload = true;
+        accessibilityTableModelChanged();
     }
     QAbstractScrollArea::resizeEvent(event);
 }
@@ -728,6 +732,27 @@ void AbstractTableView::keyPressEvent(QKeyEvent* event)
     }
     else
     {
+        if(QAccessible::isActive())
+        {
+            QAccessibleInterface* iface = QAccessible::queryAccessibleInterface(this);
+            if(iface)
+            {
+                QAccessibleTableInterface* tface = (QAccessibleTableInterface*)iface->interface_cast(QAccessible::TableInterface);
+                if(tface)
+                {
+                    if(key == Qt::Key_Left && accessibilitySelectedColumn > 0)
+                    {
+                        accessibilitySelectedColumn--;
+                        accessibilitySelectionChanged();
+                    }
+                    else if(key == Qt::Key_Right && accessibilitySelectedColumn < tface->columnCount() - 1)
+                    {
+                        accessibilitySelectedColumn++;
+                        accessibilitySelectionChanged();
+                    }
+                }
+            }
+        }
         QAbstractScrollArea::keyPressEvent(event);
     }
 }
@@ -1090,7 +1115,7 @@ int AbstractTableView::transY(int y) const
  */
 duint AbstractTableView::getViewableRowsCount() const
 {
-    auto tableHeight = viewport()->height() - getHeaderHeight();
+    auto tableHeight = std::max(0, viewport()->height() - getHeaderHeight());
     auto count = tableHeight / getRowHeight();
 
     count += (tableHeight % getRowHeight()) > 0 ? 1 : 0;
@@ -1125,6 +1150,7 @@ void AbstractTableView::addColumnAt(int width, const QString & title, bool isCli
     mColumnList.append(column);
 
     updateLastColumnWidth();
+    accessibilityTableModelChanged();
 }
 
 void AbstractTableView::setRowCount(duint count)
@@ -1139,12 +1165,14 @@ void AbstractTableView::setRowCount(duint count)
     });
 
     // TODO: report if mTableOffset is out of view
+    accessibilityTableModelChanged();
 }
 
 void AbstractTableView::deleteAllColumns()
 {
     mColumnList.clear();
     mColumnOrder.clear();
+    accessibilityTableModelChanged();
 }
 
 void AbstractTableView::setColTitle(duint col, const QString & title)
@@ -1368,4 +1396,57 @@ duint AbstractTableView::getAddressForPosition(int x, int y)
     Q_UNUSED(x);
     Q_UNUSED(y);
     return 0;
+}
+
+int AbstractTableView::accessibilitySelectedRow() const
+{
+    return 0;
+}
+
+void AbstractTableView::accessibilitySelectionChanged()
+{
+    if(QAccessible::isActive())
+    {
+        QAccessibleInterface* accessible = QAccessible::queryAccessibleInterface(this);
+        QAccessibleEvent selectionEvent(accessible, QAccessible::SectionChanged);
+        QAccessible::updateAccessibility(&selectionEvent);
+        if(hasFocus())
+        {
+            QAccessibleTableInterface* tableInterface = (QAccessibleTableInterface*)accessible->interface_cast(QAccessible::TableInterface);
+            assert(tableInterface);
+            QAccessibleInterface* cell = tableInterface->cellAt(accessibilitySelectedRow(), accessibilitySelectedColumn);
+            if(cell)
+            {
+                QAccessibleEvent focusEvent(cell, QAccessible::Focus);
+                QAccessible::updateAccessibility(&focusEvent);
+            }
+        }
+    }
+}
+
+void AbstractTableView::accessibilityTableModelChanged()
+{
+    if(QAccessible::isActive())
+    {
+        QAccessibleInterface* accessibleInterface = QAccessible::queryAccessibleInterface(this);
+        QAccessibleTableModelChangeEvent model(accessibleInterface, QAccessibleTableModelChangeEvent::ModelReset);
+        model.setFirstColumn(0);
+        model.setFirstRow(0);
+        if(getViewableRowsCount() < getRowCount())
+            model.setLastRow(getViewableRowsCount());
+        else
+            model.setLastRow(getRowCount());
+        model.setLastColumn(getColumnCount());
+        QAccessible::updateAccessibility(&model);
+    }
+}
+
+void AbstractTableView::accessibilityMousePressSetColumn(QMouseEvent* event)
+{
+    // update selected column
+    if(QAccessible::isActive() && mHeader.isVisible && getColumnCount() && event->y() > getHeaderHeight())
+    {
+        accessibilitySelectedColumn = getColumnIndexFromX(event->x());
+        accessibilitySelectionChanged();
+    }
 }

--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -1446,7 +1446,20 @@ void AbstractTableView::accessibilityMousePressSetColumn(QMouseEvent* event)
     // update selected column
     if(QAccessible::isActive() && mHeader.isVisible && getColumnCount() && event->y() > getHeaderHeight())
     {
-        accessibilitySelectedColumn = getColumnIndexFromX(event->x());
+        accessibilitySelectedColumn = getColumnDisplayIndexFromX(event->x());
+        if(accessibilitySelectedColumn == -1)
+        {
+            accessibilitySelectedColumn = 0;
+        }
+        else
+        {
+            // Exclude hidden columns
+            for(int colIndex = 0; colIndex < accessibilitySelectedColumn; colIndex++)
+            {
+                if(getColumnHidden(mColumnOrder[colIndex]))
+                    accessibilitySelectedColumn--;
+            }
+        }
         accessibilitySelectionChanged();
     }
 }

--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -1414,7 +1414,7 @@ void AbstractTableView::accessibilitySelectionChanged()
         {
             QAccessibleTableInterface* tableInterface = (QAccessibleTableInterface*)accessible->interface_cast(QAccessible::TableInterface);
             assert(tableInterface);
-            QAccessibleInterface* cell = tableInterface->cellAt(accessibilitySelectedRow(), accessibilitySelectedColumn);
+            QAccessibleInterface* cell = tableInterface->cellAt(accessibilitySelectedRow() + 1, accessibilitySelectedColumn);
             if(cell)
             {
                 QAccessibleEvent focusEvent(cell, QAccessible::Focus);
@@ -1433,9 +1433,9 @@ void AbstractTableView::accessibilityTableModelChanged()
         model.setFirstColumn(0);
         model.setFirstRow(0);
         if(getViewableRowsCount() < getRowCount())
-            model.setLastRow(getViewableRowsCount());
+            model.setLastRow(getViewableRowsCount() + 1);
         else
-            model.setLastRow(getRowCount());
+            model.setLastRow(getRowCount() + 1);
         model.setLastColumn(getColumnCount());
         QAccessible::updateAccessibility(&model);
     }

--- a/src/gui/Src/BasicView/AbstractTableView.cpp
+++ b/src/gui/Src/BasicView/AbstractTableView.cpp
@@ -1412,13 +1412,17 @@ void AbstractTableView::accessibilitySelectionChanged()
         QAccessible::updateAccessibility(&selectionEvent);
         if(hasFocus())
         {
-            QAccessibleTableInterface* tableInterface = (QAccessibleTableInterface*)accessible->interface_cast(QAccessible::TableInterface);
-            assert(tableInterface);
-            QAccessibleInterface* cell = tableInterface->cellAt(accessibilitySelectedRow() + 1, accessibilitySelectedColumn);
-            if(cell)
+            auto sel = accessibilitySelectedRow();
+            if(sel != -1)
             {
-                QAccessibleEvent focusEvent(cell, QAccessible::Focus);
-                QAccessible::updateAccessibility(&focusEvent);
+                QAccessibleTableInterface* tableInterface = (QAccessibleTableInterface*)accessible->interface_cast(QAccessible::TableInterface);
+                assert(tableInterface);
+                QAccessibleInterface* cell = tableInterface->cellAt(sel + 1, accessibilitySelectedColumn);
+                if(cell)
+                {
+                    QAccessibleEvent focusEvent(cell, QAccessible::Focus);
+                    QAccessible::updateAccessibility(&focusEvent);
+                }
             }
         }
     }
@@ -1444,7 +1448,7 @@ void AbstractTableView::accessibilityTableModelChanged()
 void AbstractTableView::accessibilityMousePressSetColumn(QMouseEvent* event)
 {
     // update selected column
-    if(QAccessible::isActive() && mHeader.isVisible && getColumnCount() && event->y() > getHeaderHeight())
+    if(QAccessible::isActive() && getColumnCount() && event->y() > getHeaderHeight())
     {
         accessibilitySelectedColumn = getColumnDisplayIndexFromX(event->x());
         if(accessibilitySelectedColumn == -1)

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -238,4 +238,9 @@ protected:
 
     friend class AccessibleAbstractTableView;
     friend class AccessibleAbstractTableViewCell;
+    void accessibilitySelectionChanged();
+    void accessibilityTableModelChanged();
+    int accessibilitySelectedColumn;
+    virtual int accessibilitySelectedRow() const;
+    void accessibilityMousePressSetColumn(QMouseEvent* event);
 };

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -241,7 +241,7 @@ protected:
     friend class AccessibleAbstractTableViewCellTitle;
     void accessibilitySelectionChanged();
     void accessibilityTableModelChanged();
-    int accessibilitySelectedColumn;
+    int accessibilitySelectedColumn; // display index excluding hidden columns
     virtual int accessibilitySelectedRow() const;
     void accessibilityMousePressSetColumn(QMouseEvent* event);
 };

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -238,6 +238,7 @@ protected:
 
     friend class AccessibleAbstractTableView;
     friend class AccessibleAbstractTableViewCell;
+    friend class AccessibleAbstractTableViewCellTitle;
     void accessibilitySelectionChanged();
     void accessibilityTableModelChanged();
     int accessibilitySelectedColumn;

--- a/src/gui/Src/BasicView/AbstractTableView.h
+++ b/src/gui/Src/BasicView/AbstractTableView.h
@@ -235,4 +235,7 @@ protected:
     void invalidateCachedFont();
 
     ColumnReorderDialog* mReorderDialog = nullptr;
+
+    friend class AccessibleAbstractTableView;
+    friend class AccessibleAbstractTableViewCell;
 };

--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -831,6 +831,7 @@ void Disassembly::mousePressEvent(QMouseEvent* event)
                     updateViewport();
 
                     accept = true;
+                    accessibilityMousePressSetColumn(event);
                 }
             }
         }
@@ -1589,6 +1590,7 @@ void Disassembly::selectionChangedSlot(duint Va)
     }
     if(DbgIsDebugging())
         DbgXrefGet(Va, &mXrefInfo);
+    accessibilitySelectionChanged();
 }
 
 void Disassembly::selectNext(bool expand)
@@ -2261,7 +2263,7 @@ bool Disassembly::historyHasNext() const
     return true;
 }
 
-QString Disassembly::getAddrText(duint cur_addr, QString & label, bool getLabel)
+QString Disassembly::getAddrText(duint cur_addr, QString & label, bool getLabel) const
 {
     QString addrText = "";
     if(mRvaDisplayEnabled) //RVA display
@@ -2388,4 +2390,15 @@ bool Disassembly::followInstruction(duint rva)
     }
 #endif // X64DBG
     return false;
+}
+
+int Disassembly::accessibilitySelectedRow() const
+{
+    auto sel = getInitialSelection();
+    for(int i = 0; i < mInstBuffer.size(); i++)
+    {
+        if(mInstBuffer[i].rva == sel)
+            return i;
+    }
+    return -1;
 }

--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -83,7 +83,7 @@ public:
     QList<Instruction_t>* instructionsBuffer(); // ugly
     const duint baseAddress() const;
 
-    QString getAddrText(duint cur_addr, QString & label, bool getLabel = true);
+    QString getAddrText(duint cur_addr, QString & label, bool getLabel = true) const;
     void prepareDataCount(const QList<duint> & rvas, QList<Instruction_t>* instBuffer);
     void prepareDataRange(duint startRva, duint endRva, const std::function<bool(int, const Instruction_t &)> & disassembled);
     RichTextPainter::List getRichBytes(const Instruction_t & instr, bool isSelected) const;
@@ -279,4 +279,6 @@ protected:
 
     void paintRichText(int x, int y, int w, int h, int xinc, const RichTextPainter::List & richText, int rowOffset, int column);
     void paintRichText(int x, int y, int w, int h, int xinc, RichTextPainter::List && richText, int rowOffset, int column);
+    friend class AccessibleDisassembly;
+    int accessibilitySelectedRow() const override;
 };

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include <QFloat16>
 #include <QDebug>
+#include <QAccessible>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QStringDecoder>
@@ -54,6 +55,7 @@ HexDump::HexDump(Architecture* architecture, QWidget* parent, MemoryPage* memPag
     connect(Bridge::getBridge(), SIGNAL(updateDump()), this, SLOT(updateDumpSlot()));
     connect(Bridge::getBridge(), SIGNAL(dbgStateChanged(DBGSTATE)), this, SLOT(debugStateChanged(DBGSTATE)));
     connect(this, &HexDump::selectionUpdated, this, &HexDump::updateSelectionUnderline);
+    connect(this, SIGNAL(selectionUpdated()), this, SLOT(selectionChangedSlot()));
     setupCopyMenu();
 
     Initialize();
@@ -347,7 +349,7 @@ QString HexDump::makeAddrText(duint va) const
     return std::move(addrText);
 }
 
-QString HexDump::makeCopyText()
+QString HexDump::makeCopyText() const
 {
     auto deltaRowBase = getSelectionStart() % getBytePerRowCount() + mByteOffset;
     if(deltaRowBase >= getBytePerRowCount())
@@ -559,6 +561,7 @@ void HexDump::mousePressEvent(QMouseEvent* event)
 
                         // TODO: only update if the selection actually changed
                         updateViewport();
+                        accessibilityMousePressSetColumn(event);
                     }
                 }
                 else if(colIndex == 0)
@@ -588,6 +591,7 @@ void HexDump::mousePressEvent(QMouseEvent* event)
 
                         // TODO: only update if the selection actually changed
                         updateViewport();
+                        accessibilityMousePressSetColumn(event);
                     }
                 }
 
@@ -699,6 +703,26 @@ void HexDump::keyPressEvent(QKeyEvent* event)
             if(granularity > 1)
                 expandSelectionUpTo(selStart + granularity - 1);
             reloadData();
+            if(QAccessible::isActive())
+            {
+                QAccessibleInterface* iface = QAccessible::queryAccessibleInterface(this);
+                if(iface)
+                {
+                    QAccessibleTableInterface* tface = (QAccessibleTableInterface*)iface->interface_cast(QAccessible::TableInterface);
+                    if(tface)
+                    {
+                        if(key == Qt::Key_Left && accessibilitySelectedColumn > 0)
+                        {
+                            accessibilitySelectedColumn--;
+                        }
+                        else if(key == Qt::Key_Right && accessibilitySelectedColumn < tface->columnCount() - 1)
+                        {
+                            accessibilitySelectedColumn++;
+                        }
+                    }
+                }
+                accessibilitySelectionChanged();
+            }
         }
     }
     else if(modifiers == Qt::ControlModifier || modifiers == (Qt::ControlModifier | Qt::AltModifier))
@@ -861,7 +885,7 @@ bool HexDump::isSelected(duint rva) const
     return rva >= mSelection.fromIndex && rva <= mSelection.toIndex;
 }
 
-void HexDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText)
+void HexDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const
 {
     RichTextPainter::CustomRichText_t curData;
     curData.underline = false;
@@ -1023,31 +1047,31 @@ void HexDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & ri
     }
 }
 
-void HexDump::toString(DataDescriptor desc, duint rva, uint8_t* data, RichTextPainter::CustomRichText_t & richText) //convert data to string
+void HexDump::toString(DataDescriptor desc, duint rva, const uint8_t* data, RichTextPainter::CustomRichText_t & richText) const //convert data to string
 {
     switch(desc.itemSize)
     {
     case Byte:
     {
-        byteToString(rva, *((uint8_t*)data), desc.byteMode, richText);
+        byteToString(rva, *((const uint8_t*)data), desc.byteMode, richText);
     }
     break;
 
     case Word:
     {
-        wordToString(rva, *((uint16_t*)data), desc.wordMode, richText);
+        wordToString(rva, *((const uint16_t*)data), desc.wordMode, richText);
     }
     break;
 
     case Dword:
     {
-        dwordToString(rva, *((uint32_t*)data), desc.dwordMode, richText);
+        dwordToString(rva, *((const uint32_t*)data), desc.dwordMode, richText);
     }
     break;
 
     case Qword:
     {
-        qwordToString(rva, *((uint64_t*)data), desc.qwordMode, richText);
+        qwordToString(rva, *((const uint64_t*)data), desc.qwordMode, richText);
     }
     break;
 
@@ -1073,7 +1097,7 @@ void HexDump::toString(DataDescriptor desc, duint rva, uint8_t* data, RichTextPa
         richText.textColor = ConfigColor("HexDumpModifiedBytesColor");
 }
 
-void HexDump::byteToString(duint rva, uint8_t byte, ByteViewMode mode, RichTextPainter::CustomRichText_t & richText)
+void HexDump::byteToString(duint rva, uint8_t byte, ByteViewMode mode, RichTextPainter::CustomRichText_t & richText) const
 {
     QString str = "";
 
@@ -1160,7 +1184,7 @@ void HexDump::byteToString(duint rva, uint8_t byte, ByteViewMode mode, RichTextP
     }
 }
 
-void HexDump::wordToString(duint rva, uint16_t word, WordViewMode mode, RichTextPainter::CustomRichText_t & richText)
+void HexDump::wordToString(duint rva, uint16_t word, WordViewMode mode, RichTextPainter::CustomRichText_t & richText) const
 {
     Q_UNUSED(rva);
     QString str;
@@ -1296,7 +1320,7 @@ void HexDump::qwordToString(duint rva, uint64_t qword, QwordViewMode mode, RichT
     richText.text = str;
 }
 
-void HexDump::twordToString(duint rva, void* tword, TwordViewMode mode, RichTextPainter::CustomRichText_t & richText)
+void HexDump::twordToString(duint rva, const void* tword, TwordViewMode mode, RichTextPainter::CustomRichText_t & richText)
 {
     Q_UNUSED(rva);
     QString str;
@@ -1652,4 +1676,18 @@ void HexDump::debugStateChanged(DBGSTATE state)
         setRowCount(0);
         reloadData();
     }
+}
+
+void HexDump::selectionChangedSlot()
+{
+    accessibilitySelectionChanged();
+}
+
+int HexDump::accessibilitySelectedRow() const
+{
+    auto sel = getInitialSelection();
+    if(sel >= getTableOffsetRva() && sel <= getTableOffsetRva() + getViewableRowsCount() * getBytePerRowCount())
+        return (getInitialSelection() - getTableOffsetRva()) / getBytePerRowCount();
+    else
+        return -1;
 }

--- a/src/gui/Src/BasicView/HexDump.h
+++ b/src/gui/Src/BasicView/HexDump.h
@@ -106,17 +106,17 @@ public:
     duint getSelectionEnd() const;
     bool isSelected(duint rva) const;
 
-    virtual void getColumnRichText(duint column, duint rva, RichTextPainter::List & richText);
+    virtual void getColumnRichText(duint column, duint rva, RichTextPainter::List & richText) const;
 
     static size_t getSizeOf(DataSize size);
 
-    void toString(DataDescriptor desc, duint rva, uint8_t* data, RichTextPainter::CustomRichText_t & richText);
+    void toString(DataDescriptor desc, duint rva, const uint8_t* data, RichTextPainter::CustomRichText_t & richText) const;
 
-    void byteToString(duint rva, uint8_t byte, ByteViewMode mode, RichTextPainter::CustomRichText_t & richText);
-    void wordToString(duint rva, uint16_t word, WordViewMode mode, RichTextPainter::CustomRichText_t & richText);
+    void byteToString(duint rva, uint8_t byte, ByteViewMode mode, RichTextPainter::CustomRichText_t & richText) const;
+    void wordToString(duint rva, uint16_t word, WordViewMode mode, RichTextPainter::CustomRichText_t & richText) const;
     static void dwordToString(duint rva, uint32_t dword, DwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
     static void qwordToString(duint rva, uint64_t qword, QwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
-    static void twordToString(duint rva, void* tword, TwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
+    static void twordToString(duint rva, const void* tword, TwordViewMode mode, RichTextPainter::CustomRichText_t & richText);
 
     int getItemIndexFromX(int x) const;
     duint getItemStartingAddress(int x, int y);
@@ -134,7 +134,7 @@ public:
 
     duint getTableOffsetRva() const;
     QString makeAddrText(duint va) const;
-    QString makeCopyText();
+    QString makeCopyText() const;
 
     void setupCopyMenu();
 
@@ -153,6 +153,7 @@ public slots:
     void gotoPreviousSlot();
     void gotoNextSlot();
     void updateSelectionUnderline();
+    void selectionChangedSlot();
 
 private:
     enum GuiState
@@ -208,7 +209,7 @@ private:
     } mUpdateCache;
     std::vector<uint8_t> mUpdateCacheData;
     std::vector<uint8_t> mUpdateCacheTemp;
-    std::vector<uint8_t> mReadBuffer;
+    mutable std::vector<uint8_t> mReadBuffer;
 
     std::vector<uint8_t> mUnderlineBuffer;
     std::vector<std::pair<duint, duint>> mUnderlineRanges;
@@ -232,4 +233,5 @@ protected:
     duint mUnderlineRangeEndVa = 0;
     bool mPointerUnderliningEnabled = true;
     bool mSelectionUnderliningEnabled = false;
+    int accessibilitySelectedRow() const override;
 };

--- a/src/gui/Src/BasicView/StdTable.cpp
+++ b/src/gui/Src/BasicView/StdTable.cpp
@@ -42,6 +42,7 @@ void StdTable::addColumnAt(int width, QString title, bool isClickable, QString c
 
     //append column sort function
     mColumnSortFunctions.push_back(sortFn);
+    accessibilityTableModelChanged();
 }
 
 void StdTable::deleteAllColumns()
@@ -50,6 +51,7 @@ void StdTable::deleteAllColumns()
     AbstractTableView::deleteAllColumns();
     mCopyTitles.clear();
     mColumnSortFunctions.clear();
+    accessibilityTableModelChanged();
 }
 
 void StdTable::setRowCount(duint count)
@@ -64,6 +66,7 @@ void StdTable::setRowCount(duint count)
         }
     }
     AbstractTableView::setRowCount(count);
+    accessibilityTableModelChanged();
 }
 
 void StdTable::setCellContent(duint r, duint c, QString s)

--- a/src/gui/Src/Disassembler/ZydisTokenizer.cpp
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.cpp
@@ -45,6 +45,7 @@ void ZydisTokenizer::UpdateColors()
     addColorName(TokenType::Uncategorized, "InstructionUncategorizedColor", "InstructionUncategorizedBackgroundColor");
     addColorName(TokenType::Address, "InstructionAddressColor", "InstructionAddressBackgroundColor"); //jump/call destinations
     addColorName(TokenType::Value, "InstructionValueColor", "InstructionValueBackgroundColor");
+    addColorName(TokenType::TraceNewValue, "TraceNewValueColor", "TraceNewValueBackgroundColor");
     //mnemonics
     addColorName(TokenType::MnemonicNormal, "InstructionMnemonicColor", "InstructionMnemonicBackgroundColor");
     addColorName(TokenType::MnemonicPushPop, "InstructionPushPopColor", "InstructionPushPopBackgroundColor");
@@ -215,7 +216,7 @@ void ZydisTokenizer::TokenizeTraceRegister(const char* reg, duint oldValue, duin
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, ": ", TokenValue()));
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(oldValue), TokenValue(8, oldValue)));
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, QString::fromUtf8("\xe2\x86\x92"), TokenValue())); // Right Arrow
-    tokens.push_back(SingleToken(TokenType::Value, ToHexString(newValue), TokenValue(8, newValue)));
+    tokens.push_back(SingleToken(TokenType::TraceNewValue, ToHexString(newValue), TokenValue(8, newValue)));
 }
 
 void ZydisTokenizer::TokenizeTraceMemory(duint address, duint oldValue, duint newValue, std::vector<SingleToken> & tokens)
@@ -228,7 +229,7 @@ void ZydisTokenizer::TokenizeTraceMemory(duint address, duint oldValue, duint ne
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, ": ", TokenValue()));
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(oldValue), TokenValue(8, oldValue)));
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, QString::fromUtf8("\xe2\x86\x92"), TokenValue())); // Right Arrow
-    tokens.push_back(SingleToken(TokenType::Value, ToHexString(newValue), TokenValue(8, newValue)));
+    tokens.push_back(SingleToken(TokenType::TraceNewValue, ToHexString(newValue), TokenValue(8, newValue)));
 }
 
 void ZydisTokenizer::UpdateConfig()

--- a/src/gui/Src/Disassembler/ZydisTokenizer.cpp
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.cpp
@@ -214,7 +214,7 @@ void ZydisTokenizer::TokenizeTraceRegister(const char* reg, duint oldValue, duin
     tokens.push_back(SingleToken(TokenType::GeneralRegister, ConfigBool("Disassembler", "Uppercase") ? regName.toUpper() : regName, TokenValue()));
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, ": ", TokenValue()));
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(oldValue), TokenValue(8, oldValue)));
-    tokens.push_back(SingleToken(TokenType::ArgumentSpace, "-> ", TokenValue()));
+    tokens.push_back(SingleToken(TokenType::ArgumentSpace, QString::fromUtf8("\xe2\x86\x92"), TokenValue())); // Right Arrow
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(newValue), TokenValue(8, newValue)));
 }
 
@@ -227,7 +227,7 @@ void ZydisTokenizer::TokenizeTraceMemory(duint address, duint oldValue, duint ne
     tokens.push_back(SingleToken(TokenType::Address, ToPtrString(address), TokenValue(8, address)));
     tokens.push_back(SingleToken(TokenType::ArgumentSpace, ": ", TokenValue()));
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(oldValue), TokenValue(8, oldValue)));
-    tokens.push_back(SingleToken(TokenType::ArgumentSpace, "-> ", TokenValue()));
+    tokens.push_back(SingleToken(TokenType::ArgumentSpace, QString::fromUtf8("\xe2\x86\x92"), TokenValue())); // Right Arrow
     tokens.push_back(SingleToken(TokenType::Value, ToHexString(newValue), TokenValue(8, newValue)));
 }
 

--- a/src/gui/Src/Disassembler/ZydisTokenizer.h
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.h
@@ -35,6 +35,7 @@ public:
         //values
         Address, //jump/call destinations or displacements inside memory
         Value,
+        TraceNewValue,
         //memory
         MemorySize,
         MemorySegment,

--- a/src/gui/Src/Disassembler/ZydisTokenizer.h
+++ b/src/gui/Src/Disassembler/ZydisTokenizer.h
@@ -111,6 +111,14 @@ public:
     {
         std::vector<SingleToken> tokens; //list of tokens that form the instruction
         int x = 0; //x of the first character
+
+        QString toString() const
+        {
+            QString text;
+            for(const auto & token : tokens)
+                text += token.text;
+            return text;
+        }
     };
 
     struct TokenColor

--- a/src/gui/Src/Gui/AppearanceDialog.cpp
+++ b/src/gui/Src/Gui/AppearanceDialog.cpp
@@ -528,6 +528,7 @@ void AppearanceDialog::colorInfoListInit()
     colorInfoListAppend(tr("Addresses"), "InstructionAddressColor", "InstructionAddressBackgroundColor");
     colorInfoListAppend(tr("Values"), "InstructionValueColor", "InstructionValueBackgroundColor");
     colorInfoListAppend(tr("Commas"), "InstructionCommaColor", "InstructionCommaBackgroundColor");
+    colorInfoListAppend(tr("New Values (Trace View)"), "TraceNewValueColor", "TraceNewValueBackgroundColor");
 
     colorInfoListAppend(tr("General Registers"), "InstructionGeneralRegisterColor", "InstructionGeneralRegisterBackgroundColor");
     colorInfoListAppend(tr("FPU Registers"), "InstructionFpuRegisterColor", "InstructionFpuRegisterBackgroundColor");

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -1590,8 +1590,7 @@ void CPUDisassembly::pushSelectionInto(bool copyBytes, QTextStream & stream, QTe
         }
         else
         {
-            for(const auto & token : inst.tokens.tokens)
-                disassembly += token.text;
+            disassembly = inst.tokens.toString();
         }
         QString fullComment;
         QString comment;

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -266,7 +266,7 @@ void CPUDump::getAttention()
     thread->start();
 }
 
-void CPUDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText)
+void CPUDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const
 {
     if(col && !mDescriptor.at(col - 1).isData && mDescriptor.at(col - 1).itemCount) //print comments
     {

--- a/src/gui/Src/Gui/CPUDump.h
+++ b/src/gui/Src/Gui/CPUDump.h
@@ -13,7 +13,7 @@ class CPUDump : public HexDump
     Q_OBJECT
 public:
     explicit CPUDump(CPUMultiDump* multiDump, CPUDisassembly* disasassembly, QWidget* parent = nullptr);
-    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) override;
+    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const override;
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
     void setupContextMenu();
     void getAttention();

--- a/src/gui/Src/Gui/CPURegistersView.cpp
+++ b/src/gui/Src/Gui/CPURegistersView.cpp
@@ -1,5 +1,4 @@
 #include <QListWidget>
-#include <QAccessibleEvent>
 #include "MiscUtil.h"
 #include "CPUWidget.h"
 #include "CPUDisassembly.h"

--- a/src/gui/Src/Gui/CPURegistersView.cpp
+++ b/src/gui/Src/Gui/CPURegistersView.cpp
@@ -1,4 +1,5 @@
 #include <QListWidget>
+#include <QAccessibleEvent>
 #include "MiscUtil.h"
 #include "CPUWidget.h"
 #include "CPUDisassembly.h"
@@ -145,7 +146,10 @@ void CPURegistersView::mousePressEvent(QMouseEvent* event)
             emit refresh();
         }
         else
+        {
             mSelected = UNKNOWN;
+        }
+        accessibilitySelectionChanged();
     }
 }
 

--- a/src/gui/Src/Gui/CPUStack.cpp
+++ b/src/gui/Src/Gui/CPUStack.cpp
@@ -308,7 +308,7 @@ void CPUStack::updateFreezeStackAction()
     mFreezeStack->setChecked(bStackFrozen);
 }
 
-void CPUStack::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText)
+void CPUStack::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const
 {
     // Compute VA
     duint va = rvaToVa(rva);

--- a/src/gui/Src/Gui/CPUStack.h
+++ b/src/gui/Src/Gui/CPUStack.h
@@ -17,7 +17,7 @@ public:
     void updateColors() override;
     void updateFonts() override;
 
-    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) override;
+    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const override;
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;

--- a/src/gui/Src/Gui/DebugStatusLabel.cpp
+++ b/src/gui/Src/Gui/DebugStatusLabel.cpp
@@ -1,4 +1,5 @@
 #include "DebugStatusLabel.h"
+#include <QAccessible>
 #include <QTextDocument>
 #include <QStyle>
 #include <QMetaEnum>
@@ -45,4 +46,11 @@ void DebugStatusLabel::debugStateChangedSlot(DBGSTATE state)
     this->style()->unpolish(this);
     this->style()->polish(this);
     this->update();
+
+    // Send accesibility events
+    if(QAccessible::isActive())
+    {
+        QAccessibleValueChangeEvent updateEvent(this, mStatusTexts[state]);
+        QAccessible::updateAccessibility(&updateEvent);
+    }
 }

--- a/src/gui/Src/Gui/LogStatusLabel.cpp
+++ b/src/gui/Src/Gui/LogStatusLabel.cpp
@@ -1,8 +1,10 @@
 #include "LogStatusLabel.h"
 #include "LogView.h"
 #include <QTextDocument>
+#include <QTextDocumentFragment>
 #include <QApplication>
 #include <QStatusBar>
+#include <QAccessible>
 
 LogStatusLabel::LogStatusLabel(QStatusBar* parent) : QLabel(parent)
 {
@@ -43,6 +45,12 @@ void LogStatusLabel::logUpdate(QString message, bool encodeHTML)
         }
     }
     setText(finalLabel);
+    // Send accesibility events
+    if(QAccessible::isActive())
+    {
+        QAccessibleValueChangeEvent updateEvent(this, QTextDocumentFragment::fromHtml(finalLabel).toPlainText());
+        QAccessible::updateAccessibility(&updateEvent);
+    }
 }
 
 void LogStatusLabel::logUpdateUtf8(QByteArray message)

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -3285,6 +3285,7 @@ void RegistersView::setRegisters(REGDUMP* reg)
         mCipRegDumpStruct = mRegDumpStruct;
 
     autoUpdateXMMModesAndRefresh();
+    accessibilityValueChanged();
 }
 
 void RegistersView::setRegisters(REGDUMP_AVX512* reg)
@@ -3314,6 +3315,7 @@ void RegistersView::setRegisters(REGDUMP_AVX512* reg)
         mCipRegDumpStruct = mRegDumpStruct;
 
     autoUpdateXMMModesAndRefresh();
+    accessibilityValueChanged();
 }
 
 // Scroll the viewport so that the register will be visible on the screen
@@ -3349,6 +3351,7 @@ void RegistersView::autoUpdateXMMModesAndRefresh()
     emit refresh();
 }
 
+// Send focused accessibility event
 void RegistersView::accessibilitySelectionChanged()
 {
     if(QAccessible::isActive())
@@ -3368,6 +3371,27 @@ void RegistersView::accessibilitySelectionChanged()
         {
             QAccessibleEvent focusEvent(static_cast<RegistersView*>(this), QAccessible::Focus);
             QAccessible::updateAccessibility(&focusEvent);
+        }
+    }
+}
+
+// Send value changed accessibility event
+void RegistersView::accessibilityValueChanged()
+{
+    if(QAccessible::isActive() && !mRegisterUpdates.empty())
+    {
+        QAccessibleInterface* a = QAccessible::queryAccessibleInterface(this);
+        for(auto & i : mRegisterUpdates)
+        {
+            if(i < REGISTER_NAME::UNKNOWN)
+            {
+                if(a)
+                {
+                    QAccessibleInterface* child = a->child(i);
+                    QAccessibleValueChangeEvent valueChangeEvent(child, QVariant(child->text(QAccessible::Value)));
+                    QAccessible::updateAccessibility(&valueChangeEvent);
+                }
+            }
         }
     }
 }

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1828,6 +1828,7 @@ void RegistersView::paintEvent(QPaintEvent* event)
     }
 
     QPainter painter(this->viewport());
+    painter.setClipRect(event->rect());
     painter.setFont(font());
     painter.fillRect(painter.viewport(), QBrush(ConfigColor("RegistersBackgroundColor")));
 

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -3368,7 +3368,7 @@ void RegistersView::accessibilitySelectionChanged()
         else
         {
             QAccessibleEvent focusEvent(static_cast<RegistersView*>(this), QAccessible::Focus);
-            QAccessible::updateAccessibility(&updateEvent);
+            QAccessible::updateAccessibility(&focusEvent);
         }
     }
 }

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -2,6 +2,7 @@
 #include <QListWidget>
 #include <QToolTip>
 #include <stdint.h>
+#include <QAccessibleEvent>
 #include "RegistersView.h"
 #include "CPUDisassembly.h"
 #include "CPUMultiDump.h"
@@ -1775,7 +1776,10 @@ void RegistersView::mousePressEvent(QMouseEvent* event)
             emit refresh();
         }
         else
+        {
             mSelected = UNKNOWN;
+        }
+        accessibilitySelectionChanged();
     }
 }
 
@@ -1869,6 +1873,7 @@ void RegistersView::keyPressEvent(QKeyEvent* event)
             mSelected = newRegister;
             ensureRegisterVisible(newRegister);
             emit refresh();
+            accessibilitySelectionChanged();
         }
     }
     QScrollArea::keyPressEvent(event);
@@ -3343,4 +3348,27 @@ void RegistersView::autoUpdateXMMModesAndRefresh()
 
     // force repaint
     emit refresh();
+}
+
+void RegistersView::accessibilitySelectionChanged()
+{
+    if(QAccessible::isActive())
+    {
+        QAccessibleEvent updateEvent(static_cast<RegistersView*>(this), QAccessible::Selection);
+        QAccessible::updateAccessibility(&updateEvent);
+        if(mSelected < REGISTER_NAME::UNKNOWN)
+        {
+            QAccessibleInterface* a = QAccessible::queryAccessibleInterface(this);
+            if(a)
+            {
+                QAccessibleEvent focusEvent(a->child(mSelected), QAccessible::Focus);
+                QAccessible::updateAccessibility(&focusEvent);
+            }
+        }
+        else
+        {
+            QAccessibleEvent focusEvent(static_cast<RegistersView*>(this), QAccessible::Focus);
+            QAccessible::updateAccessibility(&updateEvent);
+        }
+    }
 }

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1819,8 +1819,6 @@ void RegistersView::mouseDoubleClickEvent(QMouseEvent* event)
 
 void RegistersView::paintEvent(QPaintEvent* event)
 {
-    Q_UNUSED(event);
-
     if(mChangeViewButton != NULL)
     {
         if(mShowFpu)
@@ -1831,6 +1829,7 @@ void RegistersView::paintEvent(QPaintEvent* event)
 
     QPainter painter(this->viewport());
     painter.setFont(font());
+    painter.setClipRect(event->rect()); // Only repaint this dirty rect
     painter.fillRect(painter.viewport(), QBrush(ConfigColor("RegistersBackgroundColor")));
 
     // Don't draw the registers if a program isn't actually running

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -1829,7 +1829,6 @@ void RegistersView::paintEvent(QPaintEvent* event)
 
     QPainter painter(this->viewport());
     painter.setFont(font());
-    painter.setClipRect(event->rect()); // Only repaint this dirty rect
     painter.fillRect(painter.viewport(), QBrush(ConfigColor("RegistersBackgroundColor")));
 
     // Don't draw the registers if a program isn't actually running
@@ -2817,30 +2816,36 @@ void RegistersView::onCopyAllAction()
         appendRegister(text, REGISTER_NAME::XMM14, "XMM14 : ", "XMM14 : ");
         appendRegister(text, REGISTER_NAME::XMM15, "XMM15 : ", "XMM15 : ");
         appendRegister(text, REGISTER_NAME::XMM16, "XMM16 : ", "XMM16 : ");
-        appendRegister(text, REGISTER_NAME::XMM17, "XMM17 : ", "XMM17 : ");
-        appendRegister(text, REGISTER_NAME::XMM18, "XMM18 : ", "XMM18 : ");
-        appendRegister(text, REGISTER_NAME::XMM19, "XMM19 : ", "XMM19 : ");
-        appendRegister(text, REGISTER_NAME::XMM20, "XMM20 : ", "XMM20 : ");
-        appendRegister(text, REGISTER_NAME::XMM21, "XMM21 : ", "XMM21 : ");
-        appendRegister(text, REGISTER_NAME::XMM22, "XMM22 : ", "XMM22 : ");
-        appendRegister(text, REGISTER_NAME::XMM23, "XMM23 : ", "XMM23 : ");
-        appendRegister(text, REGISTER_NAME::XMM24, "XMM24 : ", "XMM24 : ");
-        appendRegister(text, REGISTER_NAME::XMM25, "XMM25 : ", "XMM25 : ");
-        appendRegister(text, REGISTER_NAME::XMM26, "XMM26 : ", "XMM26 : ");
-        appendRegister(text, REGISTER_NAME::XMM27, "XMM27 : ", "XMM27 : ");
-        appendRegister(text, REGISTER_NAME::XMM28, "XMM28 : ", "XMM28 : ");
-        appendRegister(text, REGISTER_NAME::XMM29, "XMM29 : ", "XMM29 : ");
-        appendRegister(text, REGISTER_NAME::XMM30, "XMM30 : ", "XMM30 : ");
-        appendRegister(text, REGISTER_NAME::XMM31, "XMM31 : ", "XMM31 : ");
+        if(mAVX512RegistersShown)
+        {
+            appendRegister(text, REGISTER_NAME::XMM17, "XMM17 : ", "XMM17 : ");
+            appendRegister(text, REGISTER_NAME::XMM18, "XMM18 : ", "XMM18 : ");
+            appendRegister(text, REGISTER_NAME::XMM19, "XMM19 : ", "XMM19 : ");
+            appendRegister(text, REGISTER_NAME::XMM20, "XMM20 : ", "XMM20 : ");
+            appendRegister(text, REGISTER_NAME::XMM21, "XMM21 : ", "XMM21 : ");
+            appendRegister(text, REGISTER_NAME::XMM22, "XMM22 : ", "XMM22 : ");
+            appendRegister(text, REGISTER_NAME::XMM23, "XMM23 : ", "XMM23 : ");
+            appendRegister(text, REGISTER_NAME::XMM24, "XMM24 : ", "XMM24 : ");
+            appendRegister(text, REGISTER_NAME::XMM25, "XMM25 : ", "XMM25 : ");
+            appendRegister(text, REGISTER_NAME::XMM26, "XMM26 : ", "XMM26 : ");
+            appendRegister(text, REGISTER_NAME::XMM27, "XMM27 : ", "XMM27 : ");
+            appendRegister(text, REGISTER_NAME::XMM28, "XMM28 : ", "XMM28 : ");
+            appendRegister(text, REGISTER_NAME::XMM29, "XMM29 : ", "XMM29 : ");
+            appendRegister(text, REGISTER_NAME::XMM30, "XMM30 : ", "XMM30 : ");
+            appendRegister(text, REGISTER_NAME::XMM31, "XMM31 : ", "XMM31 : ");
+        }
 #endif
-        appendRegister(text, REGISTER_NAME::K0, "K0  : ", "K0  : ");
-        appendRegister(text, REGISTER_NAME::K1, "K1  : ", "K1  : ");
-        appendRegister(text, REGISTER_NAME::K2, "K2  : ", "K2  : ");
-        appendRegister(text, REGISTER_NAME::K3, "K3  : ", "K3  : ");
-        appendRegister(text, REGISTER_NAME::K4, "K4  : ", "K4  : ");
-        appendRegister(text, REGISTER_NAME::K5, "K5  : ", "K5  : ");
-        appendRegister(text, REGISTER_NAME::K6, "K6  : ", "K6  : ");
-        appendRegister(text, REGISTER_NAME::K7, "K7  : ", "K7  : ");
+        if(mAVX512RegistersShown)
+        {
+            appendRegister(text, REGISTER_NAME::K0, "K0  : ", "K0  : ");
+            appendRegister(text, REGISTER_NAME::K1, "K1  : ", "K1  : ");
+            appendRegister(text, REGISTER_NAME::K2, "K2  : ", "K2  : ");
+            appendRegister(text, REGISTER_NAME::K3, "K3  : ", "K3  : ");
+            appendRegister(text, REGISTER_NAME::K4, "K4  : ", "K4  : ");
+            appendRegister(text, REGISTER_NAME::K5, "K5  : ", "K5  : ");
+            appendRegister(text, REGISTER_NAME::K6, "K6  : ", "K6  : ");
+            appendRegister(text, REGISTER_NAME::K7, "K7  : ", "K7  : ");
+        }
     }
     appendRegister(text, REGISTER_NAME::DR0, "DR0 : ", "DR0 : ");
     appendRegister(text, REGISTER_NAME::DR1, "DR1 : ", "DR1 : ");

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -299,6 +299,7 @@ protected:
     QAction* SIMDXMMSizeAuto;
     QAction* SIMDAlwaysShowAVX512;
     void accessibilitySelectionChanged();
+    void accessibilityValueChanged();
 
     friend class AccessibleRegistersView;
     friend class AccessibleRegistersViewItem;

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -298,4 +298,8 @@ protected:
     QAction* SIMDHQWord;
     QAction* SIMDXMMSizeAuto;
     QAction* SIMDAlwaysShowAVX512;
+    void accessibilitySelectionChanged();
+
+    friend class AccessibleRegistersView;
+    friend class AccessibleRegistersViewItem;
 };

--- a/src/gui/Src/Tracer/TraceBrowser.cpp
+++ b/src/gui/Src/Tracer/TraceBrowser.cpp
@@ -100,7 +100,7 @@ bool TraceBrowser::toggleTraceRecording(QWidget* parent)
     return false;
 }
 
-QString TraceBrowser::getAddrText(dsint cur_addr, char label[MAX_LABEL_SIZE], bool getLabel)
+QString TraceBrowser::getAddrText(dsint cur_addr, char label[MAX_LABEL_SIZE], bool getLabel) const
 {
     QString addrText = "";
     if(mRvaDisplayEnabled) //RVA display
@@ -1033,6 +1033,7 @@ void TraceBrowser::mousePressEvent(QMouseEvent* event)
                 setSingleSelection(index);
             mHistory.addVaToHistory(index);
             emit selectionChanged(getInitialSelection());
+            accessibilityMousePressSetColumn(event);
         }
         updateViewport();
         return;
@@ -1180,6 +1181,7 @@ void TraceBrowser::selectionChangedSlot(TRACEINDEX selection)
     {
         GuiDisasmAt(getTraceFile()->Address(selection), 0);
     }
+    accessibilitySelectionChanged();
 }
 
 void TraceBrowser::tokenizerConfigUpdatedSlot()
@@ -1210,22 +1212,22 @@ void TraceBrowser::setSingleSelection(duint index)
     mSelection.toIndex = index;
 }
 
-duint TraceBrowser::getInitialSelection()
+duint TraceBrowser::getInitialSelection() const
 {
     return mSelection.firstSelectedIndex;
 }
 
-duint TraceBrowser::getSelectionSize()
+duint TraceBrowser::getSelectionSize() const
 {
     return mSelection.toIndex - mSelection.fromIndex + 1;
 }
 
-duint TraceBrowser::getSelectionStart()
+duint TraceBrowser::getSelectionStart() const
 {
     return mSelection.fromIndex;
 }
 
-duint TraceBrowser::getSelectionEnd()
+duint TraceBrowser::getSelectionEnd() const
 {
     return mSelection.toIndex;
 }
@@ -1547,8 +1549,7 @@ void TraceBrowser::pushSelectionInto(bool copyBytes, QTextStream & stream, QText
         }
         else
         {
-            for(const auto & token : inst.tokens.tokens)
-                disassembly += token.text;
+            disassembly = inst.tokens.toString();
         }
         QString fullComment;
         QString comment;
@@ -1570,8 +1571,7 @@ void TraceBrowser::pushSelectionInto(bool copyBytes, QTextStream & stream, QText
         }
         else
         {
-            for(const auto & token : regTokens.tokens)
-                registersText += token.text;
+            registersText = regTokens.toString();
         }
 
         QString memoryText;
@@ -1588,8 +1588,7 @@ void TraceBrowser::pushSelectionInto(bool copyBytes, QTextStream & stream, QText
         }
         else
         {
-            for(const auto & token : memTokens.tokens)
-                memoryText += token.text;
+            memoryText = memTokens.toString();
         }
 
         stream << getTraceFile()->getIndexText(i) + " | " + address.leftJustified(addressLen, QChar(' '), true);
@@ -1960,4 +1959,13 @@ bool TraceBrowser::hightlightToken(const ZydisTokenizer::SingleToken & token)
     mHighlightToken = token;
     mHighlightingMode = false;
     return true;
+}
+
+int TraceBrowser::accessibilitySelectedRow() const
+{
+    int row = getInitialSelection() - getTableOffset();
+    if(row >= 0 && row < getViewableRowsCount())
+        return row;
+    else
+        return -1;
 }

--- a/src/gui/Src/Tracer/TraceBrowser.h
+++ b/src/gui/Src/Tracer/TraceBrowser.h
@@ -23,10 +23,10 @@ public:
 
     void expandSelectionUpTo(duint to);
     void setSingleSelection(duint index);
-    duint getInitialSelection();
-    duint getSelectionSize();
-    duint getSelectionStart();
-    duint getSelectionEnd();
+    duint getInitialSelection() const;
+    duint getSelectionSize() const;
+    duint getSelectionStart() const;
+    duint getSelectionEnd() const;
 
     bool isFileOpened() const;
     TraceFileReader* getTraceFile() { return mTraceFile; }
@@ -49,7 +49,7 @@ private:
     };
     void setupRightClickContextMenu();
     void makeVisible(duint index);
-    QString getAddrText(dsint cur_addr, char label[MAX_LABEL_SIZE], bool getLabel);
+    QString getAddrText(dsint cur_addr, char label[MAX_LABEL_SIZE], bool getLabel) const;
     RichTextPainter::List getRichBytes(const Instruction_t & instr) const;
     void pushSelectionInto(bool copyBytes, QTextStream & stream, QTextStream* htmlStream = nullptr);
     void copySelectionSlot(bool copyBytes);
@@ -199,5 +199,7 @@ private:
     // Go to by address, display the Xref dialog if multiple indicies are found
     void disasmByAddress(duint address, bool history = true);
     TraceWidget* mParent;
+    friend class AccessibleTraceBrowser;
+    int accessibilitySelectedRow() const;
 };
 

--- a/src/gui/Src/Tracer/TraceDump.cpp
+++ b/src/gui/Src/Tracer/TraceDump.cpp
@@ -251,7 +251,7 @@ void TraceDump::printDumpAt(duint parVA, bool select, bool repaint, bool updateT
         reloadData();
 }
 
-void TraceDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText)
+void TraceDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const
 {
     if(col && !mDescriptor.at(col - 1).isData && mDescriptor.at(col - 1).itemCount) //print comments
     {

--- a/src/gui/Src/Tracer/TraceDump.h
+++ b/src/gui/Src/Tracer/TraceDump.h
@@ -16,7 +16,7 @@ class TraceDump : public HexDump
 public:
     explicit TraceDump(Architecture* architecture, TraceWidget* parent, TraceFileDumpMemoryPage* memoryPage);
     ~TraceDump();
-    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) override;
+    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const override;
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
     void setupContextMenu();
     //void getAttention();

--- a/src/gui/Src/Tracer/TraceInfoBox.cpp
+++ b/src/gui/Src/Tracer/TraceInfoBox.cpp
@@ -107,7 +107,7 @@ void TraceInfoBox::update(TRACEINDEX selection, TraceFileReader* traceFile, cons
                         {
                             memoryLine += "= ";
                             memoryLine += ToDoubleString(&MemoryOldContent[memaccessindex]);
-                            memoryLine += " -> ";
+                            memoryLine += QString::fromUtf8("\xe2\x86\x92"); // Right Arrow
                             memoryLine += ToDoubleString(&MemoryNewContent[memaccessindex]);
                             break;
                         }
@@ -123,7 +123,7 @@ void TraceInfoBox::update(TRACEINDEX selection, TraceFileReader* traceFile, cons
                             memcpy(&dblval, &MemoryOldContent[memaccessindex], 4);
                             memcpy(((char*)&dblval) + 4, &MemoryOldContent[memaccessindex + 1], 4);
                             memoryLine += ToDoubleString(&dblval);
-                            memoryLine += " -> ";
+                            memoryLine += QString::fromUtf8("\xe2\x86\x92"); // Right Arrow
                             memcpy(&dblval, &MemoryNewContent[memaccessindex], 4);
                             memcpy(((char*)&dblval) + 4, &MemoryNewContent[memaccessindex + 1], 4);
                             memoryLine += ToDoubleString(&dblval);
@@ -141,7 +141,7 @@ void TraceInfoBox::update(TRACEINDEX selection, TraceFileReader* traceFile, cons
                         {
                             memoryLine += "= ";
                             memoryLine += ToFloatString(&MemoryOldContent[memaccessindex]);
-                            memoryLine += " -> ";
+                            memoryLine += QString::fromUtf8("\xe2\x86\x92"); // Right Arrow
                             memoryLine += ToFloatString(&MemoryNewContent[memaccessindex]);
                             break;
                         }
@@ -161,7 +161,7 @@ void TraceInfoBox::update(TRACEINDEX selection, TraceFileReader* traceFile, cons
                         {
                             memoryLine += "=";
                             memoryLine += ToHexString(MemoryOldContent[memaccessindex] & mask);
-                            memoryLine += " -> ";
+                            memoryLine += QString::fromUtf8("\xe2\x86\x92"); // Right Arrow
                             memoryLine += ToHexString(MemoryNewContent[memaccessindex] & mask);
                             break;
                         }

--- a/src/gui/Src/Tracer/TraceStack.cpp
+++ b/src/gui/Src/Tracer/TraceStack.cpp
@@ -190,7 +190,7 @@ void TraceStack::setupContextMenu()
 //    mFreezeStack->setChecked(bStackFrozen);
 //}
 
-void TraceStack::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText)
+void TraceStack::getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const
 {
     // Compute VA
     duint va = rvaToVa(rva);

--- a/src/gui/Src/Tracer/TraceStack.h
+++ b/src/gui/Src/Tracer/TraceStack.h
@@ -20,7 +20,7 @@ public:
     void updateColors() override;
     void updateFonts() override;
 
-    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) override;
+    void getColumnRichText(duint col, duint rva, RichTextPainter::List & richText) const override;
     QString paintContent(QPainter* painter, duint row, duint col, int x, int y, int w, int h) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -39,7 +39,7 @@ TraceWidget::TraceWidget(Architecture* architecture, const QString & fileName, Q
         mMemoryPage = nullptr;
         mDump = nullptr;
         mStack = nullptr;
-        mLoadDump = new QPushButton(tr("Load dump"), this);
+        mLoadDump = new QPushButton(DIcon("dump"), tr("Load dump"), this);
         connect(mLoadDump, SIGNAL(clicked()), this, SLOT(loadDump()));
     }
     mXrefDlg = nullptr;

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -244,6 +244,8 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultColors.insert("LinkColor", QColor("#0000ff"));
     defaultColors.insert("LogColor", QColor("#000000"));
     defaultColors.insert("LogBackgroundColor", QColor("#FFF8F0"));
+    defaultColors.insert("TraceNewValueColor", QColor("#FF0000"));
+    defaultColors.insert("TraceNewValueBackgroundColor", Qt::transparent);
 
     //bool settings
     QMap<QString, bool> disassemblyBool;

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -11,7 +11,7 @@
 #include <QDir>
 #include "MiscUtil.h"
 #include <dwmapi.h>
-#include "../Accessible/Accessible.h"
+#include "Accessible/Accessible.h"
 
 MyApplication::MyApplication(int & argc, char** argv)
     : QApplication(argc, argv)

--- a/src/gui/Src/main.cpp
+++ b/src/gui/Src/main.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include "MiscUtil.h"
 #include <dwmapi.h>
+#include "../Accessible/Accessible.h"
 
 MyApplication::MyApplication(int & argc, char** argv)
     : QApplication(argc, argv)
@@ -195,6 +196,9 @@ int main(int argc, char* argv[])
     auto path = QString("%1/../translations").arg(QCoreApplication::applicationDirPath());
     if(x64dbgTranslator.load(QString("x64dbg_%1").arg(gCurrentLocale), path))
         application.installTranslator(&x64dbgTranslator);
+
+    // Load accessibility classes
+    QAccessible::installFactory(accessibleInterfaceFactory);
 
     // load config file + set config font
     mConfiguration = new Configuration;


### PR DESCRIPTION
This pull request adds accessibility support in RegistersView. Now Microsoft narrator can read the value of selected register.
This is tested to work with Microsoft narrator. While it only exposes registers and values, it is still better than nothing.
Who knows when Copilot wants to operate a software using accessibility interfaces. It's getting more and more interesting, not only for the disabled people.