### PR TITLE
Use consistent phrase for trace coverage options

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -395,9 +395,9 @@ void CPUDisassembly::setupRightClickContextMenu()
     mCommonActions->build(mMenuBuilder, CommonActions::ActionComment | CommonActions::ActionBookmark);
 
     QAction* traceCoverageDisable = makeAction(DIcon("close-all-tabs"), tr("Disable"), SLOT(traceCoverageDisableSlot()));
-    QAction* traceCoverageEnableBit = makeAction(DIcon("bit"), tr("Bit"), SLOT(traceCoverageBitSlot()));
-    QAction* traceCoverageEnableByte = makeAction(DIcon("byte"), tr("Byte"), SLOT(traceCoverageByteSlot()));
-    QAction* traceCoverageEnableWord = makeAction(DIcon("word"), tr("Word"), SLOT(traceCoverageWordSlot()));
+    QAction* traceCoverageEnableBit = makeDescAction(DIcon("bit"), tr("Mark covered (yes/no)"), tr("Enable trace coverage with 1 bit (whether an instruction was executed or not)"), SLOT(traceCoverageBitSlot()));
+    QAction* traceCoverageEnableByte = makeDescAction(DIcon("byte"), tr("Count hits (up to 63)"), tr("Enable trace coverage with 1 byte per byte of code to record how many times an instruction has been executed, enable hit count up to 63 and accurate run trace assisted disassembly."), SLOT(traceCoverageByteSlot()));
+    QAction* traceCoverageEnableWord = makeDescAction(DIcon("word"), tr("Count hits (up to 16383)"), tr("Enable trace coverage with 2 bytes per byte of code to record how many times an instruction has been executed, enable hit count up to 16383 and accurate run trace assisted disassembly."), SLOT(traceCoverageWordSlot()));
     QAction* traceCoverageReset = makeAction(tr("Reset trace coverage"), SLOT(traceCoverageResetSlot()));
     QAction* traceCoverageToggleTraceRecording = makeShortcutAction(DIcon("control-record"), tr("Start trace recording"), SLOT(traceCoverageToggleTraceRecordingSlot()), "ActionToggleRunTrace");
     mMenuBuilder->addMenu(makeMenu(DIcon("trace"), tr("Trace coverage")), [ = ](QMenu * menu)

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -301,6 +301,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(ui->actionTRBit, SIGNAL(triggered()), mCpuWidget->getDisasmWidget(), SLOT(traceCoverageBitSlot()));
     connect(ui->actionTRByte, SIGNAL(triggered()), mCpuWidget->getDisasmWidget(), SLOT(traceCoverageByteSlot()));
     connect(ui->actionTRWord, SIGNAL(triggered()), mCpuWidget->getDisasmWidget(), SLOT(traceCoverageWordSlot()));
+    connect(ui->actionTRReset, SIGNAL(triggered()), mCpuWidget->getDisasmWidget(), SLOT(traceCoverageResetSlot()));
     connect(ui->actionTRNone, SIGNAL(triggered()), mCpuWidget->getDisasmWidget(), SLOT(traceCoverageDisableSlot()));
     makeCommandAction(ui->actionTRTIBT, "tibt");
     makeCommandAction(ui->actionTRTOBT, "tobt");

--- a/src/gui/Src/Gui/MainWindow.ui
+++ b/src/gui/Src/Gui/MainWindow.ui
@@ -1048,10 +1048,10 @@
      <normaloff>:/Default/icons/byte.png</normaloff>:/Default/icons/byte.png</iconset>
    </property>
    <property name="text">
-    <string>Count hits (up to 255)</string>
+    <string>Count hits (up to 63)</string>
    </property>
    <property name="statusTip">
-    <string>Enable trace coverage with 1 byte to record how many times an instruction has been executed.</string>
+    <string>Enable trace coverage with 1 byte per byte of code to record how many times an instruction has been executed, enable hit count up to 63 and accurate run trace assisted disassembly.</string>
    </property>
   </action>
   <action name="actionTRWord">
@@ -1060,10 +1060,15 @@
      <normaloff>:/Default/icons/word.png</normaloff>:/Default/icons/word.png</iconset>
    </property>
    <property name="text">
-    <string>Count hits (up to 65535)</string>
+    <string>Count hits (up to 16383)</string>
    </property>
    <property name="statusTip">
-    <string>Enable trace coverage with 1 word to record how many times an instruction has been executed.</string>
+    <string>Enable trace coverage with 2 bytes per byte of code to record how many times an instruction has been executed, enable hit count up to 16383 and accurate run trace assisted disassembly.</string>
+   </property>
+  </action>
+  <action name="actionTRReset">
+   <property name="text">
+    <string>Reset trace coverage</string>
    </property>
   </action>
   <action name="actionTRTIBT">

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -2695,59 +2695,59 @@ void RegistersView::onSIMDMode()
 #endif
 }
 
-// detect XMM/YMM/ZMM Mode
+// detect XMM/YMM/ZMM Mode. Return 2 if AVX-512 states are nonzero, 1 if AVX states are nonzero, 0 if AVX states are all zero.
 static int detectXMMMode(const ZMMREGISTER* ZmmRegisters)
 {
-    __m128 AVX_High = _mm_load_ps((const float*)&ZmmRegisters[0].Low.High);
-    __m128 AVX512_High = _mm_load_ps((const float*)&ZmmRegisters[0].High.Low);
-    AVX512_High = _mm_or_ps(AVX512_High, _mm_load_ps((float*)&ZmmRegisters[0].High.High));
+    __m128 AVX_High = _mm_loadu_ps((const float*)&ZmmRegisters[0].Low.High); // TODO: Misaligned / Alignment check
+    __m128 AVX512_High = _mm_loadu_ps((const float*)&ZmmRegisters[0].High.Low);
+    AVX512_High = _mm_or_ps(AVX512_High, _mm_loadu_ps((float*)&ZmmRegisters[0].High.High));
     for(int i = 1; i < ArchValue(8, 32); i++)
     {
-        AVX_High = _mm_or_ps(AVX_High, _mm_load_ps((const float*)&ZmmRegisters[i].Low.High));
-        AVX512_High = _mm_or_ps(AVX512_High, _mm_load_ps((const float*)&ZmmRegisters[i].High.Low));
-        AVX512_High = _mm_or_ps(AVX512_High, _mm_load_ps((const float*)&ZmmRegisters[i].High.High));
+        AVX_High = _mm_or_ps(AVX_High, _mm_loadu_ps((const float*)&ZmmRegisters[i].Low.High));
+        AVX512_High = _mm_or_ps(AVX512_High, _mm_loadu_ps((const float*)&ZmmRegisters[i].High.Low));
+        AVX512_High = _mm_or_ps(AVX512_High, _mm_loadu_ps((const float*)&ZmmRegisters[i].High.High));
     }
     quint64* AVXDetectPtr;
     AVXDetectPtr = (quint64*)&AVX512_High;
     if(AVXDetectPtr[0] | AVXDetectPtr[1])
     {
-        return 2;
+        return 2; // AVX-512 states are nonzero
     }
     else
     {
         AVXDetectPtr = (quint64*)&AVX_High;
         if(AVXDetectPtr[0] | AVXDetectPtr[1])
         {
-            return 1;
+            return 1; // AVX states are nonzero
         }
         else
         {
-            return 0;
+            return 0; // Just show SSE states
         }
     }
 }
 
 static bool detectAVX512Used(const REGISTERCONTEXT_AVX512* context)
 {
-    __m128 temp = _mm_load_ps((const float*)&context->Opmask[0]);
+    __m128 temp = _mm_loadu_ps((const float*)&context->Opmask[0]);
     quint64* ptr = (quint64*)&temp;
     for(int i = 1; i <= 3; i++)
-        temp = _mm_or_ps(temp, _mm_load_ps((const float*)&context->Opmask[i * 2]));
+        temp = _mm_or_ps(temp, _mm_loadu_ps((const float*)&context->Opmask[i * 2]));
     if(ptr[0] | ptr[1])
-        return true;
+        return true; // AVX-512 states are nonzero (opmask)
 #if defined(_WIN64) || defined(__x86_64__)
     for(int i = 16; i <= 31; i++)
     {
         __m128 temp2[2];
-        temp2[0] = _mm_load_ps((const float*)&context->ZmmRegisters[i].Low.Low);
-        temp2[1] = _mm_load_ps((const float*)&context->ZmmRegisters[i].Low.High);
-        temp2[0] = _mm_or_ps(temp2[0], _mm_load_ps((const float*)&context->ZmmRegisters[i].Low.High));
-        temp2[1] = _mm_or_ps(temp2[1], _mm_load_ps((const float*)&context->ZmmRegisters[i].High.High));
+        temp2[0] = _mm_loadu_ps((const float*)&context->ZmmRegisters[i].Low.Low);
+        temp2[1] = _mm_loadu_ps((const float*)&context->ZmmRegisters[i].Low.High);
+        temp2[0] = _mm_or_ps(temp2[0], _mm_loadu_ps((const float*)&context->ZmmRegisters[i].Low.High));
+        temp2[1] = _mm_or_ps(temp2[1], _mm_loadu_ps((const float*)&context->ZmmRegisters[i].High.High));
         temp = _mm_or_ps(temp, temp2[0]);
         temp = _mm_or_ps(temp, temp2[1]);
     }
     if(ptr[0] | ptr[1])
-        return true;
+        return true; // AVX-512 states are nonzero (ZMM16-ZMM31)
 #endif //defined(_WIN64) || defined(__x86_64__)
     return false;
 }


### PR DESCRIPTION
I’m not currently using x64dbg a lot recently, here are some quick fixes:
* Use consistent phrase for trace coverage options for both Main Window and CPU, and corrected the max hit count.
* Unexpectedly hit a SIMD alignment check exception. The alignment requirement of ZmmRegister_t must be lost, converted it to unaligned load.