### PR TITLE
Expression validation added to breakpoint dialog (red and green borders)

### DIFF
--- a/src/gui/Src/Gui/EditBreakpointDialog.cpp
+++ b/src/gui/Src/Gui/EditBreakpointDialog.cpp
@@ -126,7 +126,7 @@ void EditBreakpointDialog::updateExpressionStyle(QLineEdit* edit, const QString 
     }
     else if(DbgIsValidExpression(text.toUtf8().constData()))
     {
-        edit->setStyleSheet("QLineEdit { border: 1px solid green; }");
+        edit->setStyleSheet("QLineEdit { border: 1px solid #00DD00; }");
     }
     else
     {

--- a/src/gui/Src/Gui/EditBreakpointDialog.cpp
+++ b/src/gui/Src/Gui/EditBreakpointDialog.cpp
@@ -4,6 +4,7 @@
 #include "MiscUtil.h"
 #include "Configuration.h"
 #include "BrowseDialog.h"
+#include <QLineEdit>
 
 EditBreakpointDialog::EditBreakpointDialog(QWidget* parent, const Breakpoints::Data & bp)
     : QDialog(parent),
@@ -38,9 +39,13 @@ EditBreakpointDialog::EditBreakpointDialog(QWidget* parent, const Breakpoints::D
         break;
     }
     setWindowIcon(DIcon("breakpoint"));
-    loadFromBp();
 
     connect(this, SIGNAL(accepted()), this, SLOT(acceptedSlot()));
+    connect(ui->editBreakCondition, SIGNAL(textChanged(QString)), this, SLOT(onExpressionChanged(QString)));
+    connect(ui->editLogCondition, SIGNAL(textChanged(QString)), this, SLOT(onExpressionChanged(QString)));
+    connect(ui->editCommandCondition, SIGNAL(textChanged(QString)), this, SLOT(onExpressionChanged(QString)));
+
+    loadFromBp();
 
     Config()->loadWindowGeometry(this);
 }
@@ -104,4 +109,27 @@ void EditBreakpointDialog::acceptedSlot()
     mBp.silent = ui->checkBoxSilent->isChecked();
     mBp.fastResume = ui->checkBoxFastResume->isChecked();
     mBp.logFile = mLogFile;
+}
+
+void EditBreakpointDialog::onExpressionChanged(const QString & text)
+{
+    QLineEdit* edit = qobject_cast<QLineEdit*>(sender());
+    if(edit)
+        updateExpressionStyle(edit, text);
+}
+
+void EditBreakpointDialog::updateExpressionStyle(QLineEdit* edit, const QString & text)
+{
+    if(text.isEmpty() || !DbgIsDebugging())
+    {
+        edit->setStyleSheet("");
+    }
+    else if(DbgIsValidExpression(text.toUtf8().constData()))
+    {
+        edit->setStyleSheet("QLineEdit { border: 1px solid green; }");
+    }
+    else
+    {
+        edit->setStyleSheet("QLineEdit { border: 1px solid red; }");
+    }
 }

--- a/src/gui/Src/Gui/EditBreakpointDialog.h
+++ b/src/gui/Src/Gui/EditBreakpointDialog.h
@@ -4,6 +4,8 @@
 #include "Bridge.h"
 #include "Breakpoints.h"
 
+class QLineEdit;
+
 namespace Ui
 {
     class EditBreakpointDialog;
@@ -25,6 +27,7 @@ private slots:
     void on_editLogText_textEdited(const QString & arg1);
     void on_buttonLogFile_clicked();
     void acceptedSlot();
+    void onExpressionChanged(const QString & text);
 
 private:
     Ui::EditBreakpointDialog* ui;
@@ -32,4 +35,5 @@ private:
     QString mLogFile;
 
     void loadFromBp();
+    void updateExpressionStyle(QLineEdit* edit, const QString & text);
 };


### PR DESCRIPTION
Adds real-time expression validation to the Edit Breakpoint dialog.

The condition field now show a green border for a valid expressions and red for invalid.

Closes #751