### PR TITLE
Add option to detach instead of terminate when attaching to new process

### DIFF
--- a/src/cross/widgets/Configuration.cpp
+++ b/src/cross/widgets/Configuration.cpp
@@ -333,6 +333,7 @@ Configuration::Configuration(const ConfigurationPalette & p) : QObject(), noMore
     guiBool.insert("ShowGraphRva", false);
     guiBool.insert("GraphZoomMode", true);
     guiBool.insert("ShowExitConfirmation", false);
+    guiBool.insert("ShowAttachConfirmation", true);
     guiBool.insert("DisableAutoComplete", false);
     guiBool.insert("CaseSensitiveAutoComplete", false);
     guiBool.insert("AutoRepeatOnEnter", false);

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -264,8 +264,6 @@ bool cbDebugAttach(int argc, char* argv[])
             CloseHandle(hDebugLoopThread);
             hDebugLoopThread = nullptr;
         }
-
-        HistoryClear();
     }
     else
     {
@@ -361,6 +359,7 @@ bool cbDebugDetach(int argc, char* argv[])
         dputs(QT_TRANSLATE_NOOP("DBG", "Detached!"));
     _dbg_animatestop(); // Stop animating
     unlock(WAITID_RUN); // run to resume the debug loop if necessary
+    HistoryClear();
     return true;
 }
 

--- a/src/dbg/commands/cmd-debug-control.cpp
+++ b/src/dbg/commands/cmd-debug-control.cpp
@@ -252,7 +252,26 @@ bool cbDebugAttach(int argc, char* argv[])
         return false;
 
     EXCLUSIVE_ACQUIRE(LockDebugStartStop);
-    cbDebugStop(argc, argv);
+
+    // Detach instead of terminate when attaching to a new process (if setting enabled)
+    if(bIsDebugging && settingboolget("Engine", "DetachOnAttach", false))
+    {
+        cbDebugDetach(argc, argv);
+
+        if(hDebugLoopThread)
+        {
+            WaitForSingleObject(hDebugLoopThread, INFINITE);
+            CloseHandle(hDebugLoopThread);
+            hDebugLoopThread = nullptr;
+        }
+
+        HistoryClear();
+    }
+    else
+    {
+        cbDebugStop(argc, argv);
+    }
+
     ASSERT_TRUE(hDebugLoopThread == nullptr);
 
     Handle hProcess = TitanOpenProcess(PROCESS_ALL_ACCESS, false, (DWORD)pid);

--- a/src/gui/Src/Gui/AttachDialog.cpp
+++ b/src/gui/Src/Gui/AttachDialog.cpp
@@ -158,6 +158,13 @@ void AttachDialog::attachToProcess(quint32 pid)
         return;
     }
 
+    // Check if trying to attach to the same process we're already debugging
+    if(DbgValFromString("$pid") == pid)
+    {
+        QMessageBox::information(this, tr("Already attached"), tr("You are already debugging this process."));
+        return;
+    }
+
     // Check if we should show the confirmation dialog
     if(ConfigBool("Gui", "ShowAttachConfirmation"))
     {

--- a/src/gui/Src/Gui/AttachDialog.cpp
+++ b/src/gui/Src/Gui/AttachDialog.cpp
@@ -86,7 +86,7 @@ void AttachDialog::on_btnAttach_clicked()
 {
     QString pid = mSearchListView->mCurList->getCellContent(mSearchListView->mCurList->getInitialSelection(), ColPid);
     if(!pid.isEmpty())
-        attachToProcess(pid.toULongLong());
+        attachToProcess(pid.toUInt());
 }
 
 void AttachDialog::on_btnFindWindow_clicked()
@@ -148,7 +148,7 @@ void AttachDialog::processListContextMenu(QMenu* menu)
     menu->addAction(mRefreshAction);
 }
 
-void AttachDialog::attachToProcess(duint pid)
+void AttachDialog::attachToProcess(quint32 pid)
 {
     // If not currently debugging, just attach directly
     if(!DbgIsDebugging())

--- a/src/gui/Src/Gui/AttachDialog.cpp
+++ b/src/gui/Src/Gui/AttachDialog.cpp
@@ -5,6 +5,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QFileInfo>
+#include <QCheckBox>
 
 AttachDialog::AttachDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AttachDialog)
 {
@@ -84,8 +85,8 @@ void AttachDialog::refresh()
 void AttachDialog::on_btnAttach_clicked()
 {
     QString pid = mSearchListView->mCurList->getCellContent(mSearchListView->mCurList->getInitialSelection(), ColPid);
-    DbgCmdExec(QString("attach %1%2").arg(".").arg(pid));
-    accept();
+    if(!pid.isEmpty())
+        attachToProcess(pid.toULongLong());
 }
 
 void AttachDialog::on_btnFindWindow_clicked()
@@ -128,8 +129,7 @@ retryFindWindow:
                                                 QMessageBox::Yes | QMessageBox::No, this);
                 if(hiddenProcessDialog.exec() == QMessageBox::Yes)
                 {
-                    DbgCmdExec(QString("attach %1").arg(pid, 0, 16));
-                    accept();
+                    attachToProcess(pid);
                 }
             }
         }
@@ -146,4 +146,67 @@ void AttachDialog::processListContextMenu(QMenu* menu)
 
     menu->addAction(mAttachAction);
     menu->addAction(mRefreshAction);
+}
+
+void AttachDialog::attachToProcess(duint pid)
+{
+    // If not currently debugging, just attach directly
+    if(!DbgIsDebugging())
+    {
+        DbgCmdExec(QString("attach .%1").arg(pid));
+        accept();
+        return;
+    }
+
+    // Check if we should show the confirmation dialog
+    if(ConfigBool("Gui", "ShowAttachConfirmation"))
+    {
+        // Show confirmation dialog
+        auto cb = new QCheckBox(tr("Remember my choice"));
+        QMessageBox msgbox(this);
+        msgbox.setText(tr("You are already debugging a process. What would you like to do with the current process?"));
+        msgbox.setWindowTitle(tr("Already debugging"));
+        msgbox.setWindowIcon(DIcon("bug"));
+
+        auto terminateButton = msgbox.addButton(QMessageBox::Yes);
+        terminateButton->setText(tr("&Terminate"));
+        terminateButton->setToolTip(tr("Terminate the current process and attach to the new one."));
+
+        auto detachButton = msgbox.addButton(QMessageBox::No);
+        detachButton->setText(tr("&Detach"));
+        detachButton->setToolTip(tr("Detach from the current process (leaving it running) and attach to the new one."));
+
+        auto cancelButton = msgbox.addButton(QMessageBox::Cancel);
+        cancelButton->setText(tr("&Cancel"));
+        cancelButton->setToolTip(tr("Cancel and don't attach to the new process."));
+
+        msgbox.setDefaultButton(QMessageBox::Cancel);
+        msgbox.setEscapeButton(QMessageBox::Cancel);
+        msgbox.setCheckBox(cb);
+
+        auto code = msgbox.exec();
+
+        if(code == QMessageBox::Cancel)
+            return; // User cancelled
+
+        if(code == QMessageBox::No) // Detach
+        {
+            // Set DetachOnAttach so backend will detach instead of terminate
+            BridgeSettingSetUint("Engine", "DetachOnAttach", 1);
+            if(cb->isChecked())
+                Config()->setBool("Gui", "ShowAttachConfirmation", false);
+        }
+        else if(code == QMessageBox::Yes) // Terminate
+        {
+            // Ensure DetachOnAttach is off so backend will terminate
+            BridgeSettingSetUint("Engine", "DetachOnAttach", 0);
+            if(cb->isChecked())
+                Config()->setBool("Gui", "ShowAttachConfirmation", false);
+        }
+    }
+    // If ShowAttachConfirmation is false, backend uses existing DetachOnAttach setting
+    // (set by a previous "Remember my choice" selection)
+
+    DbgCmdExec(QString("attach .%1").arg(pid));
+    accept();
 }

--- a/src/gui/Src/Gui/AttachDialog.h
+++ b/src/gui/Src/Gui/AttachDialog.h
@@ -26,6 +26,8 @@ private slots:
     void processListContextMenu(QMenu* menu);
 
 private:
+    void attachToProcess(duint pid);
+
     Ui::AttachDialog* ui;
     StdIconSearchListView* mSearchListView;
     QAction* mAttachAction;

--- a/src/gui/Src/Gui/AttachDialog.h
+++ b/src/gui/Src/Gui/AttachDialog.h
@@ -26,7 +26,7 @@ private slots:
     void processListContextMenu(QMenu* menu);
 
 private:
-    void attachToProcess(duint pid);
+    void attachToProcess(quint32 pid);
 
     Ui::AttachDialog* ui;
     StdIconSearchListView* mSearchListView;

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -783,6 +783,18 @@ void MainWindow::setupLanguagesMenu2()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+    if(DbgIsDebugging())
+    {
+        duint detachOnExit = 0;
+        if(BridgeSettingGetUint("Engine", "DetachOnExit", &detachOnExit) && detachOnExit)
+        {
+            bExitWhenDetached = true;
+            DbgCmdExec("detach");
+            event->ignore();
+            return;
+        }
+    }
+
     if(DbgIsDebugging() && ConfigBool("Gui", "ShowExitConfirmation"))
     {
         auto cb = new QCheckBox(tr("Always stop the debuggee and exit"));

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -797,7 +797,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
     if(DbgIsDebugging() && ConfigBool("Gui", "ShowExitConfirmation"))
     {
-        auto cb = new QCheckBox(tr("Always stop the debuggee and exit"));
+        auto cb = new QCheckBox(tr("Remember my choice"));
         QMessageBox msgbox(this);
         msgbox.setText(tr("The debuggee is still running and will be terminated if you exit. What do you want to do?"));
         msgbox.setWindowTitle(tr("Debuggee is still running"));
@@ -818,21 +818,19 @@ void MainWindow::closeEvent(QCloseEvent* event)
         msgbox.setEscapeButton(QMessageBox::Cancel);
         msgbox.setCheckBox(cb);
 
-        QObject::connect(cb, &QCheckBox::toggled, [detachButton, restartButton](bool checked)
-        {
-            auto showConfirmation = !checked;
-            detachButton->setEnabled(showConfirmation);
-            restartButton->setEnabled(showConfirmation);
-            Config()->setBool("Gui", "ShowExitConfirmation", showConfirmation);
-        });
-
         auto code = msgbox.exec();
         if(code == QMessageBox::Retry)
             restartDebugging();
         else if(code == QMessageBox::Abort)
         {
+            if(cb->isChecked())
+                BridgeSettingSetUint("Engine", "DetachOnExit", 1);
             bExitWhenDetached = true;
             DbgCmdExec("detach");
+        }
+        else if(code == QMessageBox::Yes && cb->isChecked())
+        {
+            Config()->setBool("Gui", "ShowExitConfirmation", false);
         }
         if(code != QMessageBox::Yes)
         {

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -126,6 +126,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Engine", "VerboseExceptionLogging", &settings.engineVerboseExceptionLogging);
     GetSettingBool("Engine", "NoWow64SingleStepWorkaround", &settings.engineNoWow64SingleStepWorkaround);
     GetSettingBool("Engine", "DisableAslr", &settings.engineDisableAslr);
+    GetSettingBool("Engine", "DetachOnAttach", &settings.engineDetachOnAttach);
     if(BridgeSettingGetUint("Engine", "MaxTraceCount", &cur))
         settings.engineMaxTraceCount = int(cur);
     if(BridgeSettingGetUint("Engine", "AnimateInterval", &cur))
@@ -174,6 +175,7 @@ void SettingsDialog::LoadSettings()
     ui->chkVerboseExceptionLogging->setChecked(settings.engineVerboseExceptionLogging);
     ui->chkNoWow64SingleStepWorkaround->setChecked(settings.engineNoWow64SingleStepWorkaround);
     ui->chkDisableAslr->setChecked(settings.engineDisableAslr);
+    ui->chkDetachOnAttach->setChecked(settings.engineDetachOnAttach);
     ui->spinMaxTraceCount->setValue(settings.engineMaxTraceCount);
     ui->spinAnimateInterval->setValue(settings.engineAnimateInterval);
 
@@ -405,6 +407,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Engine", "HardcoreThreadSwitchWarning", settings.engineHardcoreThreadSwitchWarning);
     BridgeSettingSetUint("Engine", "NoWow64SingleStepWorkaround", settings.engineNoWow64SingleStepWorkaround);
     BridgeSettingSetUint("Engine", "DisableAslr", settings.engineDisableAslr);
+    BridgeSettingSetUint("Engine", "DetachOnAttach", settings.engineDetachOnAttach);
 
     //Exceptions tab
     QString exceptionRange = "";
@@ -1075,6 +1078,11 @@ void SettingsDialog::on_chkNoWow64SingleStepWorkaround_toggled(bool checked)
 void SettingsDialog::on_chkDisableAslr_toggled(bool checked)
 {
     settings.engineDisableAslr = checked;
+}
+
+void SettingsDialog::on_chkDetachOnAttach_toggled(bool checked)
+{
+    settings.engineDetachOnAttach = checked;
 }
 
 void SettingsDialog::on_chkNoCurrentModuleText_toggled(bool checked)

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -127,6 +127,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Engine", "NoWow64SingleStepWorkaround", &settings.engineNoWow64SingleStepWorkaround);
     GetSettingBool("Engine", "DisableAslr", &settings.engineDisableAslr);
     GetSettingBool("Engine", "DetachOnAttach", &settings.engineDetachOnAttach);
+    GetSettingBool("Engine", "DetachOnExit", &settings.engineDetachOnExit);
     if(BridgeSettingGetUint("Engine", "MaxTraceCount", &cur))
         settings.engineMaxTraceCount = int(cur);
     if(BridgeSettingGetUint("Engine", "AnimateInterval", &cur))
@@ -176,6 +177,7 @@ void SettingsDialog::LoadSettings()
     ui->chkNoWow64SingleStepWorkaround->setChecked(settings.engineNoWow64SingleStepWorkaround);
     ui->chkDisableAslr->setChecked(settings.engineDisableAslr);
     ui->chkDetachOnAttach->setChecked(settings.engineDetachOnAttach);
+    ui->chkDetachOnExit->setChecked(settings.engineDetachOnExit);
     ui->spinMaxTraceCount->setValue(settings.engineMaxTraceCount);
     ui->spinAnimateInterval->setValue(settings.engineAnimateInterval);
 
@@ -408,6 +410,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Engine", "NoWow64SingleStepWorkaround", settings.engineNoWow64SingleStepWorkaround);
     BridgeSettingSetUint("Engine", "DisableAslr", settings.engineDisableAslr);
     BridgeSettingSetUint("Engine", "DetachOnAttach", settings.engineDetachOnAttach);
+    BridgeSettingSetUint("Engine", "DetachOnExit", settings.engineDetachOnExit);
 
     //Exceptions tab
     QString exceptionRange = "";
@@ -1083,6 +1086,11 @@ void SettingsDialog::on_chkDisableAslr_toggled(bool checked)
 void SettingsDialog::on_chkDetachOnAttach_toggled(bool checked)
 {
     settings.engineDetachOnAttach = checked;
+}
+
+void SettingsDialog::on_chkDetachOnExit_toggled(bool checked)
+{
+    settings.engineDetachOnExit = checked;
 }
 
 void SettingsDialog::on_chkNoCurrentModuleText_toggled(bool checked)

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -285,6 +285,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Gui", "ShowGraphRva", &settings.guiShowGraphRva);
     GetSettingBool("Gui", "GraphZoomMode", &settings.guiGraphZoomMode);
     GetSettingBool("Gui", "ShowExitConfirmation", &settings.guiShowExitConfirmation);
+    GetSettingBool("Gui", "ShowAttachConfirmation", &settings.guiShowAttachConfirmation);
     GetSettingBool("Gui", "DisableAutoComplete", &settings.guiDisableAutoComplete);
     GetSettingBool("Gui", "AutoFollowInStack", &settings.guiAutoFollowInStack);
     GetSettingBool("Gui", "NoSeasons", &settings.guiHideSeasonalIcons);
@@ -301,6 +302,7 @@ void SettingsDialog::LoadSettings()
     ui->chkShowGraphRva->setChecked(settings.guiShowGraphRva);
     ui->chkGraphZoomMode->setChecked(settings.guiGraphZoomMode);
     ui->chkShowExitConfirmation->setChecked(settings.guiShowExitConfirmation);
+    ui->chkShowAttachConfirmation->setChecked(settings.guiShowAttachConfirmation);
     ui->chkDisableAutoComplete->setChecked(settings.guiDisableAutoComplete);
     ui->chkAutoFollowInStack->setChecked(settings.guiAutoFollowInStack);
     ui->chkHideSeasonalIcons->setChecked(settings.guiHideSeasonalIcons);
@@ -456,6 +458,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Gui", "ShowGraphRva", settings.guiShowGraphRva);
     BridgeSettingSetUint("Gui", "GraphZoomMode", settings.guiGraphZoomMode);
     BridgeSettingSetUint("Gui", "ShowExitConfirmation", settings.guiShowExitConfirmation);
+    BridgeSettingSetUint("Gui", "ShowAttachConfirmation", settings.guiShowAttachConfirmation);
     BridgeSettingSetUint("Gui", "DisableAutoComplete", settings.guiDisableAutoComplete);
     BridgeSettingSetUint("Gui", "AutoFollowInStack", settings.guiAutoFollowInStack);
     BridgeSettingSetUint("Gui", "NoSeasons", settings.guiHideSeasonalIcons);
@@ -1149,6 +1152,11 @@ void SettingsDialog::on_chkGraphZoomMode_toggled(bool checked)
 void SettingsDialog::on_chkShowExitConfirmation_toggled(bool checked)
 {
     settings.guiShowExitConfirmation = checked;
+}
+
+void SettingsDialog::on_chkShowAttachConfirmation_toggled(bool checked)
+{
+    settings.guiShowAttachConfirmation = checked;
 }
 
 void SettingsDialog::on_chkDisableAutoComplete_toggled(bool checked)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -65,6 +65,7 @@ private slots:
     void on_chkVerboseExceptionLogging_toggled(bool checked);
     void on_chkNoWow64SingleStepWorkaround_toggled(bool checked);
     void on_chkDisableAslr_toggled(bool checked);
+    void on_chkDetachOnAttach_toggled(bool checked);
     void on_spinMaxTraceCount_valueChanged(int arg1);
     void on_spinAnimateInterval_valueChanged(int arg1);
     //Exception tab
@@ -212,6 +213,7 @@ private:
         bool engineVerboseExceptionLogging = true;
         bool engineNoWow64SingleStepWorkaround = false;
         bool engineDisableAslr = false;
+        bool engineDetachOnAttach = false;
         int engineMaxTraceCount = 50000;
         int engineAnimateInterval = 50;
         //Exception Tab

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -66,6 +66,7 @@ private slots:
     void on_chkNoWow64SingleStepWorkaround_toggled(bool checked);
     void on_chkDisableAslr_toggled(bool checked);
     void on_chkDetachOnAttach_toggled(bool checked);
+    void on_chkDetachOnExit_toggled(bool checked);
     void on_spinMaxTraceCount_valueChanged(int arg1);
     void on_spinAnimateInterval_valueChanged(int arg1);
     //Exception tab
@@ -214,6 +215,7 @@ private:
         bool engineNoWow64SingleStepWorkaround = false;
         bool engineDisableAslr = false;
         bool engineDetachOnAttach = false;
+        bool engineDetachOnExit = false;
         int engineMaxTraceCount = 50000;
         int engineAnimateInterval = 50;
         //Exception Tab

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -106,6 +106,7 @@ private slots:
     void on_chkSidebarWatchLabels_stateChanged(int arg1);
     void on_chkNoForegroundWindow_toggled(bool checked);
     void on_chkShowExitConfirmation_toggled(bool checked);
+    void on_chkShowAttachConfirmation_toggled(bool checked);
     void on_chkDisableAutoComplete_toggled(bool checked);
     void on_chkAutoFollowInStack_toggled(bool checked);
     void on_chkHideSeasonalIcons_toggled(bool checked);
@@ -246,6 +247,7 @@ private:
         bool guiShowGraphRva = false;
         bool guiGraphZoomMode = true;
         bool guiShowExitConfirmation = true;
+        bool guiShowAttachConfirmation = true;
         bool guiDisableAutoComplete = false;
         bool guiAutoFollowInStack = false;
         bool guiHideSeasonalIcons = false;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -403,6 +403,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkDetachOnAttach">
+         <property name="text">
+          <string>Detach from process when attaching to another</string>
+         </property>
+         <property name="toolTip">
+          <string>When enabled, attaching to a new process will detach from the current process instead of terminating it</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayoutMaxTraceCount">
          <item>
           <widget class="QLabel" name="lblMaxTraceCount">

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -413,6 +413,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkDetachOnExit">
+         <property name="text">
+          <string>Detach from process when exiting debugger</string>
+         </property>
+         <property name="toolTip">
+          <string>When enabled, exiting x64dbg will detach from the current process instead of terminating it</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayoutMaxTraceCount">
          <item>
           <widget class="QLabel" name="lblMaxTraceCount">

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -975,6 +975,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkShowAttachConfirmation">
+         <property name="text">
+          <string>Show attach confirmation dialog</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkDisableAutoComplete">
          <property name="text">
           <string>Disable auto completion in goto dialog</string>

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -285,6 +285,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     guiBool.insert("ShowGraphRva", false);
     guiBool.insert("GraphZoomMode", true);
     guiBool.insert("ShowExitConfirmation", false);
+    guiBool.insert("ShowAttachConfirmation", true);
     guiBool.insert("DisableAutoComplete", false);
     guiBool.insert("CaseSensitiveAutoComplete", false);
     guiBool.insert("AutoRepeatOnEnter", false);


### PR DESCRIPTION
Adds "Detach from process when attaching to another" setting in Engine tab. When enabled, attaching to a new process will detach from current process and leave it running instead of terminating it.

Closes #648 