### PR TITLE
Add flush() to TaskThread to sync logs before savelog

### DIFF
--- a/src/dbg/console.cpp
+++ b/src/dbg/console.cpp
@@ -6,12 +6,16 @@
 #include "console.h"
 #include "taskthread.h"
 
+static StringConcatTaskThread_<void(*)(const std::string &)>* logTask = nullptr;
+static StringConcatTaskThread_<void(*)(const std::string &)>* logHtmlTask = nullptr;
+
 static void GuiAddLogMessageAsync(_In_z_ const char* msg)
 {
     static StringConcatTaskThread_<void(*)(const std::string &)> task([](const std::string & msg)
     {
         GuiAddLogMessage(msg.c_str());
     });
+    logTask = &task;
     task.WakeUp(msg);
 }
 
@@ -21,6 +25,7 @@ static void GuiAddLogMessageHtmlAsync(_In_z_ const char* msg)
     {
         GuiAddLogMessageHtml(msg.c_str());
     });
+    logHtmlTask = &task;
     task.WakeUp(msg);
 }
 
@@ -134,4 +139,12 @@ void dprintf_html(_In_z_ _Printf_format_string_ const char* Format, ...)
 void dlogprint_untranslated(const char* Text)
 {
     GuiAddLogMessageAsync(Text);
+}
+
+// flushing
+
+void dflush()
+{
+    if(logTask) logTask->Flush();
+    if(logHtmlTask) logHtmlTask->Flush();
 }

--- a/src/dbg/console.cpp
+++ b/src/dbg/console.cpp
@@ -7,7 +7,6 @@
 #include "taskthread.h"
 
 static StringConcatTaskThread_<void(*)(const std::string &)>* logTask = nullptr;
-static StringConcatTaskThread_<void(*)(const std::string &)>* logHtmlTask = nullptr;
 
 static void GuiAddLogMessageAsync(_In_z_ const char* msg)
 {
@@ -25,7 +24,6 @@ static void GuiAddLogMessageHtmlAsync(_In_z_ const char* msg)
     {
         GuiAddLogMessageHtml(msg.c_str());
     });
-    logHtmlTask = &task;
     task.WakeUp(msg);
 }
 
@@ -146,5 +144,4 @@ void dlogprint_untranslated(const char* Text)
 void dflush()
 {
     if(logTask) logTask->Flush();
-    if(logHtmlTask) logHtmlTask->Flush();
 }

--- a/src/dbg/console.h
+++ b/src/dbg/console.h
@@ -12,5 +12,5 @@ void dprintf_args_untranslated(_In_z_ _Printf_format_string_ const char* Format,
 void dprint_untranslated_html(_In_z_ _Printf_format_string_ const char* Text);
 void dprintf_html(_In_z_ _Printf_format_string_ const char* Format, ...);
 void dlogprint_untranslated(_In_z_ const char* Text);
-
+void dflush();
 #endif // _CONSOLE_H

--- a/src/dbg/taskthread.h
+++ b/src/dbg/taskthread.h
@@ -15,10 +15,11 @@ protected:
     F fn;
     std::tuple<Args...> args;
     bool active = true;
+    bool flushRequested = false;
     HANDLE hThread;
     CRITICAL_SECTION access;
     HANDLE wakeupSemaphore;
-
+    HANDLE flushEvent = nullptr;
     size_t minSleepTimeMs = 0;
     size_t wakeups = 0;
     size_t execs = 0;
@@ -31,6 +32,7 @@ protected:
     virtual void ResetArgs() { }
 public:
     void WakeUp(Args...);
+    void Flush();
     explicit TaskThread_(F, size_t minSleepTimeMs = TASK_THREAD_DEFAULT_SLEEP_TIME);
     virtual ~TaskThread_();
 };
@@ -123,13 +125,34 @@ template <typename F, typename... Args> void TaskThread_<F, Args...>::Loop()
             Sleep((DWORD)this->minSleepTimeMs);
             ++this->execs;
         }
+        bool doFlush = false;
+        EnterCriticalSection(&this->access);
+        doFlush = this->flushRequested;
+        if(doFlush)
+            this->flushRequested = false;
+        LeaveCriticalSection(&this->access);
+
+        if(doFlush)
+            SetEvent(this->flushEvent);
     }
+}
+template <typename F, typename... Args> void TaskThread_<F, Args...>::Flush()
+{
+    EnterCriticalSection(&this->access);
+    flushRequested = true;
+    LeaveCriticalSection(&this->access);
+
+    ReleaseSemaphore(this->wakeupSemaphore, 1, nullptr);
+
+    WaitForSingleObject(flushEvent, INFINITE);
+    ResetEvent(flushEvent);
 }
 
 template <typename F, typename... Args>
 TaskThread_<F, Args...>::TaskThread_(F fn,
                                      size_t minSleepTimeMs) : fn(fn), minSleepTimeMs(minSleepTimeMs)
 {
+    this->flushEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     this->wakeupSemaphore = CreateSemaphoreW(nullptr, 0, 1, nullptr);
     InitializeCriticalSection(&this->access);
 
@@ -153,6 +176,7 @@ TaskThread_<F, Args...>::~TaskThread_()
 
     DeleteCriticalSection(&this->access);
     CloseHandle(this->wakeupSemaphore);
+    CloseHandle(this->flushEvent);
 }
 
 #endif // _TASKTHREAD_H

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -56,7 +56,14 @@ static bool cbClearLog(int argc, char* argv[])
 
 static bool cbSaveLog(int argc, char* argv[])
 {
+    auto hEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);
     dflush();
+    GuiExecuteOnGuiThreadEx([](void* param)
+    {
+        SetEvent((HANDLE)param);
+    }, hEvent);
+    WaitForSingleObject(hEvent, INFINITE);
+    CloseHandle(hEvent);
 
     if(argc < 2)
         GuiLogSave(nullptr);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -56,6 +56,8 @@ static bool cbClearLog(int argc, char* argv[])
 
 static bool cbSaveLog(int argc, char* argv[])
 {
+    dflush();
+
     if(argc < 2)
         GuiLogSave(nullptr);
     else


### PR DESCRIPTION
Closes #3609

Added a flush() method to TaskThread, which is called from the main thread inside cbSaveLog, which pauses execution of the main thread until the worker thread ( triggered by the cbInstrPrintStack via dprintf_untranslated ) finishes processing its current buffer and prints messages at the time savelog is called.
Before:
<img width="892" height="356" alt="image" src="https://github.com/user-attachments/assets/f9986666-502f-4505-bcf4-f2098af75a48" />

The log is empty because the save dialog command returns before the worker thread has finished processing its buffer.

After:
<img width="702" height="239" alt="image" src="https://github.com/user-attachments/assets/cffc0dbd-3f2e-400a-a0a7-71b89eeff6f2" />
It prints the current call stack at the time savelog is called, ensuring that everything already in the buffer is flushed.

For now, this does not guarantee that all future call stack logs will be printed, since additional wakeup calls may occur after savelog returns. It only ensures that the buffer at the moment savelog is called is flushed.
