### PR TITLE
Fix invalid pointer dereference in setfpuvalue for Opmask/ZMM registers

### DIFF
--- a/src/dbg/value.cpp
+++ b/src/dbg/value.cpp
@@ -2285,7 +2285,7 @@ static void setfpuvalue(const char* string, duint value)
             }
             else
             {
-                context.Opmask[registerindex] = *(ULONGLONG*)value;
+                context.Opmask[registerindex] = (ULONGLONG)value;
                 SetAVX512Context(hActiveThread, &context);
             }
         }


### PR DESCRIPTION
`setfpuvalue` was dereferencing `value` as a pointer (`*(ULONGLONG*)value`) instead of casting it directly. This crashes the debugger when setting Opmask/ZMM registers via expressions like `_K0=5`.

- Opmask: cast directly to `ULONGLONG`
- ZMM: zero-init + `memcpy` since `ZmmRegister_t` is larger than `duint`

Fixes : #3803 