### PR TITLE
Prevent unintended execution after declining elevation

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2877,6 +2877,14 @@ static void debugLoopFunction(INIT_STRUCT* init)
                     GuiCloseApplication();
                     return;
                 }
+                if(answer == IDNO)
+                {
+                    //No auto launching the binary on the other admin restart
+                    //https://github.com/x64dbg/x64dbg/issues/3658
+                    gInitExe.clear();
+                    gInitCmd.clear();
+                    gInitDir.clear();
+                }
             }
             else if(isElevated)
             {


### PR DESCRIPTION
Clears the `gInitExe`, `gInitCmd`, and `gInitDir` init variables when user explicitly declines the elevation prompt, preventing the binary from being auto-executed on a manual "Restart as Admin".

This PR closes #3658.