### PR TITLE
Fix patch import undo bug

### DIFF
--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -501,6 +501,7 @@ void PatchDialog::on_btnImport_clicked()
     {
         bool badoriginal;
         bool alreadypatched;
+        unsigned char actualbyte; // byte snapshot on import
     } IMPORTSTATUS;
     QList<QPair<DBGPATCHINFO, IMPORTSTATUS>> patchList;
     DBGPATCHINFO curPatch;
@@ -558,6 +559,7 @@ void PatchDialog::on_btnImport_clicked()
             IMPORTSTATUS status;
             status.alreadypatched = (checkbyte == newbyte);
             status.badoriginal = (checkbyte != oldbyte);
+            status.actualbyte = checkbyte;  
             if(status.alreadypatched)
                 bAlreadyDone = true;
             else if(status.badoriginal)
@@ -606,7 +608,13 @@ void PatchDialog::on_btnImport_clicked()
         curPatch = patchList.at(i).first;
         if(bUndoPatched && patchList.at(i).second.alreadypatched)
         {
-            if(DbgFunctions()->MemPatch(curPatch.addr, &curPatch.oldbyte, 1))
+            unsigned char byteToWrite;
+            if (patchList.at(i).second.badoriginal)
+                byteToWrite = patchList.at(i).second.actualbyte;  
+            else
+                byteToWrite = curPatch.oldbyte;
+
+            if(DbgFunctions()->MemPatch(curPatch.addr, &byteToWrite, 1))
                 patched++;
         }
         else

--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -501,7 +501,7 @@ void PatchDialog::on_btnImport_clicked()
     {
         bool badoriginal;
         bool alreadypatched;
-        unsigned char actualbyte; // byte snapshot on import
+        unsigned char actualbyte; // byte snapshot on import 
     } IMPORTSTATUS;
     QList<QPair<DBGPATCHINFO, IMPORTSTATUS>> patchList;
     DBGPATCHINFO curPatch;

--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -501,7 +501,7 @@ void PatchDialog::on_btnImport_clicked()
     {
         bool badoriginal;
         bool alreadypatched;
-        unsigned char actualbyte; // byte snapshot on import 
+        unsigned char actualbyte; // byte snapshot on import
     } IMPORTSTATUS;
     QList<QPair<DBGPATCHINFO, IMPORTSTATUS>> patchList;
     DBGPATCHINFO curPatch;
@@ -559,7 +559,7 @@ void PatchDialog::on_btnImport_clicked()
             IMPORTSTATUS status;
             status.alreadypatched = (checkbyte == newbyte);
             status.badoriginal = (checkbyte != oldbyte);
-            status.actualbyte = checkbyte;  
+            status.actualbyte = checkbyte;
             if(status.alreadypatched)
                 bAlreadyDone = true;
             else if(status.badoriginal)
@@ -609,8 +609,8 @@ void PatchDialog::on_btnImport_clicked()
         if(bUndoPatched && patchList.at(i).second.alreadypatched)
         {
             unsigned char byteToWrite;
-            if (patchList.at(i).second.badoriginal)
-                byteToWrite = patchList.at(i).second.actualbyte;  
+            if(patchList.at(i).second.badoriginal)
+                byteToWrite = patchList.at(i).second.actualbyte;
             else
                 byteToWrite = curPatch.oldbyte;
 


### PR DESCRIPTION
Closes #3461

I changed it so theres "actualbyte" thats in the IMPORTSTATUS struct, which takes a "snapshot" of the byte on import.

So it can actually compared the original byte on import, not compare it to the original byte in the patch file which can be wrong.
This basically handles the edge case error where a user can type out a wrong original byte, but correct newbyte, which causes it to take the original byte in the .1337 as the real byte and actually swaps it when it "undoes" patching, resulting in lets say a 00 original byte which was never in the file, to be replaced.

New build:
<img width="1266" height="537" alt="image" src="https://github.com/user-attachments/assets/4dc9e43c-4167-46b2-86a0-b23e9c466d97" />
<img width="1266" height="537" alt="image" src="https://github.com/user-attachments/assets/aa9bb326-ef48-4277-9475-9824bd54ed7a" />

Old build:
<img width="1103" height="701" alt="image" src="https://github.com/user-attachments/assets/7575544d-9522-4cb9-bb48-f58c0cdacb4e" />

Notice how it switches CC for 35? When the newbyte should have been CC, as it is.

