### PR TITLE
faster search list filtering

### DIFF
--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -238,7 +238,7 @@ void SearchListView::searchTextEdited(const QString & text)
         if(rowCount <= 10000)
             return 0;   // seems to be OK for up to 10000 rows
         else
-            return 400; // 400 ms between keypresses should be ok for the average user typing speed.
+            return 250; // 250 ms between keypresses should be ok for the average user typing speed.
     }(mAbstractSearchList->list()->getRowCount()));
     mAbstractSearchList->unlock();
     mTypingTimer->start(); // This will fire filterEntries after interval ms.

--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -238,7 +238,7 @@ void SearchListView::searchTextEdited(const QString & text)
         if(rowCount <= 10000)
             return 0;   // seems to be OK for up to 10000 rows
         else
-            return 250; // 250 ms between keypresses should be ok for the average user typing speed.
+            return 400; // 400 ms between keypresses should be ok for the average user typing speed.
     }(mAbstractSearchList->list()->getRowCount()));
     mAbstractSearchList->unlock();
     mTypingTimer->start(); // This will fire filterEntries after interval ms.

--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -235,11 +235,8 @@ void SearchListView::searchTextEdited(const QString & text)
     mAbstractSearchList->lock();
     mTypingTimer->setInterval([](dsint rowCount)
     {
-        // These numbers are kind of arbitrarily chosen, but seem to work
         if(rowCount <= 10000)
-            return 0;
-        else if(rowCount <= 600000)
-            return 100;
+            return 0;   // seems to be OK for up to 10000 rows
         else
             return 350;
     }(mAbstractSearchList->list()->getRowCount()));

--- a/src/gui/Src/BasicView/SearchListView.cpp
+++ b/src/gui/Src/BasicView/SearchListView.cpp
@@ -238,7 +238,7 @@ void SearchListView::searchTextEdited(const QString & text)
         if(rowCount <= 10000)
             return 0;   // seems to be OK for up to 10000 rows
         else
-            return 350;
+            return 250; // 250 ms between keypresses should be ok for the average user typing speed.
     }(mAbstractSearchList->list()->getRowCount()));
     mAbstractSearchList->unlock();
     mTypingTimer->start(); // This will fire filterEntries after interval ms.

--- a/src/gui/Src/BasicView/StdTableSearchList.cpp
+++ b/src/gui/Src/BasicView/StdTableSearchList.cpp
@@ -27,8 +27,9 @@ void StdTableSearchList::filter(const QString & filter, FilterType type, duint s
         duint listRow = matchingRows[searchListRow];
         for(duint column = 0; column < columns; column++)
         {
-            mSearchList->setCellContent(searchListRow, column, mList->getCellContent(listRow, column));
-            mSearchList->setCellUserdata(searchListRow, column, mList->getCellUserdata(listRow, column));
+            mSearchList->setCellContent(searchListRow, column,
+                                        mList->getCellContent(listRow, column),
+                                        mList->getCellUserdata(listRow, column));
         }
         if(mSearchIconList && mIconList)
             mSearchIconList->setRowIcon(searchListRow, mIconList->getRowIcon(listRow));

--- a/src/gui/Src/BasicView/StdTableSearchList.cpp
+++ b/src/gui/Src/BasicView/StdTableSearchList.cpp
@@ -5,22 +5,33 @@ void StdTableSearchList::filter(const QString & filter, FilterType type, duint s
 {
     StdIconTable* mSearchIconList = qobject_cast<StdIconTable*>(mSearchList);
     StdIconTable* mIconList = qobject_cast<StdIconTable*>(mList);
-    mSearchList->setRowCount(0);
+
     auto rows = mList->getRowCount();
     auto columns = mList->getColumnCount();
-    for(duint i = 0, j = 0; i < rows; i++)
+
+    // collect matching row indices
+    std::vector<duint> matchingRows;
+    matchingRows.reserve(rows);
+
+    for(duint row = 0; row < rows; row++)
     {
-        if(rowMatchesFilter(filter, type, i, startColumn))
+        if(rowMatchesFilter(filter, type, row, startColumn))
+            matchingRows.push_back(row);
+    }
+
+    // resize once with exact size
+    mSearchList->setRowCount(matchingRows.size());
+
+    // populate searchList with matched results
+    for(duint searchListRow = 0; searchListRow < matchingRows.size(); searchListRow++)
+    {
+        duint listRow = matchingRows[searchListRow];
+        for(duint column = 0; column < columns; column++)
         {
-            mSearchList->setRowCount(j + 1);
-            for(duint k = 0; k < columns; k++)
-            {
-                mSearchList->setCellContent(j, k, mList->getCellContent(i, k));
-                mSearchList->setCellUserdata(j, k, mList->getCellUserdata(i, k));
-            }
-            if(mSearchIconList && mIconList)
-                mSearchIconList->setRowIcon(j, mIconList->getRowIcon(i));
-            j++;
+            mSearchList->setCellContent(searchListRow, column, mList->getCellContent(listRow, column));
+            mSearchList->setCellUserdata(searchListRow, column, mList->getCellUserdata(listRow, column));
         }
+        if(mSearchIconList && mIconList)
+            mSearchIconList->setRowIcon(searchListRow, mIconList->getRowIcon(listRow));
     }
 }

--- a/src/gui/Src/BasicView/StdTableSearchList.cpp
+++ b/src/gui/Src/BasicView/StdTableSearchList.cpp
@@ -11,7 +11,6 @@ void StdTableSearchList::filter(const QString & filter, FilterType type, duint s
 
     // collect matching row indices
     std::vector<duint> matchingRows;
-    matchingRows.reserve(rows);
 
     for(duint row = 0; row < rows; row++)
     {


### PR DESCRIPTION
For improving the UI experience while using the search filter this PR will adjust the typing timer values for average human typing speed. 

In addition this fixes a performance issue in `StdTableSearchList::filter`. 

I have changed also some variable names like "i" and "j" to make the code easier to understand.