### PR TITLE
Fix module loading when file path is stale or file is locked

### DIFF
--- a/src/dbg/_global.cpp
+++ b/src/dbg/_global.cpp
@@ -272,10 +272,17 @@ bool GetFileNameFromModuleHandle(HANDLE hProcess, HMODULE hModule, char* szFileN
     auto result = false;
     if(GetMappedFileNameW(hProcess, hModule, wszDosFileName, _countof(wszDosFileName)))
     {
-        if(!DevicePathToPathW(wszDosFileName, wszFileName, _countof(wszFileName)))
+        if(DevicePathToPathW(wszDosFileName, wszFileName, _countof(wszFileName)))
+        {
+            // Verify the file exists - GetMappedFileNameW can return stale paths due to kernel section caching
+            // https://github.com/x64dbg/x64dbg/issues/3756
+            if(GetFileAttributesW(wszFileName) != INVALID_FILE_ATTRIBUTES)
+                result = true;
+        }
+
+        // Fall back to GetModuleFileNameExW if the path conversion failed or the file doesn't exist
+        if(!result)
             result = !!GetModuleFileNameExW(hProcess, hModule, wszFileName, _countof(wszFileName));
-        else
-            result = true;
     }
     else
         result = !!GetModuleFileNameExW(hProcess, hModule, wszFileName, _countof(wszFileName));

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1844,14 +1844,46 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     hActiveThread = ThreadGetHandle(GetDebugData()->dwThreadId);
     void* base = LoadDll->lpBaseOfDll;
 
+    // Retrieve the DLL path using a fallback
+    // https://github.com/x64dbg/x64dbg/issues/3756
     char DLLDebugFileName[MAX_PATH] = "";
-    if(!GetFileNameFromHandle(LoadDll->hFile, DLLDebugFileName, _countof(DLLDebugFileName)))
+    bool validPath = false;
+
+    //1 - Try kernel path from file handle
+    if(GetFileNameFromHandle(LoadDll->hFile, DLLDebugFileName, _countof(DLLDebugFileName)) &&
+       FileExists(DLLDebugFileName))
     {
-        if(!GetFileNameFromModuleHandle(fdProcessInfo->hProcess, HMODULE(base), DLLDebugFileName, _countof(DLLDebugFileName)))
-            strcpy_s(DLLDebugFileName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "??? (GetFileNameFromHandle failed)")));
+        validPath = true;
     }
 
-    ModLoad((duint)base, 1, DLLDebugFileName);
+    //2 - Invalidate section cache and retry
+    // FSCTL_CHECK_FOR_SECTION releases cached image sections. This primarily helps step 3 (GetMappedFileNameW)
+    // which uses NtQueryVirtualMemory. The retry here is kinda speculative - GetFileNameFromHandle uses
+    // NtQueryInformationFile which may not benefit, but we retry anyway in case it helps.
+    // https://github.com/x64dbg/x64dbg/issues/3756
+    if(!validPath && LoadDll->hFile)
+    {
+        IO_STATUS_BLOCK iosb = {};
+        constexpr ULONG FSCTL_CHECK_FOR_SECTION = 0x90348;
+        NtFsControlFile(LoadDll->hFile, nullptr, nullptr, nullptr, &iosb, FSCTL_CHECK_FOR_SECTION, nullptr, 0, nullptr, 0);
+        if(GetFileNameFromHandle(LoadDll->hFile, DLLDebugFileName, _countof(DLLDebugFileName)) &&
+           FileExists(DLLDebugFileName))
+        {
+            validPath = true;
+        }
+    }
+
+    //3 - Try GetMappedFileNameW (with internal fallback to PEB)
+    if(!validPath)
+    {
+        validPath = GetFileNameFromModuleHandle(fdProcessInfo->hProcess, HMODULE(base), DLLDebugFileName, _countof(DLLDebugFileName));
+    }
+
+    //Give up
+    if(!validPath)
+        strcpy_s(DLLDebugFileName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "??? (GetFileNameFromHandle failed)")));
+
+    ModLoad((duint)base, 1, DLLDebugFileName, true, LoadDll->hFile);
 
     // Update memory map
     MemUpdateMapAsync();

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1851,7 +1851,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
 
     //1 - Try kernel path from file handle
     if(GetFileNameFromHandle(LoadDll->hFile, DLLDebugFileName, _countof(DLLDebugFileName)) &&
-       FileExists(DLLDebugFileName))
+            FileExists(DLLDebugFileName))
     {
         validPath = true;
     }
@@ -1867,7 +1867,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
         constexpr ULONG FSCTL_CHECK_FOR_SECTION = 0x90348;
         NtFsControlFile(LoadDll->hFile, nullptr, nullptr, nullptr, &iosb, FSCTL_CHECK_FOR_SECTION, nullptr, 0, nullptr, 0);
         if(GetFileNameFromHandle(LoadDll->hFile, DLLDebugFileName, _countof(DLLDebugFileName)) &&
-           FileExists(DLLDebugFileName))
+                FileExists(DLLDebugFileName))
         {
             validPath = true;
         }

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1857,9 +1857,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     }
 
     //2 - Invalidate section cache and retry
-    // FSCTL_CHECK_FOR_SECTION releases cached image sections. This primarily helps step 3 (GetMappedFileNameW)
-    // which uses NtQueryVirtualMemory. The retry here is kinda speculative - GetFileNameFromHandle uses
-    // NtQueryInformationFile which may not benefit, but we retry anyway in case it helps.
+    // FSCTL_CHECK_FOR_SECTION releases cached image sections, fixing stale paths from kernel section caching.
     // https://github.com/x64dbg/x64dbg/issues/3756
     if(!validPath && LoadDll->hFile)
     {
@@ -1883,7 +1881,21 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     if(!validPath)
         strcpy_s(DLLDebugFileName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "??? (GetFileNameFromHandle failed)")));
 
-    ModLoad((duint)base, 1, DLLDebugFileName, true, LoadDll->hFile);
+    // If hFile is NULL but we have a valid path, try to open the file ourselves
+    HANDLE effectiveHFile = LoadDll->hFile;
+    if(!effectiveHFile && validPath)
+    {
+        effectiveHFile = CreateFileA(DLLDebugFileName, GENERIC_READ,
+                                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                     NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if(effectiveHFile == INVALID_HANDLE_VALUE)
+            effectiveHFile = NULL;
+    }
+
+    ModLoad((duint)base, 1, DLLDebugFileName, true, effectiveHFile);
+
+    if(effectiveHFile && effectiveHFile != LoadDll->hFile)
+        CloseHandle(effectiveHFile);
 
     // Update memory map
     MemUpdateMapAsync();

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1881,21 +1881,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
     if(!validPath)
         strcpy_s(DLLDebugFileName, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "??? (GetFileNameFromHandle failed)")));
 
-    // If hFile is NULL but we have a valid path, try to open the file ourselves
-    HANDLE effectiveHFile = LoadDll->hFile;
-    if(!effectiveHFile && validPath)
-    {
-        effectiveHFile = CreateFileA(DLLDebugFileName, GENERIC_READ,
-                                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                                     NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-        if(effectiveHFile == INVALID_HANDLE_VALUE)
-            effectiveHFile = NULL;
-    }
-
-    ModLoad((duint)base, 1, DLLDebugFileName, true, effectiveHFile);
-
-    if(effectiveHFile && effectiveHFile != LoadDll->hFile)
-        CloseHandle(effectiveHFile);
+    ModLoad((duint)base, 1, DLLDebugFileName, true, LoadDll->hFile);
 
     // Update memory map
     MemUpdateMapAsync();

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -963,6 +963,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
             CloseHandle(info.fileHandle);
             info.fileHandle = (HANDLE)1; // Set to non-zero for TitanEngine compatibility
             fileLoaded = true;
+            dprintf(QT_TRANSLATE_NOOP("DBG", "Module %s%s loaded from file handle (path inaccessible)\n"), info.name, info.extension);
         }
 
         // 3. If both failed, try reading from process memory as last resort

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -859,7 +859,7 @@ void GetModuleInfo(MODINFO & Info, ULONG_PTR FileMapVA)
 #undef GetUnsafeModuleInfo
 }
 
-bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols)
+bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HANDLE hFile)
 {
     // Handle a new module being loaded
     if(!Base || !Size || !FullPath)
@@ -928,25 +928,68 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols)
     if(!info.isVirtual)
     {
         auto wszFullPath = StringUtils::Utf8ToUtf16(FullPath);
+        bool fileLoaded = false;
 
-        // Load the physical module from disk
+        // 1. Try loading the physical module from disk
         if(StaticFileLoadW(wszFullPath.c_str(), UE_ACCESS_READ, false, &info.fileHandle, &info.loadedSize, &info.fileMap, &info.fileMapVA))
         {
             // Fix an anti-debug trick, which opens exclusive access to the file
             CloseHandle(info.fileHandle);
             info.fileHandle = (HANDLE)1; // Set to non-zero for TitanEngine compatibility
+            fileLoaded = true;
+        }
 
-            GetModuleInfo(info, info.fileMapVA);
+        // 2. If path-based loading failed and we have a file handle, try mapping from it
+        // This handles cases where the file is locked with exclusive access
+        // https://github.com/x64dbg/x64dbg/issues/3756
+        if(!fileLoaded && hFile)
+        {
+            DWORD fileSize = GetFileSize(hFile, nullptr);
+            if(fileSize != INVALID_FILE_SIZE && fileSize > 0)
+            {
+                HANDLE hMap = CreateFileMappingW(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+                if(hMap)
+                {
+                    LPVOID mapView = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+                    if(mapView)
+                    {
+                        info.fileHandle = (HANDLE)1; // Non-zero for TitanEngine compatibility
+                        info.loadedSize = fileSize;
+                        info.fileMap = hMap;
+                        info.fileMapVA = (ULONG_PTR)mapView;
+                        fileLoaded = true;
+                    }
+                    else
+                    {
+                        CloseHandle(hMap);
+                    }
+                }
+            }
+        }
 
-            Size = HEADER_FIELD(info.headers, SizeOfImage);
-            info.size = Size;
+        // 3. If both failed, try reading from process memory as last resort
+        // Note: This may not work perfectly for file offset -> RVA conversions since process memory is SEC_IMAGE mapped
+        if(!fileLoaded)
+        {
+            info.mappedData.realloc(Size);
+            if(MemRead(Base, info.mappedData(), info.mappedData.size()))
+            {
+                info.loadedSize = (DWORD)Size;
+                GetModuleInfo(info, (ULONG_PTR)info.mappedData());
+            }
+            else
+            {
+                info.fileHandle = nullptr;
+                info.loadedSize = 0;
+                info.fileMap = nullptr;
+                info.fileMapVA = 0;
+            }
         }
         else
         {
-            info.fileHandle = nullptr;
-            info.loadedSize = 0;
-            info.fileMap = nullptr;
-            info.fileMapVA = 0;
+            GetModuleInfo(info, info.fileMapVA);
+            Size = HEADER_FIELD(info.headers, SizeOfImage);
+            info.size = Size;
         }
     }
     else

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -930,19 +930,9 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
         auto wszFullPath = StringUtils::Utf8ToUtf16(FullPath);
         bool fileLoaded = false;
 
-        // 1. Try loading the physical module from disk
-        if(StaticFileLoadW(wszFullPath.c_str(), UE_ACCESS_READ, false, &info.fileHandle, &info.loadedSize, &info.fileMap, &info.fileMapVA))
-        {
-            // Fix an anti-debug trick, which opens exclusive access to the file
-            CloseHandle(info.fileHandle);
-            info.fileHandle = (HANDLE)1; // Set to non-zero for TitanEngine compatibility
-            fileLoaded = true;
-        }
-
-        // 2. If path-based loading failed and we have a file handle, try mapping from it
-        // This handles cases where the file is locked with exclusive access
+        // 1. If we have a file handle from the debug event, try mapping from it first
         // https://github.com/x64dbg/x64dbg/issues/3756
-        if(!fileLoaded && hFile)
+        if(hFile)
         {
             DWORD fileSize = GetFileSize(hFile, nullptr);
             if(fileSize != INVALID_FILE_SIZE && fileSize > 0)
@@ -958,7 +948,6 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                         info.fileMap = hMap;
                         info.fileMapVA = (ULONG_PTR)mapView;
                         fileLoaded = true;
-                        dprintf(QT_TRANSLATE_NOOP("DBG", "Module %s%s loaded from file handle (path inaccessible)\n"), info.name, info.extension);
                     }
                     else
                     {
@@ -966,6 +955,14 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                     }
                 }
             }
+        }
+
+        // 2. If no file handle or mapping failed, try loading from disk path
+        if(!fileLoaded && StaticFileLoadW(wszFullPath.c_str(), UE_ACCESS_READ, false, &info.fileHandle, &info.loadedSize, &info.fileMap, &info.fileMapVA))
+        {
+            CloseHandle(info.fileHandle);
+            info.fileHandle = (HANDLE)1; // Set to non-zero for TitanEngine compatibility
+            fileLoaded = true;
         }
 
         // 3. If both failed, try reading from process memory as last resort

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -971,11 +971,54 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
         // Note: This may not work perfectly for file offset -> RVA conversions since process memory is SEC_IMAGE mapped
         if(!fileLoaded)
         {
-            info.mappedData.realloc(Size);
-            if(MemRead(Base, info.mappedData(), info.mappedData.size()))
+            // The Size parameter is unreliable here (all pass 1 as a placeholder).
+            // This is consistent with steps 1 and 2 which also determine size from their source.
+            duint actualSize = 0;
+            unsigned char headerBuf[0x1000] = {0};
+            if(MemRead(Base, headerBuf, sizeof(headerBuf)))
             {
-                info.loadedSize = (DWORD)Size;
-                GetModuleInfo(info, (ULONG_PTR)info.mappedData());
+                PIMAGE_DOS_HEADER dosHeader = (PIMAGE_DOS_HEADER)headerBuf;
+                if(dosHeader->e_magic == IMAGE_DOS_SIGNATURE &&
+                        dosHeader->e_lfanew > 0 &&
+                        dosHeader->e_lfanew < 0x1000 - sizeof(IMAGE_NT_HEADERS))
+                {
+                    PIMAGE_NT_HEADERS ntHeaders = (PIMAGE_NT_HEADERS)(headerBuf + dosHeader->e_lfanew);
+                    if(ntHeaders->Signature == IMAGE_NT_SIGNATURE)
+                        actualSize = HEADER_FIELD(ntHeaders, SizeOfImage);
+                }
+            }
+
+            //fallback if PE header parsing failed
+            if(actualSize == 0)
+            {
+                MEMORY_BASIC_INFORMATION mbi;
+                duint regionSize = 0;
+                duint addr = Base;
+                while(VirtualQueryEx(fdProcessInfo->hProcess, (LPCVOID)addr, &mbi, sizeof(mbi)))
+                {
+                    if(mbi.AllocationBase != (PVOID)Base)
+                        break;
+                    regionSize += mbi.RegionSize;
+                    addr += mbi.RegionSize;
+                }
+                actualSize = regionSize;
+            }
+
+            if(actualSize > 0)
+            {
+                info.mappedData.realloc(actualSize);
+                if(MemRead(Base, info.mappedData(), info.mappedData.size()))
+                {
+                    info.loadedSize = (DWORD)actualSize;
+                    GetModuleInfo(info, (ULONG_PTR)info.mappedData());
+                }
+                else
+                {
+                    info.fileHandle = nullptr;
+                    info.loadedSize = 0;
+                    info.fileMap = nullptr;
+                    info.fileMapVA = 0;
+                }
             }
             else
             {

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -1011,6 +1011,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                 {
                     info.loadedSize = (DWORD)actualSize;
                     GetModuleInfo(info, (ULONG_PTR)info.mappedData());
+                    info.size = HEADER_FIELD(info.headers, SizeOfImage);
                 }
                 else
                 {

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -958,6 +958,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                         info.fileMap = hMap;
                         info.fileMapVA = (ULONG_PTR)mapView;
                         fileLoaded = true;
+                        dprintf(QT_TRANSLATE_NOOP("DBG", "Module %s%s loaded from file handle (path inaccessible)\n"), info.name, info.extension);
                     }
                     else
                     {
@@ -968,7 +969,6 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
         }
 
         // 3. If both failed, try reading from process memory as last resort
-        // Note: This may not work perfectly for file offset -> RVA conversions since process memory is SEC_IMAGE mapped
         if(!fileLoaded)
         {
             // The Size parameter is unreliable here (all pass 1 as a placeholder).
@@ -1013,6 +1013,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                     info.loadedSize = (DWORD)actualSize;
                     GetModuleInfo(info, (ULONG_PTR)info.mappedData());
                     info.size = HEADER_FIELD(info.headers, SizeOfImage);
+                    dprintf(QT_TRANSLATE_NOOP("DBG", "Module %s%s loaded from process memory (file inaccessible)\n"), info.name, info.extension);
                 }
                 else
                 {

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -1009,6 +1009,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                 info.mappedData.realloc(actualSize);
                 if(MemRead(Base, info.mappedData(), info.mappedData.size()))
                 {
+                    info.isVirtual = true; // Process memory is SEC_IMAGE mapped
                     info.loadedSize = (DWORD)actualSize;
                     GetModuleInfo(info, (ULONG_PTR)info.mappedData());
                     info.size = HEADER_FIELD(info.headers, SizeOfImage);

--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -147,7 +147,7 @@ struct MODINFO
 };
 
 ULONG64 ModRvaToOffset(ULONG64 base, PIMAGE_NT_HEADERS ntHeaders, ULONG64 rva);
-bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols = true);
+bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols = true, HANDLE hFile = nullptr);
 bool ModUnload(duint Base);
 void ModClear(bool updateGui = true);
 MODINFO* ModInfoFromAddr(duint Address);


### PR DESCRIPTION
This PR addresses the "weird bug" message that appears when module headers can't be loaded.

The issue occurs in two scenarios. First, kernel section caching can return stale file paths after a file is renamed or moved, causing the file open to fail. Second, if a file is locked with exclusive access, the debugger can't open it by path even though the path is correct.

The fix adds a fallback chain in `ModLoad`. It first tries opening the file by path as before. If that fails and we have the debug API's file handle, it maps directly from that handle instead of trying to reopen. If both fail, it reads from process memory as a last resort, reading the PE header first to determine the correct module size (since callers pass `Size=1` as a placeholder).

The path resolution in `cbLoadDll` now also validates that paths actually exist before using them, uses `FSCTL_CHECK_FOR_SECTION` to invalidate stale kernel section cache, and tries to open the file ourselves when the debug API provides a NULL file handle.

This PR closes #3756