### PR TITLE
Optimized patternfind

### DIFF
--- a/src/dbg/commands/cmd-searching.cpp
+++ b/src/dbg/commands/cmd-searching.cpp
@@ -31,10 +31,8 @@ static bool handlePatternArgument(const char* pattern, std::vector<PatternByte> 
             {
                 auto ch = data[i];
                 PatternByte b;
-                b.nibble[0].data = (ch >> 4) & 0xF;
-                b.nibble[0].wildcard = false;
-                b.nibble[1].data = ch & 0xF;
-                b.nibble[1].wildcard = false;
+                b.data = ch;
+                b.mask = 0xFF;
                 searchpattern.push_back(b);
             }
             return true;
@@ -55,15 +53,15 @@ static bool handlePatternArgument(const char* pattern, std::vector<PatternByte> 
         const size_t maxShortSize = 16;
         for(size_t i = 0; i < std::min(searchpattern.size(), maxShortSize); i++)
         {
-            auto doNibble = [&patternshort](const PatternByte::PatternNibble & n)
+            auto doNibble = [&patternshort](const PatternByte& n, int shift)
             {
-                if(n.wildcard)
-                    *patternshort += "?";
+                if((n.mask >> shift) & 0xf)
+                    *patternshort += "0123456789ABCDEF"[(n.data >> shift) & 0xf];
                 else
-                    *patternshort += "0123456789ABCDEF"[n.data & 0xf];
+                    *patternshort += "?";
             };
-            doNibble(searchpattern[i].nibble[0]);
-            doNibble(searchpattern[i].nibble[1]);
+            doNibble(searchpattern[i], 4);
+            doNibble(searchpattern[i], 0);
         }
         if(searchpattern.size() > maxShortSize)
             *patternshort += "...";

--- a/src/dbg/patternfind.cpp
+++ b/src/dbg/patternfind.cpp
@@ -1,6 +1,7 @@
 #include "patternfind.h"
 #include <vector>
 #include <algorithm>
+#include <memory>
 
 using namespace std;
 
@@ -53,14 +54,12 @@ bool patterntransform(const string & patterntext, vector<PatternByte> & pattern)
     PatternByte newByte = {};
     for(int i = 0, j = 0; i < len; i++)
     {
-        if(formattext[i] == '?') //wildcard
+        int shift = j ? 0 : 4;
+
+        if(formattext[i] != '?')
         {
-            newByte.nibble[j].wildcard = true; //match anything
-        }
-        else //hex
-        {
-            newByte.nibble[j].wildcard = false;
-            newByte.nibble[j].data = hexchtoint(formattext[i]) & 0xF;
+            newByte.data |= (hexchtoint(formattext[i]) & 0xF) << shift;
+            newByte.mask |= 0xf << shift;
         }
 
         j++;
@@ -68,37 +67,19 @@ bool patterntransform(const string & patterntext, vector<PatternByte> & pattern)
         {
             j = 0;
             pattern.push_back(newByte);
+            newByte = {};
         }
     }
 
     //reject wildcard only patterns
     bool allWildcard = std::all_of(pattern.begin(), pattern.end(), [](const PatternByte & patternByte)
     {
-        return patternByte.nibble[0].wildcard & patternByte.nibble[1].wildcard;
+        return patternByte.mask == 0x00;
     });
     if(allWildcard)
         return false;
 
     return true;
-}
-
-static inline bool patternmatchbyte(unsigned char byte, const PatternByte & pbyte)
-{
-    int matched = 0;
-
-    unsigned char n1 = (byte >> 4) & 0xF;
-    if(pbyte.nibble[0].wildcard)
-        matched++;
-    else if(pbyte.nibble[0].data == n1)
-        matched++;
-
-    unsigned char n2 = byte & 0xF;
-    if(pbyte.nibble[1].wildcard)
-        matched++;
-    else if(pbyte.nibble[1].data == n2)
-        matched++;
-
-    return (matched == 2);
 }
 
 size_t patternfind(const unsigned char* data, size_t datasize, const char* pattern, int* patternsize)
@@ -110,36 +91,9 @@ size_t patternfind(const unsigned char* data, size_t datasize, const char* patte
     return patternfind(data, datasize, searchpattern);
 }
 
-size_t patternfind(const unsigned char* data, size_t datasize, unsigned char* pattern, size_t patternsize)
-{
-    if(patternsize > datasize)
-        patternsize = datasize;
-    for(size_t i = 0, pos = 0; i < datasize; i++)
-    {
-        if(data[i] == pattern[pos])
-        {
-            pos++;
-            if(pos == patternsize)
-                return i - patternsize + 1;
-        }
-        else if(pos > 0)
-        {
-            i -= pos;
-            pos = 0; //reset current pattern position
-        }
-    }
-    return -1;
-}
-
 static inline void patternwritebyte(unsigned char* byte, const PatternByte & pbyte)
 {
-    unsigned char n1 = (*byte >> 4) & 0xF;
-    unsigned char n2 = *byte & 0xF;
-    if(!pbyte.nibble[0].wildcard)
-        n1 = pbyte.nibble[0].data;
-    if(!pbyte.nibble[1].wildcard)
-        n2 = pbyte.nibble[1].data;
-    *byte = ((n1 << 4) & 0xF0) | (n2 & 0xF);
+    *byte = pbyte.data | (*byte & ~pbyte.mask);
 }
 
 void patternwrite(unsigned char* data, size_t datasize, const char* pattern)
@@ -164,22 +118,87 @@ bool patternsnr(unsigned char* data, size_t datasize, const char* searchpattern,
     return true;
 }
 
-size_t patternfind(const unsigned char* data, size_t datasize, const std::vector<PatternByte> & pattern)
+struct PatternNeedle
+{
+    unsigned char data;
+    unsigned char mask;
+    size_t offset;
+};
+
+size_t patternfind(const unsigned char* data, size_t datasize, const std::vector<PatternByte>& pattern)
 {
     size_t searchpatternsize = pattern.size();
-    for(size_t i = 0, pos = 0; i < datasize; i++) //search for the pattern
+
+    if(datasize < searchpatternsize)
+        return -1;
+
+    std::unique_ptr<PatternNeedle[]> const needles(new PatternNeedle[searchpatternsize]);
+    size_t n_needles = 0;
+
+    // Collect all of the literal bytes.
+    // The less common bytes tend to be at the end, so iterate back-to-front.
+    for(size_t i = searchpatternsize; i--;)
     {
-        if(patternmatchbyte(data[i], pattern.at(pos))) //check if our pattern matches the current byte
-        {
-            pos++;
-            if(pos == searchpatternsize) //everything matched
-                return i - searchpatternsize + 1;
-        }
-        else if(pos > 0) //fix by Computer_Angel
-        {
-            i -= pos;
-            pos = 0; //reset current pattern position
-        }
+        if(pattern[i].mask == 0xFF)
+            needles[n_needles++] = { pattern[i].data, pattern[i].mask, i };
     }
+
+    size_t literals = n_needles;
+
+    // Don't forget the partially masked bytes.
+    for(size_t i = searchpatternsize; i--;)
+    {
+        if(pattern[i].mask != 0x00 && pattern[i].mask != 0xFF)
+            needles[n_needles++] = { pattern[i].data, pattern[i].mask, i };
+    }
+
+    if(n_needles == 0)
+        return -1;
+
+    const unsigned char* here = data;
+    const unsigned char* end = &data[datasize - (searchpatternsize - 1)];
+
+    do
+    {
+        if(literals)
+        {
+            PatternNeedle needle = needles[0];
+
+            // On Windows, memchr is not as fast as it could be, so MSVC's std::find uses its own SIMD implementation.
+            here = std::find(here + needle.offset, end + needle.offset, needle.data) - needle.offset;
+            if(here == end)
+                break;
+
+            for(size_t i = 1; i < literals; ++i)
+            {
+                needle = needles[i];
+
+                if(here[needle.offset] != needle.data)
+                {
+                    // Swap this mismatched needle with the previously matched one.
+                    // By constantly re-adjusting the order of the needles, the least common one should be moved to the front,
+                    // maximizing the time spent inside std::find, and minimizing the time spent checking the rest of the bytes.
+                    needles[i] = needles[i - 1];
+                    needles[i - 1] = needle;
+                    goto skip;
+                }
+            }
+        }
+
+        for(size_t i = literals; i < n_needles; ++i)
+        {
+            PatternNeedle needle = needles[i];
+
+            if((here[needle.offset] & needle.mask) != needle.data)
+                goto skip;
+        }
+
+        return here - data;
+
+skip:
+        ++here;
+    }
+    while(here != end);
+
     return -1;
 }

--- a/src/dbg/patternfind.h
+++ b/src/dbg/patternfind.h
@@ -6,11 +6,8 @@
 
 struct PatternByte
 {
-    struct PatternNibble
-    {
-        unsigned char data;
-        bool wildcard;
-    } nibble[2];
+    unsigned char data;
+    unsigned char mask;
 };
 
 //returns: offset to data when found, -1 when not found
@@ -19,14 +16,6 @@ size_t patternfind(
     size_t datasize, //size of data
     const char* pattern, //pattern to search
     int* patternsize = 0 //outputs the number of bytes the pattern is
-);
-
-//returns: offset to data when found, -1 when not found
-size_t patternfind(
-    const unsigned char* data, //data
-    size_t datasize, //size of data
-    unsigned char* pattern, //bytes to search
-    size_t patternsize //size of bytes to search
 );
 
 //returns: nothing


### PR DESCRIPTION
The patternfind algorithm has been replaced with a SIMD-accelerated version (using `std::find`), which dynamically adjusts the order in which the bytes are matched in an attempt to maximize the time spent in `std::find`.

This has been tested in pattern-bench (https://github.com/0x1F9F1/pattern-bench/commit/71780c2e58a5158e92021fbbd8da7713dc39b52b) and generally provides speeds within 2x of `mem::simd_scanner` (which uses the same technique, but with dual anchors and manual SIMD). The `patternfind` function has a slight disadvantange since it can't save any state between scans, but in general it fares quite well.

```
Aggregate Combined Leaderboard (14 runs)

mem::simd_scanner                | geo  0.158 cpb | mean  0.238 cpb |  1.00x | 0 / 14 runs failed | 0 failed tests
dynamic_freq_scanner             | geo  0.207 cpb | mean  0.293 cpb |  1.31x | 0 / 14 runs failed | 0 failed tests
x64dbg                           | geo  0.217 cpb | mean  0.301 cpb |  1.38x | 0 / 14 runs failed | 0 failed tests
qis                              | geo  0.557 cpb | mean  1.518 cpb |  3.53x | 0 / 14 runs failed | 0 failed tests
Can (AVX2)                       | geo  1.148 cpb | mean  3.434 cpb |  7.27x | 0 / 14 runs failed | 0 failed tests
libhat                           | geo  1.760 cpb | mean  4.148 cpb | 11.15x | 0 / 14 runs failed | 0 failed tests
```

Closes issue #2689 