### PR TITLE
Added cycling hotkeys for dump view modes

### DIFF
--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -255,6 +255,12 @@ void CPUDump::setupContextMenu()
         return true;
     }));
 
+    makeShortcutAction(DIcon("hex"), tr("Cycle Hex View"), SLOT(cycleHexViewSlot()), "ActionDumpViewHex");
+    makeShortcutAction(DIcon("strings"), tr("Cycle Text View"), SLOT(cycleTextViewSlot()), "ActionDumpViewText");
+    makeShortcutAction(DIcon("integer"), tr("Cycle Integer View"), SLOT(cycleIntegerViewSlot()), "ActionDumpViewInteger");
+    makeShortcutAction(DIcon("float"), tr("Cycle Float View"), SLOT(cycleFloatViewSlot()), "ActionDumpViewFloat");
+    makeShortcutAction(DIcon("address"), tr("Cycle Address View"), SLOT(cycleAddressViewSlot()), "ActionDumpViewAddress");
+
     mMenuBuilder->loadFromConfig();
     updateShortcuts();
 }
@@ -706,6 +712,7 @@ void CPUDump::hexCodepageSlot()
     CodepageSelectionDialog dialog(this);
     if(dialog.exec() != QDialog::Accepted)
         return;
+    Config()->setUint("HexDump", "DefaultView", (duint)ViewHexCodepage);
     auto codepage = dialog.getSelectedCodepage();
 
     int charwidth = getCharWidth();
@@ -844,6 +851,7 @@ void CPUDump::textCodepageSlot()
     CodepageSelectionDialog dialog(this);
     if(dialog.exec() != QDialog::Accepted)
         return;
+    Config()->setUint("HexDump", "DefaultView", (duint)ViewTextCodepage);
     auto codepage = dialog.getSelectedCodepage();
 
     ColumnDescriptor colDesc;
@@ -1604,6 +1612,103 @@ void CPUDump::allocMemorySlot()
             return;
         }
     }
+}
+
+CPUDump::ViewEnum_t CPUDump::getCurrentView() const
+{
+    return (ViewEnum_t)ConfigUint("HexDump", "DefaultView");
+}
+
+void CPUDump::cycleHexViewSlot()
+{
+    ViewEnum_t current = getCurrentView();
+
+    if(current == ViewHexAscii)
+        setView(ViewHexUnicode);
+    else if(current == ViewHexUnicode)
+        hexCodepageSlot();
+    else
+        setView(ViewHexAscii);
+}
+
+void CPUDump::cycleTextViewSlot()
+{
+    ViewEnum_t current = getCurrentView();
+
+    if(current == ViewTextAscii)
+        setView(ViewTextUnicode);
+    else if(current == ViewTextUnicode)
+        textCodepageSlot();
+    else
+        setView(ViewTextAscii);
+}
+
+void CPUDump::cycleIntegerViewSlot()
+{
+    ViewEnum_t current = getCurrentView();
+    static const ViewEnum_t intViews[] =
+    {
+        ViewIntegerHexByte,
+        ViewIntegerHexShort,
+        ViewIntegerHexLong,
+        ViewIntegerHexLongLong,
+        ViewIntegerSignedByte,
+        ViewIntegerSignedShort,
+        ViewIntegerSignedLong,
+        ViewIntegerSignedLongLong,
+        ViewIntegerUnsignedByte,
+        ViewIntegerUnsignedShort,
+        ViewIntegerUnsignedLong,
+        ViewIntegerUnsignedLongLong,
+    };
+
+    const size_t intViewsCount = sizeof(intViews) / sizeof(intViews[0]);
+    ViewEnum_t next = intViews[0];
+    for(size_t i = 0; i < intViewsCount; i++)
+    {
+        if(intViews[i] == current)
+        {
+            next = intViews[(i + 1) % intViewsCount];
+            break;
+        }
+    }
+
+    setView(next);
+}
+
+void CPUDump::cycleFloatViewSlot()
+{
+    ViewEnum_t current = getCurrentView();
+    static const ViewEnum_t floatViews[] =
+    {
+        ViewFloatHalf,
+        ViewFloatFloat,
+        ViewFloatDouble,
+        ViewFloatLongDouble,
+    };
+
+    const size_t floatViewsCount = sizeof(floatViews) / sizeof(floatViews[0]);
+    ViewEnum_t next = floatViews[0];
+    for(size_t i = 0; i < floatViewsCount; i++)
+    {
+        if(floatViews[i] == current)
+        {
+            next = floatViews[(i + 1) % floatViewsCount];
+            break;
+        }
+    }
+
+    setView(next);
+}
+
+void CPUDump::cycleAddressViewSlot()
+{
+    ViewEnum_t current = getCurrentView();
+
+    if(current == ViewAddressAscii || current == ViewAddress)
+        setView(ViewAddressUnicode);
+    else
+        setView(ViewAddressAscii);
 }
 
 void CPUDump::setView(ViewEnum_t view)

--- a/src/gui/Src/Gui/CPUDump.h
+++ b/src/gui/Src/Gui/CPUDump.h
@@ -86,6 +86,12 @@ public slots:
 
     void headerButtonReleasedSlot(duint colIndex);
 
+    void cycleHexViewSlot();
+    void cycleTextViewSlot();
+    void cycleIntegerViewSlot();
+    void cycleFloatViewSlot();
+    void cycleAddressViewSlot();
+
 private:
     MenuBuilder* mMenuBuilder;
     CommonActions* mCommonActions;
@@ -130,5 +136,6 @@ private:
         ViewIntegerHexByte,
     };
 
+    ViewEnum_t getCurrentView() const;
     void setView(ViewEnum_t view);
 };

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -478,6 +478,11 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ActionBinaryEdit", Shortcut({tr("Actions"), tr("Binary Edit")}, "Ctrl+E"));
     defaultShortcuts.insert("ActionBinaryFill", Shortcut({tr("Actions"), tr("Binary Fill")}, "F"));
     defaultShortcuts.insert("ActionBinaryFillNops", Shortcut({tr("Actions"), tr("Binary Fill NOPs")}, "Ctrl+9"));
+    defaultShortcuts.insert("ActionDumpViewHex", Shortcut({tr("Dump"), tr("Cycle Hex View")}, "Ctrl+H"));
+    defaultShortcuts.insert("ActionDumpViewText", Shortcut({tr("Dump"), tr("Cycle Text View")}, "Ctrl+T"));
+    defaultShortcuts.insert("ActionDumpViewInteger", Shortcut({tr("Dump"), tr("Cycle Integer View")}, "Ctrl+N"));
+    defaultShortcuts.insert("ActionDumpViewFloat", Shortcut({tr("Dump"), tr("Cycle Float View")}, "Ctrl+F"));
+    defaultShortcuts.insert("ActionDumpViewAddress", Shortcut({tr("Dump"), tr("Cycle Address View")}, "Ctrl+A"));
     defaultShortcuts.insert("ActionBinaryCopy", Shortcut({tr("Actions"), tr("Binary Copy")}, "Shift+C"));
     defaultShortcuts.insert("ActionBinaryPaste", Shortcut({tr("Actions"), tr("Binary Paste")}, "Shift+V"));
     defaultShortcuts.insert("ActionBinaryPasteIgnoreSize", Shortcut({tr("Actions"), tr("Binary Paste (Ignore Size)")}, "Ctrl+Shift+V"));


### PR DESCRIPTION
Issue link: https://github.com/x64dbg/x64dbg/issues/1322

I have added Ctrl-based hotkeys to cycle dump view categories (Hex/Text/Integer/Float/Address) with codepage selection dialog on codepage views.

Summary of hotkeys:
- Ctrl+H -> cycles through Hex views
- Ctrl+T -> cycles through Text views  
- Ctrl+N -> cycles through Integer views
- Ctrl+F -> cycles through Float views
- Ctrl+A -> cycles through Address views