### PR TITLE
"Run to user code" switched to "rtu" command

### DIFF
--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -295,7 +295,7 @@ MainWindow::MainWindow(QWidget* parent)
     makeCommandAction(ui->actioneStepInto, "eStepInto");
     makeCommandAction(ui->actioneRun, "eRun");
     makeCommandAction(ui->actioneRtr, "eRtr");
-    makeCommandAction(ui->actionRtu, "TraceOverConditional mod.user(cip)");
+    makeCommandAction(ui->actionRtu, "rtu");
     connect(ui->actionTicnd, SIGNAL(triggered()), this, SLOT(execTicnd()));
     connect(ui->actionTocnd, SIGNAL(triggered()), this, SLOT(execTocnd()));
     connect(ui->actionTRBit, SIGNAL(triggered()), mCpuWidget->getDisasmWidget(), SLOT(traceCoverageBitSlot()));


### PR DESCRIPTION
Verbatim:
> The "run to user code" button on the toolbar is not the rtu command, but TraceOverConditional mod.user(cip) . This is historical because there were problems with rtu, but now the problem is fixed, rtu should be used now. rtu is more accurate, it can be used to get to user callback from a breakpoint in system code, while TraceOverConditional mod.user(cip) cannot be used to locate this callback.

Closes #2423