### PR TITLE
Use run trace to assist correct disassembly (experimental)

### DIFF
--- a/src/cross/widgets/Bridge.cpp
+++ b/src/cross/widgets/Bridge.cpp
@@ -94,7 +94,7 @@ DBGFUNCTIONS* DbgFunctions()
         };
         f.GetTraceRecordByteType = [](duint addr)
         {
-            return TRACERECORDBYTETYPE::Unknown;
+            return TRACERECORDBYTETYPE::TraceRecordByteTypeUnknown;
         };
         f.ModBaseFromAddr = [](duint addr) -> duint
         {

--- a/src/cross/widgets/Bridge.cpp
+++ b/src/cross/widgets/Bridge.cpp
@@ -92,6 +92,10 @@ DBGFUNCTIONS* DbgFunctions()
         {
             return 0;
         };
+        f.GetTraceRecordByteType = [](duint addr)
+        {
+            return TRACERECORDBYTETYPE::Unknown;
+        };
         f.ModBaseFromAddr = [](duint addr) -> duint
         {
             return 0;

--- a/src/cross/widgets/Bridge.h
+++ b/src/cross/widgets/Bridge.h
@@ -74,7 +74,7 @@ typedef enum
     InstructionHeading = 1,
     InstructionTailing = 2,
     InstructionOverlapped = 3, // The byte was executed with differing instruction base addresses
-    Unknown = 4// The following is not implemented yet.
+    TraceRecordByteTypeUnknown = 4 // The following is not implemented yet.
 } TRACERECORDBYTETYPE;
 
 typedef struct

--- a/src/cross/widgets/Bridge.h
+++ b/src/cross/widgets/Bridge.h
@@ -68,6 +68,15 @@ typedef enum
     ARG_SINGLE
 } ARGTYPE;
 
+typedef enum
+{
+    InstructionBody = 0,
+    InstructionHeading = 1,
+    InstructionTailing = 2,
+    InstructionOverlapped = 3, // The byte was executed with differing instruction base addresses
+    Unknown = 4// The following is not implemented yet.
+} TRACERECORDBYTETYPE;
+
 typedef struct
 {
     uint32_t rva;
@@ -86,6 +95,7 @@ typedef struct
 struct DBGFUNCTIONS
 {
     duint(*GetTraceRecordHitCount)(duint addr);
+    TRACERECORDBYTETYPE(*GetTraceRecordByteType)(duint address);
     duint(*ModBaseFromAddr)(duint addr);
     bool (*ModNameFromAddr)(duint base, char* name, bool extension);
     bool (*StringFormatInline)(char* dest, duint size, const char* format);

--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -460,7 +460,7 @@ TraceRecordManager::TraceRecordByteType TraceRecordManager::getByteType(duint ad
     duint base = address & ~((duint)4096 - 1);
     auto pageInfoIterator = TraceRecord.find(ModHashFromAddr(base));
     if(pageInfoIterator == TraceRecord.end())
-        return TraceRecordByteType::InstructionHeading;
+        return TraceRecordByteType::Unknown;
     else
     {
         TraceRecordPage pageInfo = pageInfoIterator->second;
@@ -469,11 +469,18 @@ TraceRecordManager::TraceRecordByteType TraceRecordManager::getByteType(duint ad
         {
         case TraceRecordType::TraceRecordBitExec:
         default:
-            return TraceRecordByteType::InstructionHeading;
+            // bit type don't store byte type
+            return TraceRecordByteType::Unknown;
         case TraceRecordType::TraceRecordByteWithExecTypeAndCounter:
-            return (TraceRecordByteType)((((char*)pageInfo.rawPtr)[offset] & 0xC0) >> 6);
+            if((((char*)pageInfo.rawPtr)[offset] & 0x3F) != 0)
+                return (TraceRecordByteType)((((char*)pageInfo.rawPtr)[offset] & 0xC0) >> 6);
+            else
+                return TraceRecordByteType::Unknown;
         case TraceRecordType::TraceRecordWordWithExecTypeAndCounter:
-            return (TraceRecordByteType)((((short*)pageInfo.rawPtr)[offset] & 0xC000) >> 14);
+            if((((short*)pageInfo.rawPtr)[offset] & 0x3FFF) != 0)
+                return (TraceRecordByteType)((((short*)pageInfo.rawPtr)[offset] & 0xC000) >> 14);
+            else
+                return TraceRecordByteType::Unknown;
         }
     }
 }

--- a/src/dbg/TraceRecord.h
+++ b/src/dbg/TraceRecord.h
@@ -15,6 +15,7 @@ public:
         InstructionHeading = 1,
         InstructionTailing = 2,
         InstructionOverlapped = 3, // The byte was executed with differing instruction base addresses
+        Unknown = 4,
         DataByte,  // This and the following is not implemented yet.
         DataWord,
         DataDWord,
@@ -66,12 +67,14 @@ public:
     void saveToDb(JSON root);
     void loadFromDb(JSON root);
 private:
+    // An enumerated value indicating this byte is either start of instruction, middle of instruction, end of instruction, or part of overlapped instruction.
     enum TraceRecordByteType_2bit
     {
         _InstructionBody = 0,
         _InstructionHeading = 1,
         _InstructionTailing = 2,
-        _InstructionOverlapped = 3
+        _InstructionOverlapped = 3,
+        _Unknown = 4 // Never recorded, unknown
     };
 
     struct TraceRecordPage

--- a/src/gui/Src/Disassembler/QZydis.cpp
+++ b/src/gui/Src/Disassembler/QZydis.cpp
@@ -8,6 +8,16 @@
 #define _countof(array) (sizeof(array) / sizeof(array[0]))
 #endif // _countof
 
+// TODO: header
+enum TraceRecordByteType_2bit
+{
+    _InstructionBody = 0,
+    _InstructionHeading = 1,
+    _InstructionTailing = 2,
+    _InstructionOverlapped = 3,
+    _Unknown = 4
+};
+
 QZydis::QZydis(int maxModuleSize, Architecture* architecture)
     : mTokenizer(maxModuleSize, architecture), mArchitecture(architecture)
 {
@@ -41,6 +51,8 @@ ulong QZydis::DisassembleBack(const uint8_t* data, duint base, duint size, duint
 
     // Reset Disasm Structure
     Zydis zydis(mArchitecture->disasm64());
+
+    auto GetTraceRecordByteType = DbgFunctions()->GetTraceRecordByteType;
 
     // Check if the pointer is not null
     if(data == NULL)
@@ -94,10 +106,36 @@ ulong QZydis::DisassembleBack(const uint8_t* data, duint base, duint size, duint
         }
         else
         {
-            if(!zydis.DisassembleSafe(addr + base, pdata, (int)size))
-                cmdsize = 2; //heuristic for better output (FF FE or FE FF are usually part of an instruction)
-            else
-                cmdsize = zydis.Size();
+            // Check byte type
+            bool hasByteType = false;
+            if(mUseRunTrace && GetTraceRecordByteType(base + addr + 1) != TraceRecordByteType_2bit::_Unknown)
+            {
+                for(int m = 1; m <= 16; m++)
+                {
+                    auto byteType = GetTraceRecordByteType(base + addr + m);
+                    if(byteType == TraceRecordByteType_2bit::_InstructionTailing)
+                    {
+                        cmdsize = m + 1;
+                        hasByteType = true;
+                        break;
+                    }
+                    else if(byteType == TraceRecordByteType_2bit::_InstructionHeading || byteType == TraceRecordByteType_2bit::_InstructionOverlapped)
+                    {
+                        // TODO one instruction with multiple overlapped instructions
+                        cmdsize = m;
+                        hasByteType = true;
+                        break;
+                    }
+
+                }
+            }
+            if(!hasByteType)
+            {
+                if(!zydis.DisassembleSafe(addr + base, pdata, (int)size))
+                    cmdsize = 2; //heuristic for better output (FF FE or FE FF are usually part of an instruction)
+                else
+                    cmdsize = zydis.Size();
+            }
 
             cmdsize = mEncodeMap->getDataSize(base + addr, cmdsize);
 
@@ -147,6 +185,7 @@ ulong QZydis::DisassembleNext(const uint8_t* data, duint base, duint size, duint
     if(n <= 0)
         return ip;
 
+    auto GetTraceRecordByteType = DbgFunctions()->GetTraceRecordByteType;
 
     pdata = data + ip;
     size -= ip;
@@ -159,11 +198,35 @@ ulong QZydis::DisassembleNext(const uint8_t* data, duint base, duint size, duint
         }
         else
         {
-            if(!zydis.DisassembleSafe(ip + base, pdata, (int)size))
-                cmdsize = 1;
-            else
-                cmdsize = zydis.Size();
+            bool hasByteType = false;
+            if(mUseRunTrace && GetTraceRecordByteType(base + ip + 1) != TraceRecordByteType_2bit::_Unknown)
+            {
+                for(int m = 1; m <= 16; m++)
+                {
+                    auto byteType = GetTraceRecordByteType(base + ip + m);
+                    if(byteType == TraceRecordByteType_2bit::_InstructionTailing)
+                    {
+                        cmdsize = m + 1;
+                        hasByteType = true;
+                        break;
+                    }
+                    else if(byteType == TraceRecordByteType_2bit::_InstructionHeading || byteType == TraceRecordByteType_2bit::_InstructionOverlapped)
+                    {
+                        // TODO one instruction with multiple overlapped instructions
+                        cmdsize = m;
+                        hasByteType = true;
+                        break;
+                    }
 
+                }
+            }
+            if(!hasByteType)
+            {
+                if(!zydis.DisassembleSafe(ip + base, pdata, (int)size))
+                    cmdsize = 1;
+                else
+                    cmdsize = zydis.Size();
+            }
             cmdsize = mEncodeMap->getDataSize(base + ip, cmdsize);
 
         }
@@ -379,6 +442,7 @@ void QZydis::setCodeFoldingManager(CodeFoldingHelper* CodeFoldingManager)
 void QZydis::UpdateConfig()
 {
     mLongDataInst = ConfigBool("Disassembler", "LongDataInstruction");
+    mUseRunTrace = ConfigBool("Disassembler", "UseRunTrace");
     mTokenizer.UpdateConfig();
 }
 

--- a/src/gui/Src/Disassembler/QZydis.cpp
+++ b/src/gui/Src/Disassembler/QZydis.cpp
@@ -1,5 +1,6 @@
 #include "QZydis.h"
 #include "StringUtil.h"
+#include <algorithm>
 #include <Utils/EncodeMap.h>
 #include <Utils/CodeFolding.h>
 #include <Bridge.h>
@@ -17,6 +18,29 @@ enum TraceRecordByteType_2bit
     _InstructionOverlapped = 3,
     _Unknown = 4
 };
+
+static uint getTraceRecordInstructionSize(TRACERECORDBYTETYPE(*getTraceRecordByteType)(duint), duint address, duint remainingSize)
+{
+    if(getTraceRecordByteType == nullptr || remainingSize == 0)
+        return 0;
+
+    auto currentByteType = getTraceRecordByteType(address);
+    if(currentByteType != TraceRecordByteType_2bit::_InstructionHeading
+            && currentByteType != TraceRecordByteType_2bit::_InstructionOverlapped)
+        return 0;
+
+    auto maxLookahead = std::min<duint>(remainingSize - 1, 14); // x86/x64 instructions are at most 15 bytes long
+    for(duint m = 1; m <= maxLookahead; m++)
+    {
+        auto byteType = getTraceRecordByteType(address + m);
+        if(byteType == TraceRecordByteType_2bit::_InstructionTailing)
+            return m + 1;
+        if(byteType == TraceRecordByteType_2bit::_InstructionHeading || byteType == TraceRecordByteType_2bit::_InstructionOverlapped)
+            return m;
+    }
+
+    return 0;
+}
 
 QZydis::QZydis(int maxModuleSize, Architecture* architecture)
     : mTokenizer(maxModuleSize, architecture), mArchitecture(architecture)
@@ -108,25 +132,13 @@ ulong QZydis::DisassembleBack(const uint8_t* data, duint base, duint size, duint
         {
             // Check byte type
             bool hasByteType = false;
-            if(mUseRunTrace && GetTraceRecordByteType(base + addr + 1) != TraceRecordByteType_2bit::_Unknown)
+            if(mUseRunTrace)
             {
-                for(int m = 1; m <= 16; m++)
+                auto traceCmdSize = getTraceRecordInstructionSize(GetTraceRecordByteType, base + addr, size);
+                if(traceCmdSize != 0)
                 {
-                    auto byteType = GetTraceRecordByteType(base + addr + m);
-                    if(byteType == TraceRecordByteType_2bit::_InstructionTailing)
-                    {
-                        cmdsize = m + 1;
-                        hasByteType = true;
-                        break;
-                    }
-                    else if(byteType == TraceRecordByteType_2bit::_InstructionHeading || byteType == TraceRecordByteType_2bit::_InstructionOverlapped)
-                    {
-                        // TODO one instruction with multiple overlapped instructions
-                        cmdsize = m;
-                        hasByteType = true;
-                        break;
-                    }
-
+                    cmdsize = traceCmdSize;
+                    hasByteType = true;
                 }
             }
             if(!hasByteType)
@@ -199,25 +211,13 @@ ulong QZydis::DisassembleNext(const uint8_t* data, duint base, duint size, duint
         else
         {
             bool hasByteType = false;
-            if(mUseRunTrace && GetTraceRecordByteType(base + ip + 1) != TraceRecordByteType_2bit::_Unknown)
+            if(mUseRunTrace)
             {
-                for(int m = 1; m <= 16; m++)
+                auto traceCmdSize = getTraceRecordInstructionSize(GetTraceRecordByteType, base + ip, size);
+                if(traceCmdSize != 0)
                 {
-                    auto byteType = GetTraceRecordByteType(base + ip + m);
-                    if(byteType == TraceRecordByteType_2bit::_InstructionTailing)
-                    {
-                        cmdsize = m + 1;
-                        hasByteType = true;
-                        break;
-                    }
-                    else if(byteType == TraceRecordByteType_2bit::_InstructionHeading || byteType == TraceRecordByteType_2bit::_InstructionOverlapped)
-                    {
-                        // TODO one instruction with multiple overlapped instructions
-                        cmdsize = m;
-                        hasByteType = true;
-                        break;
-                    }
-
+                    cmdsize = traceCmdSize;
+                    hasByteType = true;
                 }
             }
             if(!hasByteType)

--- a/src/gui/Src/Disassembler/QZydis.h
+++ b/src/gui/Src/Disassembler/QZydis.h
@@ -73,6 +73,7 @@ private:
     ZydisTokenizer mTokenizer;
     QHash<ENCODETYPE, DataInstructionInfo> mDataInstMap;
     bool mLongDataInst = false;
+    bool mUseRunTrace = false;
     EncodeMap* mEncodeMap = nullptr;
     CodeFoldingHelper* mCodeFoldingManager = nullptr;
 };

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -398,6 +398,7 @@ void CPUDisassembly::setupRightClickContextMenu()
     QAction* traceCoverageEnableBit = makeAction(DIcon("bit"), tr("Bit"), SLOT(traceCoverageBitSlot()));
     QAction* traceCoverageEnableByte = makeAction(DIcon("byte"), tr("Byte"), SLOT(traceCoverageByteSlot()));
     QAction* traceCoverageEnableWord = makeAction(DIcon("word"), tr("Word"), SLOT(traceCoverageWordSlot()));
+    QAction* traceCoverageReset = makeAction(tr("Reset trace coverage"), SLOT(traceCoverageResetSlot()));
     QAction* traceCoverageToggleTraceRecording = makeShortcutAction(DIcon("control-record"), tr("Start trace recording"), SLOT(traceCoverageToggleTraceRecordingSlot()), "ActionToggleRunTrace");
     mMenuBuilder->addMenu(makeMenu(DIcon("trace"), tr("Trace coverage")), [ = ](QMenu * menu)
     {
@@ -408,7 +409,10 @@ void CPUDisassembly::setupRightClickContextMenu()
             menu->addAction(traceCoverageEnableWord);
         }
         else
+        {
+            menu->addAction(traceCoverageReset);
             menu->addAction(traceCoverageDisable);
+        }
         menu->addSeparator();
         if(TraceBrowser::isRecording())
         {
@@ -1974,6 +1978,25 @@ void CPUDisassembly::traceCoverageWordSlot()
         {
             GuiAddLogMessage(tr("Failed to enable trace coverage for page %1.\n").arg(ToPtrString(i)).toUtf8().constData());
             break;
+        }
+    }
+    DbgCmdExec("traceexecute cip");
+}
+
+void CPUDisassembly::traceCoverageResetSlot()
+{
+    if(!DbgIsDebugging())
+        return;
+    duint base = mMemPage->getBase();
+    duint size = mMemPage->getSize();
+    for(duint i = base; i < base + size; i += 4096)
+    {
+        auto t = DbgFunctions()->GetTraceRecordType(i);
+        if(t == TRACERECORDTYPE::TraceRecordNone)
+            continue;
+        if(!(DbgFunctions()->SetTraceRecordType(i, TRACERECORDTYPE::TraceRecordNone) && DbgFunctions()->SetTraceRecordType(i, t)))
+        {
+            GuiAddLogMessage(tr("Failed to reset trace coverage for page %1.\n").arg(ToPtrString(i)).toUtf8().constData());
         }
     }
     DbgCmdExec("traceexecute cip");

--- a/src/gui/Src/Gui/CPUDisassembly.h
+++ b/src/gui/Src/Gui/CPUDisassembly.h
@@ -91,6 +91,7 @@ public slots:
     void traceCoverageBitSlot();
     void traceCoverageByteSlot();
     void traceCoverageWordSlot();
+    void traceCoverageResetSlot();
     void traceCoverageDisableSlot();
     void traceCoverageToggleTraceRecordingSlot();
     void displayWarningSlot(QString title, QString text);

--- a/src/gui/Src/Gui/SettingsDialog.cpp
+++ b/src/gui/Src/Gui/SettingsDialog.cpp
@@ -243,6 +243,7 @@ void SettingsDialog::LoadSettings()
     GetSettingBool("Disassembler", "NoBranchDisasmPreview", &settings.disasmNoBranchDisasmPreview);
     GetSettingBool("Disassembler", "NoSourceLineAutoComments", &settings.disasmNoSourceLineAutoComments);
     GetSettingBool("Disassembler", "AssembleOnDoubleClick", &settings.disasmAssembleOnDoubleClick);
+    GetSettingBool("Disassembler", "UseRunTrace", &settings.disasmUseRunTrace);
 
     if(BridgeSettingGetUint("Disassembler", "0xPrefixValues", &cur))
     {
@@ -274,6 +275,7 @@ void SettingsDialog::LoadSettings()
     ui->chkNoSourceLinesAutoComments->setChecked(settings.disasmNoSourceLineAutoComments);
     ui->chkDoubleClickAssemble->setChecked(settings.disasmAssembleOnDoubleClick);
     ui->spinMaximumModuleNameSize->setValue(settings.disasmMaxModuleSize);
+    ui->chkUseRunTrace->setChecked(settings.disasmUseRunTrace);
 
     //Gui tab
     GetSettingBool("Gui", "FpuRegistersLittleEndian", &settings.guiFpuRegistersLittleEndian);
@@ -447,6 +449,7 @@ void SettingsDialog::SaveSettings()
     BridgeSettingSetUint("Disassembler", "NoSourceLineAutoComments", settings.disasmNoSourceLineAutoComments);
     BridgeSettingSetUint("Disassembler", "AssembleOnDoubleClick", settings.disasmAssembleOnDoubleClick);
     BridgeSettingSetUint("Disassembler", "MaxModuleSize", settings.disasmMaxModuleSize);
+    BridgeSettingSetUint("Disassembler", "UseRunTrace", settings.disasmUseRunTrace);
 
     //Gui tab
     BridgeSettingSetUint("Gui", "FpuRegistersLittleEndian", settings.guiFpuRegistersLittleEndian);
@@ -972,6 +975,11 @@ void SettingsDialog::on_chkUppercase_stateChanged(int arg1)
 {
     bTokenizerConfigUpdated = true;
     settings.disasmUppercase = arg1 != Qt::Unchecked;
+}
+
+void SettingsDialog::on_chkUseRunTrace_toggled(bool checked)
+{
+    settings.disasmUseRunTrace = checked;
 }
 
 void SettingsDialog::on_chkOnlyCipAutoComments_stateChanged(int arg1)

--- a/src/gui/Src/Gui/SettingsDialog.h
+++ b/src/gui/Src/Gui/SettingsDialog.h
@@ -98,6 +98,7 @@ private slots:
     void on_chkNoSourceLinesAutoComments_toggled(bool checked);
     void on_chkDoubleClickAssemble_toggled(bool checked);
     void on_spinMaximumModuleNameSize_valueChanged(int arg1);
+    void on_chkUseRunTrace_toggled(bool checked);
     //Gui Tab
     void on_chkFpuRegistersLittleEndian_stateChanged(int arg1);
     void on_chkSaveColumnOrder_stateChanged(int arg1);
@@ -237,6 +238,7 @@ private:
         bool disasmNoSourceLineAutoComments = false;
         bool disasmAssembleOnDoubleClick = false;
         int disasmMaxModuleSize = -1;
+        bool disasmUseRunTrace = false;
         //Gui Tab
         bool guiFpuRegistersLittleEndian = false;
         bool guiSaveColumnOrder = false;

--- a/src/gui/Src/Gui/SettingsDialog.ui
+++ b/src/gui/Src/Gui/SettingsDialog.ui
@@ -769,6 +769,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkUseRunTrace">
+         <property name="text">
+          <string>Use trace coverage data to assist more accurate disassembling (experimental)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="layoutValueNotation">
          <item>
           <widget class="QLabel" name="labelValueNotation">

--- a/src/gui/Src/Utils/Configuration.cpp
+++ b/src/gui/Src/Utils/Configuration.cpp
@@ -266,6 +266,7 @@ Configuration::Configuration() : QObject(), noMoreMsgbox(false)
     disassemblyBool.insert("NoBranchDisasmPreview", false);
     disassemblyBool.insert("NoCurrentModuleText", false);
     disassemblyBool.insert("ShowMnemonicBrief", false);
+    disassemblyBool.insert("UseRunTrace", false);
     defaultBools.insert("Disassembler", disassemblyBool);
 
     QMap<QString, bool> engineBool;


### PR DESCRIPTION
This is part of original run trace (same name as Ollydbg) feature roadmap. It saves the boundaries of executed instructions in run trace. Previously, this byte type information was unused. Now, the disassembler starts to use the byte execution type to ensure correct disassembly, especially in obfuscated code.
Before:
<img width="1351" height="153" alt="before" src="https://github.com/user-attachments/assets/8dbf643b-d737-4b6e-b14b-94050d6b97c8" />
After:
<img width="1091" height="122" alt="after" src="https://github.com/user-attachments/assets/6b4d8d4a-4715-49ea-adc5-b5e2893ef7fb" />
This is currently working and experimental.
