### PR TITLE
Added References tab copy address shortcut

### DIFF
--- a/src/gui/Src/BasicView/ReferenceView.cpp
+++ b/src/gui/Src/BasicView/ReferenceView.cpp
@@ -84,6 +84,12 @@ void ReferenceView::setupContextMenu()
     StdSearchListView::addAction(mToggleBookmark);
     connect(mToggleBookmark, SIGNAL(triggered()), this, SLOT(toggleBookmark()));
 
+    mCopyReferenceAddress = new QAction(DIcon("copy_item"), tr("Copy Address"), this);
+    mCopyReferenceAddress->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    addAction(mCopyReferenceAddress);
+    StdSearchListView::addAction(mCopyReferenceAddress);
+    connect(mCopyReferenceAddress, SIGNAL(triggered()), this, SLOT(copyReferenceAddress()));
+
     mSetBreakpointOnAllCommands = new QAction(DIcon("breakpoint_seton_all_commands"), tr("Set breakpoint on all commands"), this);
     connect(mSetBreakpointOnAllCommands, SIGNAL(triggered()), this, SLOT(setBreakpointOnAllCommands()));
 
@@ -134,6 +140,7 @@ void ReferenceView::refreshShortcutsSlot()
 {
     mToggleBreakpoint->setShortcut(ConfigShortcut("ActionToggleBreakpoint"));
     mToggleBookmark->setShortcut(ConfigShortcut("ActionToggleBookmark"));
+    mCopyReferenceAddress->setShortcut(ConfigShortcut("ActionCopyReferenceAddress"));
 }
 
 void ReferenceView::referenceSetProgressSlot(int progress)
@@ -402,6 +409,17 @@ void ReferenceView::toggleBookmark()
         SimpleErrorBox(this, tr("Error!"), tr("DbgSetBookmarkAt failed!"));
     GuiUpdateAllViews();
 }
+
+void ReferenceView::copyReferenceAddress()
+{
+    if(!mCurList->getRowCount())
+        return;
+    QString address = mCurList->getCellContent(mCurList->getInitialSelection(), 0);
+    if(address.isEmpty())
+        return;
+    Bridge::CopyToClipboard(address);
+}
+
 
 dsint ReferenceView::apiAddressFromString(const QString & s)
 {

--- a/src/gui/Src/BasicView/ReferenceView.h
+++ b/src/gui/Src/BasicView/ReferenceView.h
@@ -36,6 +36,7 @@ public slots:
     void setBreakpointOnAllApiCalls();
     void removeBreakpointOnAllApiCalls();
     void toggleBookmark();
+    void copyReferenceAddress();
     void refreshShortcutsSlot();
     void referenceSetProgressSlot(int progress);
     void referenceSetCurrentTaskProgressSlot(int progress, QString taskTitle);
@@ -56,6 +57,7 @@ private:
     QAction* mFollowApiAddress;
     QAction* mToggleBreakpoint;
     QAction* mToggleBookmark;
+    QAction* mCopyReferenceAddress;
     QAction* mSetBreakpointOnAllCommands;
     QAction* mRemoveBreakpointOnAllCommands;
     QAction* mSetBreakpointOnAllApiCalls;

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -565,6 +565,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     defaultShortcuts.insert("ActionToggleRegisterValue", Shortcut({tr("Actions"), tr("Toggle Register Value")}, "Space"));
     defaultShortcuts.insert("ActionClear", Shortcut({tr("Actions"), tr("Clear")}, "Ctrl+L"));
     defaultShortcuts.insert("ActionCopy", Shortcut({tr("Actions"), tr("Copy")}, "Ctrl+C"));
+    defaultShortcuts.insert("ActionCopyReferenceAddress", Shortcut({tr("Actions"), tr("Copy Reference Address")}, "Ctrl+Shift+C"));
     defaultShortcuts.insert("ActionCopyAddress", Shortcut({tr("Actions"), tr("Copy Address")}, "Alt+INS"));
     defaultShortcuts.insert("ActionCopyRva", Shortcut({tr("Actions"), tr("Copy RVA")}, ""));
     defaultShortcuts.insert("ActionCopySymbol", Shortcut({tr("Actions"), tr("Copy Symbol")}, "Ctrl+S"));


### PR DESCRIPTION
Issue: https://github.com/x64dbg/x64dbg/issues/3651

Added a References-only “Copy Address” action with Ctrl+Shift+C