### PR TITLE
Fix #3467: can't load DLL with no entrypoint

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -1901,7 +1901,7 @@ static void cbLoadDll(LOAD_DLL_DEBUG_INFO* LoadDll)
         bIsDebuggingThis = true;
         pDebuggedBase = (duint)base;
         DbCheckHash(ModContentHashFromAddr(pDebuggedBase)); //Check hash mismatch
-        if(settingboolget("Events", "EntryBreakpoint", true))
+        if(pDebuggedEntry != 0 && settingboolget("Events", "EntryBreakpoint", true))
         {
             bAlreadySetEntry = true;
             sprintf_s(command, "bp %p,\"%s\",ss", (void*)(pDebuggedBase + pDebuggedEntry), GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "entry breakpoint")));


### PR DESCRIPTION
x64dbg tries to set a breakpoint on the entry point. However, DLL files may not have an entry point defined, therefore we need to check if it is defined before setting a breakpoint so that the file can be properly loaded. This fix implements a guard that prevents the breakpoint from being set if there is no entry point.