### PR TITLE
fix "Running" label font color for dark theme

### DIFF
--- a/bin/themes/Dark/style.css
+++ b/bin/themes/Dark/style.css
@@ -1051,7 +1051,7 @@ DebugStatusLabel[state="paused"] {
 }
 
 DebugStatusLabel[state="running"] {
-    color: #000000;
+    color: #f0f0f0;
     /*background-color: #c0c0c0;*/
 }
 


### PR DESCRIPTION
before:
<img width="278" height="88" alt="image" src="https://github.com/user-attachments/assets/d171fd7e-f9a6-4fae-b1cd-00483c245513" />

changed the dark color to #f0f0f0

after:
<img width="156" height="50" alt="image" src="https://github.com/user-attachments/assets/e5f9aab4-cb21-454c-9814-1b3d6869d8c7" />

closes https://github.com/x64dbg/x64dbg/issues/3840