### PR TITLE
Fixed 2GB+ files causing a crash

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -114,11 +114,15 @@ static const wchar_t* InitializeUserDirectory(HINSTANCE hMainModule, const wchar
         auto hFile = CreateFileW(szFolderRedirect, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
         if(hFile != INVALID_HANDLE_VALUE)
         {
-            auto size = GetFileSize(hFile, nullptr);
-            userDirUtf8.resize(size + 1);
-            DWORD read = 0;
-            if(!ReadFile(hFile, userDirUtf8.data(), size, &read, nullptr))
-                userDirUtf8.clear();
+            LARGE_INTEGER fileSizeLI;
+            if(GetFileSizeEx(hFile, &fileSizeLI) && fileSizeLI.QuadPart > 0 && fileSizeLI.QuadPart < MAXDWORD)
+            {
+                DWORD size = (DWORD)fileSizeLI.QuadPart;
+                userDirUtf8.resize(size + 1);
+                DWORD read = 0;
+                if(!ReadFile(hFile, userDirUtf8.data(), size, &read, nullptr))
+                    userDirUtf8.clear();
+            }
             CloseHandle(hFile);
             userDirUtf16 = Utf8ToUtf16(userDirUtf8.data());
         }
@@ -404,9 +408,10 @@ BRIDGE_IMPEXP bool BridgeSettingRead(int* errorLine)
     HANDLE hFile = CreateFileW(szIniFile, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
     if(hFile != INVALID_HANDLE_VALUE)
     {
-        DWORD fileSize = GetFileSize(hFile, nullptr);
-        if(fileSize)
+        LARGE_INTEGER fileSizeLI;
+        if(GetFileSizeEx(hFile, &fileSizeLI) && fileSizeLI.QuadPart > 0 && fileSizeLI.QuadPart < MAXDWORD)
         {
+            DWORD fileSize = (DWORD)fileSizeLI.QuadPart;
             unsigned char utf8bom[] = { 0xEF, 0xBB, 0xBF };
             char* fileData = (char*)BridgeAlloc(sizeof(utf8bom) + fileSize + 1);
             DWORD read = 0;

--- a/src/dbg/_plugins.cpp
+++ b/src/dbg/_plugins.cpp
@@ -185,7 +185,7 @@ PLUG_IMPEXP bool _plugin_load(const char* pluginName)
 
 duint _plugin_hash(const void* data, duint size)
 {
-    return murmurhash(data, int(size));
+    return murmurhash(data, (size_t)size);
 }
 
 PLUG_IMPEXP bool _plugin_registerformatfunction(int pluginHandle, const char* type, CBPLUGINFORMATFUNCTION cbFunction, void* userdata)

--- a/src/dbg/filehelper.cpp
+++ b/src/dbg/filehelper.cpp
@@ -9,12 +9,17 @@ bool FileHelper::ReadAllData(const String & fileName, std::vector<unsigned char>
         Handle hFile = CreateFileW(StringUtils::Utf8ToUtf16(fileName).c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
         if(hFile == INVALID_HANDLE_VALUE)
             return false;
-        unsigned int filesize = GetFileSize(hFile, nullptr);
-        if(!filesize)
+        LARGE_INTEGER fileSizeLI;
+        if(!GetFileSizeEx(hFile, &fileSizeLI))
+            return false;
+        if(fileSizeLI.QuadPart == 0)
         {
             content.clear();
             return true;
         }
+        if(fileSizeLI.QuadPart > MAXDWORD)
+            return false; // File too large to read into memory
+        DWORD filesize = (DWORD)fileSizeLI.QuadPart;
         content.resize(filesize);
         DWORD read = 0;
         return !!ReadFile(hFile, content.data(), filesize, &read, nullptr);

--- a/src/dbg/filemap.h
+++ b/src/dbg/filemap.h
@@ -10,15 +10,19 @@ struct FileMap
         hFile = CreateFileW(szFileName, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
         if(hFile != INVALID_HANDLE_VALUE)
         {
-            size = GetFileSize(hFile, nullptr);
-            hMap = CreateFileMappingW(hFile, nullptr, PAGE_READONLY | (mapImage ? SEC_IMAGE : 0), 0, 0, nullptr);
-            if(hMap)
-                data = (const T*)MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+            LARGE_INTEGER fileSizeLI;
+            if(GetFileSizeEx(hFile, &fileSizeLI))
+            {
+                size = fileSizeLI.QuadPart;
+                hMap = CreateFileMappingW(hFile, nullptr, PAGE_READONLY | (mapImage ? SEC_IMAGE : 0), 0, 0, nullptr);
+                if(hMap)
+                    data = (const T*)MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+            }
         }
         return data != nullptr;
     }
 
-    unsigned int Size()
+    uint64_t Size()
     {
         return size;
     }
@@ -52,7 +56,7 @@ private:
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE hMap = nullptr;
     const T* data = nullptr;
-    unsigned int size = 0;
+    uint64_t size = 0;
 };
 
 struct BufferedWriter

--- a/src/dbg/module.cpp
+++ b/src/dbg/module.cpp
@@ -934,9 +934,10 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
         // https://github.com/x64dbg/x64dbg/issues/3756
         if(hFile)
         {
-            DWORD fileSize = GetFileSize(hFile, nullptr);
-            if(fileSize != INVALID_FILE_SIZE && fileSize > 0)
+            LARGE_INTEGER fileSizeLI;
+            if(GetFileSizeEx(hFile, &fileSizeLI) && fileSizeLI.QuadPart > 0)
             {
+                uint64_t fileSize = fileSizeLI.QuadPart;
                 HANDLE hMap = CreateFileMappingW(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
                 if(hMap)
                 {
@@ -957,9 +958,11 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
             }
         }
 
-        // 2. If no file handle or mapping failed, try loading from disk path
-        if(!fileLoaded && StaticFileLoadW(wszFullPath.c_str(), UE_ACCESS_READ, false, &info.fileHandle, &info.loadedSize, &info.fileMap, &info.fileMapVA))
+        // 2. If no file handle or mapping failed, try loading from disk path (TitanEngine path, limited to 4GB)
+        DWORD titanLoadedSize = 0;
+        if(!fileLoaded && StaticFileLoadW(wszFullPath.c_str(), UE_ACCESS_READ, false, &info.fileHandle, &titanLoadedSize, &info.fileMap, &info.fileMapVA))
         {
+            info.loadedSize = titanLoadedSize;
             CloseHandle(info.fileHandle);
             info.fileHandle = (HANDLE)1; // Set to non-zero for TitanEngine compatibility
             fileLoaded = true;
@@ -1008,7 +1011,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
                 if(MemRead(Base, info.mappedData(), info.mappedData.size()))
                 {
                     info.isVirtual = true; // Process memory is SEC_IMAGE mapped
-                    info.loadedSize = (DWORD)actualSize;
+                    info.loadedSize = actualSize;
                     GetModuleInfo(info, (ULONG_PTR)info.mappedData());
                     info.size = HEADER_FIELD(info.headers, SizeOfImage);
                     dprintf(QT_TRANSLATE_NOOP("DBG", "Module %s%s loaded from process memory (file inaccessible)\n"), info.name, info.extension);
@@ -1044,7 +1047,7 @@ bool ModLoad(duint Base, duint Size, const char* FullPath, bool loadSymbols, HAN
 
         // Get information from the local buffer
         // TODO: this does not properly work for file offset -> rva conversions (since virtual modules are SEC_IMAGE)
-        info.loadedSize = (DWORD)Size;
+        info.loadedSize = Size;
         GetModuleInfo(info, (ULONG_PTR)info.mappedData());
     }
 
@@ -1580,9 +1583,8 @@ void MODINFO::unloadSymbols()
 
 void MODINFO::unmapFile()
 {
-    // Unload the mapped file from memory
     if(fileMapVA)
-        StaticFileUnloadW(StringUtils::Utf8ToUtf16(path).c_str(), false, fileHandle, loadedSize, fileMap, fileMapVA);
+        StaticFileUnloadW(StringUtils::Utf8ToUtf16(path).c_str(), false, fileHandle, (DWORD)loadedSize, fileMap, fileMapVA);
 }
 
 const MODEXPORT* MODINFO::findExport(duint rva) const
@@ -1625,10 +1627,12 @@ static bool resolveApiSetForward(const String & originatingDll, String & forward
     wcsncat_s(szApiSetDllPath, L".dll", _TRUNCATE);
 
     auto ticks = GetTickCount();
-    // Load the physical module from disk
+    // Load the physical module from disk (TitanEngine path, limited to 4GB)
     MODINFO info = {};
-    if(!StaticFileLoadW(szApiSetDllPath, UE_ACCESS_READ, false, &info.fileHandle, &info.loadedSize, &info.fileMap, &info.fileMapVA))
+    DWORD titanLoadedSize = 0;
+    if(!StaticFileLoadW(szApiSetDllPath, UE_ACCESS_READ, false, &info.fileHandle, &titanLoadedSize, &info.fileMap, &info.fileMapVA))
         return false;
+    info.loadedSize = titanLoadedSize;
 
     GetModuleInfo(info, info.fileMapVA);
 

--- a/src/dbg/module.h
+++ b/src/dbg/module.h
@@ -116,7 +116,7 @@ struct MODINFO
     std::vector<String> pdbPaths; // Possible PDB paths (tried in order)
 
     HANDLE fileHandle = nullptr;
-    DWORD loadedSize = 0;
+    uint64_t loadedSize = 0;
     HANDLE fileMap = nullptr;
     ULONG_PTR fileMapVA = 0;
 

--- a/src/dbg/murmurhash.cpp
+++ b/src/dbg/murmurhash.cpp
@@ -7,6 +7,9 @@
 // compile and run any of them on any platform, but your performance with the
 // non-native version will be less than optimal.
 
+// x64dbg: changed 'int len' to 'size_t len' and converted loops to forward
+// indexing to support files >2GB. See: https://github.com/x64dbg/x64dbg/issues/3583
+
 #include "murmurhash.h"
 
 //-----------------------------------------------------------------------------
@@ -125,7 +128,7 @@ inline uint64_t rotl64(uint64_t x, int8_t r)
  @return An uint32_t.
  */
 
-FORCE_INLINE uint32_t getblock32(const uint32_t* p, int i)
+FORCE_INLINE uint32_t getblock32(const uint32_t* p, size_t i)
 {
     return p[i];
 }
@@ -141,7 +144,7 @@ FORCE_INLINE uint32_t getblock32(const uint32_t* p, int i)
  @return An uint64_t.
  */
 
-FORCE_INLINE uint64_t getblock64(const uint64_t* p, int i)
+FORCE_INLINE uint64_t getblock64(const uint64_t* p, size_t i)
 {
     return p[i];
 }
@@ -204,11 +207,11 @@ FORCE_INLINE uint64_t fmix64(uint64_t k)
  @param [in,out] out If non-null, the out.
  */
 
-void MurmurHash3_x86_32(const void* key, int len,
+void MurmurHash3_x86_32(const void* key, size_t len,
                         uint32_t seed, void* out)
 {
     const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 4;
+    const size_t nblocks = len / 4;
 
     uint32_t h1 = seed;
 
@@ -218,9 +221,9 @@ void MurmurHash3_x86_32(const void* key, int len,
     //----------
     // body
 
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 4);
+    const uint32_t* blocks = (const uint32_t*)(data);
 
-    for(int i = -nblocks; i; i++)
+    for(size_t i = 0; i < nblocks; i++)
     {
         uint32_t k1 = getblock32(blocks, i);
 
@@ -277,11 +280,11 @@ void MurmurHash3_x86_32(const void* key, int len,
  @param [in,out] out If non-null, the out.
  */
 
-void MurmurHash3_x86_128(const void* key, const int len,
+void MurmurHash3_x86_128(const void* key, const size_t len,
                          uint32_t seed, void* out)
 {
     const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 16;
+    const size_t nblocks = len / 16;
 
     uint32_t h1 = seed;
     uint32_t h2 = seed;
@@ -296,9 +299,9 @@ void MurmurHash3_x86_128(const void* key, const int len,
     //----------
     // body
 
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 16);
+    const uint32_t* blocks = (const uint32_t*)(data);
 
-    for(int i = -nblocks; i; i++)
+    for(size_t i = 0; i < nblocks; i++)
     {
         uint32_t k1 = getblock32(blocks, i * 4 + 0);
         uint32_t k2 = getblock32(blocks, i * 4 + 1);
@@ -451,11 +454,11 @@ void MurmurHash3_x86_128(const void* key, const int len,
  @param [in,out] out If non-null, the out.
  */
 
-void MurmurHash3_x64_128(const void* key, const int len,
+void MurmurHash3_x64_128(const void* key, const size_t len,
                          const uint32_t seed, void* out)
 {
     const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 16;
+    const size_t nblocks = len / 16;
 
     uint64_t h1 = seed;
     uint64_t h2 = seed;
@@ -468,7 +471,7 @@ void MurmurHash3_x64_128(const void* key, const int len,
 
     const uint64_t* blocks = (const uint64_t*)(data);
 
-    for(int i = 0; i < nblocks; i++)
+    for(size_t i = 0; i < nblocks; i++)
     {
         uint64_t k1 = getblock64(blocks, i * 2 + 0);
         uint64_t k2 = getblock64(blocks, i * 2 + 1);

--- a/src/dbg/murmurhash.h
+++ b/src/dbg/murmurhash.h
@@ -16,21 +16,24 @@ typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;
 typedef unsigned __int64 uint64_t;
 
+#include <stddef.h>
+
 // Other compilers
 
 #else    // defined(_MSC_VER)
 
 #include <stdint.h>
+#include <stddef.h>
 
 #endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* out);
+void MurmurHash3_x86_32(const void* key, size_t len, uint32_t seed, void* out);
 
-void MurmurHash3_x86_128(const void* key, int len, uint32_t seed, void* out);
+void MurmurHash3_x86_128(const void* key, size_t len, uint32_t seed, void* out);
 
-void MurmurHash3_x64_128(const void* key, int len, uint32_t seed, void* out);
+void MurmurHash3_x64_128(const void* key, size_t len, uint32_t seed, void* out);
 
 //-----------------------------------------------------------------------------
 
@@ -39,13 +42,13 @@ static inline
 unsigned long long murmurhash(const void* data, size_t len)
 {
     unsigned long long hash[2];
-    MurmurHash3_x64_128(data, (int)len, 0x1337, hash);
+    MurmurHash3_x64_128(data, len, 0x1337, hash);
 #else //x86
 static inline
 unsigned long murmurhash(const void* data, size_t len)
 {
     unsigned int hash[1];
-    MurmurHash3_x86_32(data, (int)len, 0x1337, hash);
+    MurmurHash3_x86_32(data, len, 0x1337, hash);
 #endif //_WIN64
     return hash[0];
 }

--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -2617,7 +2617,9 @@ duint valvatofileoffset(duint va)
     const auto modInfo = ModInfoFromAddr(va);
     if(modInfo && modInfo->fileMapVA)
     {
-        ULONGLONG offset = ConvertVAtoFileOffsetEx(modInfo->fileMapVA, modInfo->loadedSize, 0, va - modInfo->base, true, false);
+        if(modInfo->loadedSize > MAXDWORD)
+            return 0;
+        ULONGLONG offset = ConvertVAtoFileOffsetEx(modInfo->fileMapVA, (DWORD)modInfo->loadedSize, 0, va - modInfo->base, true, false);
         return (duint)offset;
     }
     return 0;

--- a/src/exe/signaturecheck.cpp
+++ b/src/exe/signaturecheck.cpp
@@ -56,18 +56,32 @@ static bool VerifyEmbeddedSignature(LPCWSTR pwszSourceFile, bool checkRevocation
         return false;
     }
 
-    auto fileSize = GetFileSize(hFile, nullptr);
-    SetFilePointer(hFile, fileSize - sizeof(EmbeddedSignature), nullptr, FILE_BEGIN);
+    LARGE_INTEGER fileSizeLI;
+    if(!GetFileSizeEx(hFile, &fileSizeLI) || fileSizeLI.QuadPart < (LONGLONG)sizeof(EmbeddedSignature))
+    {
+        CloseHandle(hFile);
+        return false;
+    }
+    LONGLONG fileSize = fileSizeLI.QuadPart;
+    LARGE_INTEGER seekPos;
+    seekPos.QuadPart = fileSize - sizeof(EmbeddedSignature);
+    SetFilePointerEx(hFile, seekPos, nullptr, FILE_BEGIN);
     EmbeddedSignature signature = {};
     DWORD read = 0;
     ReadFile(hFile, &signature, sizeof(signature), &read, nullptr);
-    SetFilePointer(hFile, 0, nullptr, FILE_BEGIN);
+    seekPos.QuadPart = 0;
+    SetFilePointerEx(hFile, seekPos, nullptr, FILE_BEGIN);
     if(signature.magic == 0xDEAD13371337BEEF)
     {
         // Read the file in memory
         fileSize -= sizeof(EmbeddedSignature);
-        std::vector<uint8_t> fileData(fileSize);
-        auto success = ReadFile(hFile, fileData.data(), fileSize, &read, nullptr);
+        if(fileSize > MAXDWORD)
+        {
+            CloseHandle(hFile);
+            return false;
+        }
+        std::vector<uint8_t> fileData((size_t)fileSize);
+        auto success = ReadFile(hFile, fileData.data(), (DWORD)fileSize, &read, nullptr);
         CloseHandle(hFile);
         if(!success)
         {
@@ -76,7 +90,7 @@ static bool VerifyEmbeddedSignature(LPCWSTR pwszSourceFile, bool checkRevocation
 
         // Hash the file contents
         uint8_t expected[64] = {};
-        crypto_hash(expected, fileData.data(), fileSize);
+        crypto_hash(expected, fileData.data(), (size_t)fileSize);
 
         // Verify the signature block
         u8 pk[32] =


### PR DESCRIPTION
This PR will:
- Fix crash when loading files >2GB by replacing `GetFileSize` with `GetFileSizeEx` and using 64-bit size types
- Fix integer overflow in murmurhash for large files by changing `int` parameters to `size_t`

Solves #3583 and closes #3685