### PR TITLE
Add patch comments

### DIFF
--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -809,13 +809,12 @@ void PatchDialog::showEvent(QShowEvent* event)
 void PatchDialog::closeEvent(QCloseEvent* event)
 {
     Q_UNUSED(event);
-    if(!isEligibleForComment(mActiveCommentType))
-        return;
-
-    if(isCommentForModule(mActiveCommentType))
-        syncComment(nullptr, ui->listModules->currentItem(), mActiveCommentType, mActiveCommentType);
+    if(isCommentUninitialized(mActiveCommentType) || isCommentStale(mActiveCommentType))
+        syncComment(nullptr, getSelectedOrFirst(ui->listModules), mActiveCommentType, mActiveCommentType);
+    else if(isCommentForModule(mActiveCommentType))
+        syncComment(nullptr, getSelectedOrFirst(ui->listModules), mActiveCommentType, mActiveCommentType);
     else if(isCommentForAddress(mActiveCommentType))
-        syncComment(nullptr, ui->listPatches->currentItem(), mActiveCommentType, mActiveCommentType);
+        syncComment(nullptr, getSelectedOrFirst(ui->listPatches), mActiveCommentType, mActiveCommentType);
 
     mActiveCommentType = ActiveCommentType::Stale;
 }
@@ -889,9 +888,6 @@ void PatchDialog::loadCommentForAddress(const DBGPATCHINFO & patchInfo)
 
 void PatchDialog::saveCommentForModule(const DBGPATCHINFO & patchInfo, const QString & comment)
 {
-    if(comment.isEmpty())
-        return;
-
     mModulePatchComments[patchInfo.mod] = comment;
     if(!mAddressPatchComments.contains(patchInfo.mod))
         mAddressPatchComments.insert(patchInfo.mod, QMap<QString, QString>());
@@ -899,9 +895,6 @@ void PatchDialog::saveCommentForModule(const DBGPATCHINFO & patchInfo, const QSt
 
 void PatchDialog::saveCommentForAddress(const DBGPATCHINFO & patchInfo, const QString & comment)
 {
-    if(comment.isEmpty())
-        return;
-
     QString commentBytes = getCommentKeyForPatchInfo(patchInfo);
     mAddressPatchComments[patchInfo.mod][commentBytes] = comment;
 }

--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -3,6 +3,7 @@
 #include <QMessageBox>
 #include <QIcon>
 #include <QFileDialog>
+#include <QRegularExpression>
 #include <QTextStream>
 #include "MiscUtil.h"
 #include "StringUtil.h"
@@ -27,6 +28,7 @@ PatchDialog::PatchDialog(QWidget* parent) :
     connect(mGroupSelector, SIGNAL(groupPrevious()), this, SLOT(groupPrevious()));
     connect(mGroupSelector, SIGNAL(groupNext()), this, SLOT(groupNext()));
 
+    mActiveCommentType = ActiveCommentType::None;
     mIsWorking = false;
 }
 
@@ -96,6 +98,8 @@ void PatchDialog::updatePatches()
     //clear GUI
     ui->listModules->clear();
     ui->listPatches->clear();
+    ui->listModules->show();
+    ui->listPatches->show();
     mPatches.clear();
 
     //get patches from DBG
@@ -156,7 +160,11 @@ void PatchDialog::updatePatches()
     }
 
     if(mPatches.size())
+    {
         ui->listModules->item(0)->setSelected(true); //select first module
+        ui->listPatches->item(0)->setSelected(true);
+        syncComment(ui->listModules->item(0), nullptr, ActiveCommentType::Module, ActiveCommentType::Module);
+    }
 
     mIsWorking = false;
 }
@@ -273,6 +281,26 @@ void PatchDialog::on_listModules_itemSelectionChanged()
     mIsWorking = false;
 }
 
+void PatchDialog::on_listModules_currentItemChanged(QListWidgetItem* current, QListWidgetItem* previous)
+{
+    syncComment(current, previous, mActiveCommentType, ActiveCommentType::Module);
+}
+
+void PatchDialog::on_listModules_itemClicked(QListWidgetItem* item)
+{
+    syncComment(item, mActiveCommentType, ActiveCommentType::Module);
+}
+
+void PatchDialog::on_listPatches_currentItemChanged(QListWidgetItem* current, QListWidgetItem* previous)
+{
+    syncComment(current, previous, mActiveCommentType, ActiveCommentType::Address);
+}
+
+void PatchDialog::on_listPatches_itemClicked(QListWidgetItem* item)
+{
+    syncComment(item, mActiveCommentType, ActiveCommentType::Address);
+}
+
 void PatchDialog::on_listPatches_itemChanged(QListWidgetItem* item) //checkbox changed
 {
     if(mIsWorking || !ui->listModules->selectedItems().size())
@@ -384,6 +412,13 @@ void PatchDialog::on_btnRestoreSelected_clicked()
     updatePatches();
     if(removed != total)
         ui->listModules->setCurrentRow(selModIdx);
+    if(ui->listModules->count() > 0)
+        ui->listModules->setCurrentRow(0);
+    else
+    {
+        ui->txtComment->clear();
+        ui->txtComment->setDisabled(true);
+    }
     GuiUpdateAllViews();
 }
 
@@ -528,20 +563,36 @@ void PatchDialog::on_btnImport_clicked()
         }
 
         dsint modbase = 0;
+        QString moduleLevelComment = "";
+        int currentCommentOffsetForModule = 0;
         for(int i = 0; i < lines.size(); i++)
         {
             ULONGLONG rva;
             unsigned int oldbyte;
             unsigned int newbyte;
             QString curLine = lines.at(i);
+            if(curLine.startsWith(";") && curLine.length() > 1) // module-level comment
+            {
+                moduleLevelComment = curLine.mid(1);
+                continue;
+            }
             if(curLine.startsWith(">")) //module
             {
                 strcpy_s(curPatch.mod, curLine.toUtf8().constData() + 1);
                 modbase = DbgFunctions()->ModBaseFromName(curPatch.mod);
+
+                currentCommentOffsetForModule = 0;
+                saveCommentForModule(curPatch, moduleLevelComment);
                 continue;
             }
             if(!modbase)
                 continue;
+
+            QString commentText;
+            int commentTextIndex = curLine.indexOf(';');
+            if(commentTextIndex != -1 && commentTextIndex != curLine.length() - 1)
+                commentText = curLine.mid(commentTextIndex + 1);
+
             curLine = curLine.replace(" ", "");
             if(sscanf_s(curLine.toUtf8().constData(), "%llX:%X->%X", &rva, &oldbyte, &newbyte) != 3)
             {
@@ -567,6 +618,9 @@ void PatchDialog::on_btnImport_clicked()
             curPatch.oldbyte = oldbyte;
             curPatch.newbyte = newbyte;
             patchList.push_back(QPair<DBGPATCHINFO, IMPORTSTATUS>(curPatch, status));
+
+            currentCommentOffsetForModule++;
+            saveCommentForAddress(curPatch, commentText);
         }
     }
 
@@ -652,6 +706,11 @@ void PatchDialog::saveAs1337(const QString & filename)
     QStringList lines;
 
     int patches = 0;
+
+    QListWidgetItem* pendingComment = isCommentForAddress(mActiveCommentType) ?
+                                      getSelectedOrFirst(ui->listPatches) : getSelectedOrFirst(ui->listModules);
+    syncComment(pendingComment, pendingComment, mActiveCommentType, mActiveCommentType);
+
     for(PatchMap::iterator i = mPatches.begin(); i != mPatches.end(); ++i)
     {
         const PatchInfoList & curPatchList = i.value();
@@ -665,11 +724,18 @@ void PatchDialog::saveAs1337(const QString & filename)
                 continue;
             if(!bModPlaced)
             {
+                if(mModulePatchComments.contains(i.key()))
+                    lines.push_back(";" + mModulePatchComments[i.key()].replace(QRegularExpression("\\R"), "\\n").toUtf8());
                 lines.push_back(">" + i.key());
                 bModPlaced = true;
             }
             QString addrText = ToPtrString(curPatchList.at(j).patch.addr - modbase);
-            lines.push_back(addrText + QString().sprintf(":%.2X->%.2X", curPatchList.at(j).patch.oldbyte, curPatchList.at(j).patch.newbyte));
+            QString patchLine = addrText + QString().sprintf(":%.2X->%.2X", curPatchList.at(j).patch.oldbyte, curPatchList.at(j).patch.newbyte);
+            QString commentKey = getCommentKeyForPatchInfo(curPatchList.at(j).patch);
+            if(mAddressPatchComments.contains(i.key()) && mAddressPatchComments[i.key()].contains(commentKey))
+                patchLine += " ;" + mAddressPatchComments[i.key()][commentKey].replace(QRegularExpression("\\R"), "\\n").toUtf8();
+            lines.push_back(patchLine);
+
             patches++;
         }
     }
@@ -716,4 +782,250 @@ bool PatchDialog::showRelocatedBytesWarning()
 {
     auto result = QMessageBox::question(this, tr("Patches overlap with relocation regions"), tr("Your patches overlap with relocation regions. This can cause your code to become corrupted when you load the patched executable. Do you want to continue?"));
     return result == QMessageBox::Yes;
+}
+
+void PatchDialog::showEvent(QShowEvent* event)
+{
+    Q_UNUSED(event);
+    if(!isEligibleForComment(mActiveCommentType) || ui->listModules->count() == 0)
+    {
+        ui->txtComment->setDisabled(true);
+        ui->txtComment->clear();
+    }
+
+    if(ui->listModules->count() > 0)
+    {
+        ActiveCommentType previousCommentType = mActiveCommentType;
+        syncComment(ui->listModules->item(0), nullptr, ActiveCommentType::None, ActiveCommentType::Module);
+        mActiveCommentType = previousCommentType;
+    }
+
+    if(!isCommentStale(mActiveCommentType))
+        mActiveCommentType = ActiveCommentType::None;
+
+    ui->listPatches->show();
+}
+
+void PatchDialog::closeEvent(QCloseEvent* event)
+{
+    Q_UNUSED(event);
+    if(!isEligibleForComment(mActiveCommentType))
+        return;
+
+    if(isCommentForModule(mActiveCommentType))
+        syncComment(nullptr, ui->listModules->currentItem(), mActiveCommentType, mActiveCommentType);
+    else if(isCommentForAddress(mActiveCommentType))
+        syncComment(nullptr, ui->listPatches->currentItem(), mActiveCommentType, mActiveCommentType);
+
+    mActiveCommentType = ActiveCommentType::Stale;
+}
+
+bool PatchDialog::getPatchInfoForModuleFromUi(QListWidgetItem* item, DBGPATCHINFO & patchInfo)
+{
+    if(item == nullptr)
+        return false;
+
+    PatchMap::iterator found = mPatches.find(item->text());
+    if(found == mPatches.end())
+        return false;
+
+    PatchInfoList & curPatchList = found.value();
+    if(curPatchList.size() == 0)
+        return false;
+
+    PatchPair & patch = curPatchList[0];
+    patchInfo = patch.patch;
+    return true;
+}
+
+bool PatchDialog::getPatchInfoForAddressFromUi(QListWidgetItem* item, DBGPATCHINFO & patchInfo)
+{
+    if(item == nullptr)
+        return false;
+
+    if(ui->listModules->selectedItems().size() == 0)
+        return false;
+
+    QString mod = ui->listModules->selectedItems().at(0)->text();
+    PatchMap::iterator found = mPatches.find(mod);
+    if(found == mPatches.end())
+        return false;
+
+    PatchInfoList & curPatchList = found.value();
+    if(curPatchList.size() == 0)
+        return false;
+
+    PatchPair & patch = curPatchList[ui->listPatches->row(item)];
+    patchInfo = patch.patch;
+    return true;
+}
+
+QListWidgetItem* PatchDialog::getSelectedOrFirst(QListWidget* items)
+{
+    if(items == nullptr || items->count() == 0)
+        return nullptr;
+
+    return (items->currentItem() != nullptr) ?
+           items->currentItem() : items->item(0);
+}
+
+QString PatchDialog::getCommentKeyForPatchInfo(const DBGPATCHINFO & patchInfo)
+{
+    return ToPtrString(patchInfo.addr) + QString::asprintf(":%.2X->%.2X", patchInfo.oldbyte, patchInfo.newbyte);
+}
+
+void PatchDialog::loadCommentForModule(const DBGPATCHINFO & patchInfo)
+{
+    QString moduleComment = mModulePatchComments.value(patchInfo.mod, "");
+    ui->txtComment->setPlainText(moduleComment.replace("\\n", "\n"));
+}
+
+void PatchDialog::loadCommentForAddress(const DBGPATCHINFO & patchInfo)
+{
+    QString commentKey = getCommentKeyForPatchInfo(patchInfo);
+    QString commentForAddress = mAddressPatchComments[patchInfo.mod].value(commentKey, "");
+    ui->txtComment->setPlainText(commentForAddress.replace("\\n", "\n"));
+}
+
+void PatchDialog::saveCommentForModule(const DBGPATCHINFO & patchInfo, const QString & comment)
+{
+    if(comment.isEmpty())
+        return;
+
+    mModulePatchComments[patchInfo.mod] = comment;
+    if(!mAddressPatchComments.contains(patchInfo.mod))
+        mAddressPatchComments.insert(patchInfo.mod, QMap<QString, QString>());
+}
+
+void PatchDialog::saveCommentForAddress(const DBGPATCHINFO & patchInfo, const QString & comment)
+{
+    if(comment.isEmpty())
+        return;
+
+    QString commentBytes = getCommentKeyForPatchInfo(patchInfo);
+    mAddressPatchComments[patchInfo.mod][commentBytes] = comment;
+}
+
+void PatchDialog::syncComment(QListWidgetItem* current, QListWidgetItem* previous, ActiveCommentType previousCommentType, ActiveCommentType incomingCommentType)
+{
+    if(!isVisible())
+        return;
+
+    // Patch info is being populated, nothing to do yet
+    if(mIsWorking || !ui->listModules->isVisible())
+    {
+        ui->txtComment->clear();
+        return;
+    }
+
+    // A comment can be shown or made at this point
+    ui->txtComment->setDisabled(false);
+
+    DBGPATCHINFO previousModulePatchInfo;
+    DBGPATCHINFO previousAddressPatchInfo;
+    DBGPATCHINFO currentModulePatchInfo;
+    DBGPATCHINFO currentAddressPatchInfo;
+
+    bool foundPreviousPatchInfo = false;
+    bool foundCurrentPatchInfo = false;
+
+    QListWidgetItem* previousTarget = nullptr;
+    QListWidgetItem* currentTarget = nullptr;
+    if(previousCommentType == incomingCommentType)
+    {
+        // Coming from the same list widget, i.e. module -> module
+        previousTarget = previous;
+        currentTarget = current;
+    }
+    else
+    {
+        if(isCommentStale(mActiveCommentType))
+        {
+            // Window is re-opened and list data was refreshed
+            // Load comment for the module in this case
+            previousTarget = nullptr;
+            currentTarget = ui->listModules->item(0);
+            incomingCommentType = ActiveCommentType::Module;
+        }
+        else if(isCommentUninitialized(previousCommentType))
+        {
+            // First click on a list
+            previousTarget = nullptr;
+            currentTarget = isCommentForModule(incomingCommentType) ?
+                            ui->listModules->currentItem() : ui->listPatches->currentItem();
+        }
+        else if(isCommentForModule(previousCommentType))
+        {
+            // Coming from module -> address
+            previousTarget = ui->listModules->currentItem();
+            currentTarget = ui->listPatches->currentItem();
+        }
+        else
+        {
+            // Coming from address -> module
+            previousTarget = ui->listPatches->currentItem();
+            currentTarget = ui->listModules->currentItem();
+        }
+    }
+
+    foundPreviousPatchInfo = isCommentForModule(previousCommentType) ?
+                             getPatchInfoForModuleFromUi(previousTarget, previousModulePatchInfo) :
+                             getPatchInfoForAddressFromUi(previousTarget, previousAddressPatchInfo);
+
+    foundCurrentPatchInfo = isCommentForModule(incomingCommentType) ?
+                            getPatchInfoForModuleFromUi(currentTarget, currentModulePatchInfo) :
+                            getPatchInfoForAddressFromUi(currentTarget, currentAddressPatchInfo);
+
+    if(foundPreviousPatchInfo)
+    {
+        QString commentText = ui->txtComment->toPlainText();
+        if(isCommentForModule(previousCommentType))
+            saveCommentForModule(previousModulePatchInfo, commentText);
+        else
+            saveCommentForAddress(previousAddressPatchInfo, commentText);
+    }
+
+    if(foundCurrentPatchInfo)
+    {
+        if(isCommentForModule(incomingCommentType))
+            loadCommentForModule(currentModulePatchInfo);
+        else
+            loadCommentForAddress(currentAddressPatchInfo);
+    }
+    else
+        ui->txtComment->clear();
+
+    mActiveCommentType = incomingCommentType;
+}
+
+void PatchDialog::syncComment(QListWidgetItem* item, ActiveCommentType previousCommentType, ActiveCommentType incomingCommentType)
+{
+    QListWidgetItem* previous = isCommentForModule(previousCommentType) ?
+                                ui->listModules->currentItem() : ui->listPatches->currentItem();
+    syncComment(item, previous, previousCommentType, incomingCommentType);
+}
+
+bool PatchDialog::isCommentForModule(ActiveCommentType type)
+{
+    return type == ActiveCommentType::Module;
+}
+
+bool PatchDialog::isCommentForAddress(ActiveCommentType type)
+{
+    return type == ActiveCommentType::Address;
+}
+
+bool PatchDialog::isCommentStale(ActiveCommentType type)
+{
+    return type == ActiveCommentType::Stale;
+}
+
+bool PatchDialog::isCommentUninitialized(ActiveCommentType type)
+{
+    return type == ActiveCommentType::None;
+}
+
+bool PatchDialog::isEligibleForComment(ActiveCommentType type)
+{
+    return !isCommentUninitialized(type);
 }

--- a/src/gui/Src/Gui/PatchDialog.h
+++ b/src/gui/Src/Gui/PatchDialog.h
@@ -32,9 +32,19 @@ class PatchDialog : public QDialog
         }
     };
 
+    enum class ActiveCommentType
+    {
+        None = 0,
+        Module,
+        Address,
+        Stale
+    };
+
     //typedef QPair<DBGPATCHINFO, STATUSINFO> PatchPair;
     typedef QList<PatchPair> PatchInfoList;
     typedef QMap<QString, PatchInfoList> PatchMap;
+    typedef QMap<QString, QString> PatchModuleCommentsMap;
+    typedef QMap<QString, QMap<QString, QString>> PatchAddressCommentsMap;
 
     static bool PatchInfoLess(const PatchPair & a, const PatchPair & b)
     {
@@ -48,6 +58,9 @@ public:
 private:
     Ui::PatchDialog* ui;
     PatchMap mPatches;
+    PatchModuleCommentsMap mModulePatchComments;
+    PatchAddressCommentsMap mAddressPatchComments;
+    ActiveCommentType mActiveCommentType;
     PatchDialogGroupSelector* mGroupSelector;
     bool mIsWorking;
 
@@ -64,6 +77,24 @@ private:
     bool containsRelocatedBytes(const PatchInfoList & patchList);
     bool showRelocatedBytesWarning();
 
+    void showEvent(QShowEvent* event);
+    void closeEvent(QCloseEvent* event);
+
+    QListWidgetItem* getSelectedOrFirst(QListWidget* items);
+    QString getCommentKeyForPatchInfo(const DBGPATCHINFO & patchInfo);
+    bool getPatchInfoForModuleFromUi(QListWidgetItem* item, DBGPATCHINFO & patchInfo);
+    bool getPatchInfoForAddressFromUi(QListWidgetItem* item, DBGPATCHINFO & patchInfo);
+    void loadCommentForModule(const DBGPATCHINFO & patchInfo);
+    void loadCommentForAddress(const DBGPATCHINFO & patchInfo);
+    void saveCommentForModule(const DBGPATCHINFO & patchInfo, const QString & comment);
+    void saveCommentForAddress(const DBGPATCHINFO & patchInfo, const QString & comment);
+    void syncComment(QListWidgetItem* current, QListWidgetItem* previous, ActiveCommentType previousCommentType, ActiveCommentType incomingCommentType);
+    void syncComment(QListWidgetItem* item, ActiveCommentType previousCommentType, ActiveCommentType incomingCommentType);
+    bool isCommentForModule(ActiveCommentType type);
+    bool isCommentForAddress(ActiveCommentType type);
+    bool isCommentStale(ActiveCommentType type);
+    bool isCommentUninitialized(ActiveCommentType type);
+    bool isEligibleForComment(ActiveCommentType type);
 private slots:
     void dbgStateChanged(DBGSTATE state);
     void updatePatches();
@@ -71,6 +102,10 @@ private slots:
     void groupPrevious();
     void groupNext();
     void on_listModules_itemSelectionChanged();
+    void on_listModules_currentItemChanged(QListWidgetItem* current, QListWidgetItem* previous);
+    void on_listModules_itemClicked(QListWidgetItem* item);
+    void on_listPatches_currentItemChanged(QListWidgetItem* current, QListWidgetItem* previous);
+    void on_listPatches_itemClicked(QListWidgetItem* item);
     void on_listPatches_itemChanged(QListWidgetItem* item);
     void on_btnSelectAll_clicked();
     void on_btnDeselectAll_clicked();

--- a/src/gui/Src/Gui/PatchDialog.ui
+++ b/src/gui/Src/Gui/PatchDialog.ui
@@ -21,7 +21,7 @@
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="handleWidth">
       <number>1</number>

--- a/src/gui/Src/Gui/PatchDialog.ui
+++ b/src/gui/Src/Gui/PatchDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
+    <width>738</width>
     <height>451</height>
    </rect>
   </property>
@@ -21,7 +21,7 @@
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="handleWidth">
       <number>1</number>
@@ -137,6 +137,26 @@
           </widget>
          </item>
         </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="layoutComments">
+       <item>
+        <widget class="QGroupBox" name="groupComments">
+         <property name="title">
+          <string>&amp;Comments</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QTextEdit" name="txtComment">
+            <property name="sizeAdjustPolicy">
+             <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Closes #3783

This adds the ability to attach comments to patches, both for a module and for individual addresses. This is done by introducing a "Comments" text box to the current Patches dialog where a user can now type in notes/comments about what the patch changes are doing. By default this text box will be disabled, but enabled when a comment is eligible to be made (there is a module with patches present).

A few screenshots of what this ends up looking like:

<img width="1476" height="956" alt="image" src="https://github.com/user-attachments/assets/7863ab6b-9a2e-4ed7-960f-53f604e30a1f" />

<img width="1474" height="954" alt="image" src="https://github.com/user-attachments/assets/235f3c3c-fdb4-4452-9d6b-8b123b839eb8" />

In the `.1337` file, each comment starts with a `;` and is either it's own line preceding the module name in the case of a module-level comment, or is added after the patch information for an address-level comment (example below). These changes remain backwards compatible with the existing `.1337` format parsing so older versions of x64dbg can still parse `.1337` files that have comments embedded in them.

At a high-level, this feature works by keeping track of three things:
- Which comment type (if any) is active and should be saved/displayed: `mActiveCommentType`.
- A map of module name to a comment for that module: `mModulePatchComments`.
- A map of module name to another map that maps each byte patch to a comment: `mAddressPatchComments`.

The last one is a bit more complicated so I'll try to explain my reasoning here... Comments are separate from the underlying `DBGPATCHINFO` for a patch, but we need a way to tie them together and keep them in sync despite them not knowing of each other. The most convenient way I could think of to do this was to tie the text representation of the patch, i.e. `000000000011F530:65->90` to a comment. This ends up making it a lot simpler and can give a unique representation for every patch.

Take this example `.1337` file with some comments:
```
;My module-level comment
>ntdll.dll
000000000011F530:65->90
000000000011F531:48->90 ;Comment for second entry
000000000011F532:8B->90
000000000011F533:0C->90
000000000011F534:25->90 ;Comment for fifth entry
000000000011F535:60->90
000000000011F536:00->90
000000000011F537:00->90
000000000011F538:00->90
```

This would have
```
mModulePatchComments:
Key = "ntdll.dll", Value = "My module-level comment"
```
```
mAddressPatchComments:
Key = "ntdll.dll",
Value = 
    Key = "000000000011F531:48->90", Value = "Comment for second entry"
    Key = "000000000011F534:25->90", Value = "Comment for fifth entry"
```

This mapping logic works the same for imported patches from `.1337` files or patches created at runtime. This map is what is used to save/load comment information and what is referenced when doing an export.

A lot of the other UI-related code changes are mostly for handling edge cases related to the UI:
- Navigating to a new item in the Modules or Patches list should save the comment that is being navigated away from and then load the comment for the newly selected item.
- Comments should be saved/loaded on selection changes (keyboard navigation or clicking). But they also need to be saved/loaded on item clicks because a user can click already selected items in the Modules and Patches windows as well.
- Comments should persist if a user closes and re-opens the Patches window.
- If a user is entering a comment then it needs to be saved on an export or window close. This is separate from the auto-saving that's done when a user clicks to another list item.
- Restoring all patch bytes in all modules should disable the comments window because there is nothing to comment on.

Its been a while since I've done Qt development so I tried to make the UI state management changes as small as possible, but happy to hear suggestions if this can be improved. 