### PR TITLE
Crash when pasting/loading script due to wrong Order of evaluation

### DIFF
--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -187,7 +187,10 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
     if(*temp)
     {
         entry = {};
-        strcpy_s(entry.raw, temp);
+        int add = 0;
+        while (isspace(temp[add]))
+            add++;
+        strcpy_s(entry.raw, temp + add);
         scriptLineMap.push_back(entry);
     }
     int linemapsize = (int)scriptLineMap.size();

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -144,6 +144,7 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
     auto len = filedata.length();
     String temp;
     LINEMAPENTRY entry = {};
+    size_t rawElements = sizeof(LINEMAPENTRY::raw) / sizeof(LINEMAPENTRY::raw[0]);
     scriptLineMap.clear();
     for(size_t i = 0; i < len; i++) //make raw line map
     {
@@ -169,6 +170,20 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
             strcpy_s(entry.raw, temp.c_str());
             temp = "";
             scriptLineMap.push_back(entry);
+        }
+        else if(temp.length() >= rawElements - 2)
+        {
+            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
+            {
+                return !std::isspace(ch);
+            }));
+            if (temp.length())
+            {
+                entry = {};
+                strcpy_s(entry.raw, temp.c_str());
+                scriptLineMap.push_back(entry);
+            }
+            temp = "";
         }
         else
         {

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -142,60 +142,49 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
         return false;
     }
     auto len = filedata.length();
-    char temp[256] = "";
+    String temp;
     LINEMAPENTRY entry = {};
     scriptLineMap.clear();
-    for(size_t i = 0, j = 0; i < len; i++) //make raw line map
+    for(size_t i = 0; i < len; i++) //make raw line map
     {
-        if(filedata[i] == '\r' && filedata[i + 1] == '\n') //windows file
+        if (filedata[i] == '\r' && filedata[i + 1] == '\n') //windows file
         {
             entry = {};
-            int add = 0;
-            while(isspace(temp[add]))
-                add++;
-            strcpy_s(entry.raw, temp + add);
-            *temp = 0;
-            j = 0;
+            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch) {
+                return !std::isspace(ch);
+                }));
+            strcpy_s(entry.raw, temp.c_str());
+            temp = "";
             i++;
             scriptLineMap.push_back(entry);
         }
-        else if(filedata[i] == '\n') //other file
+        else if (filedata[i] == '\n') //other file
         {
             entry = {};
-            int add = 0;
-            while(isspace(temp[add]))
-                add++;
-            strcpy_s(entry.raw, temp + add);
-            *temp = 0;
-            j = 0;
+            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch) {
+                return !std::isspace(ch);
+                }));
+            strcpy_s(entry.raw, temp.c_str());
+            temp = "";
             scriptLineMap.push_back(entry);
         }
-        else if(j >= 254)
-        {
-            entry = {};
-            int add = 0;
-            while(isspace(temp[add]))
-                add++;
-            if(add < 254)
-            {
-                strcpy_s(entry.raw, temp + add);
-                scriptLineMap.push_back(entry);
-            }
-            *temp = 0;
-            j = 0;
-        }
         else
-            j += sprintf_s(temp + j, sizeof(temp) - j, "%c", filedata[i]);
+        {
+            temp += filedata[i];
+        }    
     }
-    if(*temp)
+
+    temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }));
+
+    if(temp.length())
     {
         entry = {};
-        int add = 0;
-        while(isspace(temp[add]))
-            add++;
-        strcpy_s(entry.raw, temp + add);
+        strcpy_s(entry.raw, temp.c_str());
         scriptLineMap.push_back(entry);
     }
+
     int linemapsize = (int)scriptLineMap.size();
     while(linemapsize && !*scriptLineMap.at(linemapsize - 1).raw) //remove empty lines from the end
     {
@@ -271,8 +260,8 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
             cur.type = linelabel;
             sprintf_s(cur.u.label, "l %.*s", rawlen - 1, cur.raw); //create a fake command for formatting
             strcpy_s(cur.u.label, StringUtils::Trim(cur.u.label).c_str());
-            strcpy_s(temp, cur.u.label + 2);
-            strcpy_s(cur.u.label, temp); //remove fake command
+            temp = String(cur.u.label + 2);
+            strcpy_s(cur.u.label, temp.c_str()); //remove fake command
             if(!*cur.u.label || !strcmp(cur.u.label, "\"\"")) //no label text
             {
                 char message[256] = "";

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -147,23 +147,25 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
     scriptLineMap.clear();
     for(size_t i = 0; i < len; i++) //make raw line map
     {
-        if (filedata[i] == '\r' && filedata[i + 1] == '\n') //windows file
+        if(filedata[i] == '\r' && filedata[i + 1] == '\n') //windows file
         {
             entry = {};
-            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch) {
+            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
+            {
                 return !std::isspace(ch);
-                }));
+            }));
             strcpy_s(entry.raw, temp.c_str());
             temp = "";
             i++;
             scriptLineMap.push_back(entry);
         }
-        else if (filedata[i] == '\n') //other file
+        else if(filedata[i] == '\n') //other file
         {
             entry = {};
-            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch) {
+            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
+            {
                 return !std::isspace(ch);
-                }));
+            }));
             strcpy_s(entry.raw, temp.c_str());
             temp = "";
             scriptLineMap.push_back(entry);
@@ -174,9 +176,10 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
         }    
     }
 
-    temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch) {
+    temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
+    {
         return !std::isspace(ch);
-        }));
+    }));
 
     if(temp.length())
     {

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -176,10 +176,13 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
             int add = 0;
             while(isspace(temp[add]))
                 add++;
-            strcpy_s(entry.raw, temp + add);
+            if (add < 254)
+            {
+                strcpy_s(entry.raw, temp + add);
+                scriptLineMap.push_back(entry);
+            }
             *temp = 0;
             j = 0;
-            scriptLineMap.push_back(entry);
         }
         else
             j += sprintf_s(temp + j, sizeof(temp) - j, "%c", filedata[i]);

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -152,10 +152,7 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
         if(filedata[i] == '\r' && filedata[i + 1] == '\n') //windows file
         {
             entry = {};
-            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
-            {
-                return !std::isspace(ch);
-            }));
+            temp = StringUtils::Trim(temp);
             strcpy_s(entry.raw, temp.c_str());
             temp = "";
             i++;
@@ -164,20 +161,14 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
         else if(filedata[i] == '\n') //other file
         {
             entry = {};
-            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
-            {
-                return !std::isspace(ch);
-            }));
+            temp = StringUtils::Trim(temp);
             strcpy_s(entry.raw, temp.c_str());
             temp = "";
             scriptLineMap.push_back(entry);
         }
         else if(temp.size() >= rawSize - 2)
         {
-            temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
-            {
-                return !std::isspace(ch);
-            }));
+            temp = StringUtils::Trim(temp);
             if(temp.length())
             {
                 entry = {};
@@ -192,10 +183,7 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
         }
     }
 
-    temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }));
+    temp = StringUtils::Trim(temp);
 
     if(temp.length())
     {

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -106,7 +106,7 @@ static int scriptNextIp(int fromIp) //internal step routine
     int maxIp = (int)scriptLineMap.size(); //maximum ip
     if(fromIp >= maxIp) //script end
         return fromIp;
-    while(isEmptyLine(scriptLineMap.at(fromIp).type) && fromIp < maxIp) //skip empty lines
+    while((fromIp < maxIp) && isEmptyLine(scriptLineMap.at(fromIp).type)) //skip empty lines
         fromIp++;
     fromIp++;
     return fromIp;

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -176,7 +176,7 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
             int add = 0;
             while(isspace(temp[add]))
                 add++;
-            if (add < 254)
+            if(add < 254)
             {
                 strcpy_s(entry.raw, temp + add);
                 scriptLineMap.push_back(entry);

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -144,10 +144,11 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
     auto len = filedata.length();
     String temp;
     LINEMAPENTRY entry = {};
-    size_t rawElements = sizeof(LINEMAPENTRY::raw) / sizeof(LINEMAPENTRY::raw[0]);
+    size_t rawSize = sizeof(LINEMAPENTRY::raw);
     scriptLineMap.clear();
     for(size_t i = 0; i < len; i++) //make raw line map
     {
+        size_t s = temp.size();
         if(filedata[i] == '\r' && filedata[i + 1] == '\n') //windows file
         {
             entry = {};
@@ -171,13 +172,13 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
             temp = "";
             scriptLineMap.push_back(entry);
         }
-        else if(temp.length() >= rawElements - 2)
+        else if(temp.size() >= rawSize - 2)
         {
             temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)
             {
                 return !std::isspace(ch);
             }));
-            if (temp.length())
+            if(temp.length())
             {
                 entry = {};
                 strcpy_s(entry.raw, temp.c_str());
@@ -188,7 +189,7 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
         else
         {
             temp += filedata[i];
-        }    
+        }
     }
 
     temp.erase(temp.begin(), std::find_if(temp.begin(), temp.end(), [](unsigned char ch)

--- a/src/dbg/simplescript.cpp
+++ b/src/dbg/simplescript.cpp
@@ -191,7 +191,7 @@ static bool scriptCreateLineMap(const char* filename, bool gui)
     {
         entry = {};
         int add = 0;
-        while (isspace(temp[add]))
+        while(isspace(temp[add]))
             add++;
         strcpy_s(entry.raw, temp + add);
         scriptLineMap.push_back(entry);


### PR DESCRIPTION
The program can crash for some special scripts.

I'm not fully sure when or why this happens, but it's possible that `fromIp` starts from `maxIp - 1`. In this case it loops one time and then it crashes on the next iteration for 'obvious reasons'.

The fix is simple, change the order of evaluation.

Minimal example to provoke the crash:

```
jmp error
error:
end:
``` 