### PR TITLE
Add module rva address display mode in CPU

### DIFF
--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -2064,9 +2064,6 @@ void Disassembly::disassembleAt(duint va, bool history, duint newTableOffset)
     mMemPage->setAttributes(base, size);
     mDisasm->getEncodeMap()->setMemoryRegion(base);
 
-    if(mRvaDisplayMode != RvaDisplayDisabled && mMemPage->getBase() != mRvaDisplayPageBase)
-        mRvaDisplayMode = RvaDisplayDisabled;
-
     setRowCount(size);
 
     // Selects disassembled instruction

--- a/src/gui/Src/BasicView/Disassembly.cpp
+++ b/src/gui/Src/BasicView/Disassembly.cpp
@@ -2064,8 +2064,8 @@ void Disassembly::disassembleAt(duint va, bool history, duint newTableOffset)
     mMemPage->setAttributes(base, size);
     mDisasm->getEncodeMap()->setMemoryRegion(base);
 
-    if(mRvaDisplayEnabled && mMemPage->getBase() != mRvaDisplayPageBase)
-        mRvaDisplayEnabled = false;
+    if(mRvaDisplayMode != RvaDisplayDisabled && mMemPage->getBase() != mRvaDisplayPageBase)
+        mRvaDisplayMode = RvaDisplayDisabled;
 
     setRowCount(size);
 
@@ -2266,7 +2266,7 @@ bool Disassembly::historyHasNext() const
 QString Disassembly::getAddrText(duint cur_addr, QString & label, bool getLabel) const
 {
     QString addrText = "";
-    if(mRvaDisplayEnabled) //RVA display
+    if(mRvaDisplayMode == RvaDisplayRelative)
     {
         dsint rva = cur_addr - mRvaDisplayBase;
         if(rva == 0)
@@ -2290,8 +2290,21 @@ QString Disassembly::getAddrText(duint cur_addr, QString & label, bool getLabel)
             else
                 addrText = "$-" + QString("%1").arg(-rva, -7, 16, QChar(' ')).toUpper();
         }
+        addrText += ToPtrString(cur_addr);
     }
-    addrText += ToPtrString(cur_addr);
+    else if(mRvaDisplayMode == RvaDisplayModule)
+    {
+        char module[MAX_MODULE_SIZE] = "";
+        duint modBase = DbgFunctions()->ModBaseFromAddr(cur_addr);
+        if(modBase && DbgGetModuleAt(cur_addr, module))
+            addrText = QString(module) + ":$" + QString("%1").arg(cur_addr - modBase, 0, 16).toUpper();
+        else
+            addrText = "?:$" + QString("%1").arg(cur_addr - mMemPage->getBase(), 0, 16).toUpper();
+    }
+    else
+    {
+        addrText = ToPtrString(cur_addr);
+    }
     char label_[MAX_LABEL_SIZE] = "";
     if(getLabel && DbgGetLabelAt(cur_addr, SEG_DEFAULT, label_)) //has label
     {

--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -248,7 +248,13 @@ protected:
     QPen mConditionalFalsePen;
 
     // Misc
-    bool mRvaDisplayEnabled;
+    enum RvaDisplayMode
+    {
+        RvaDisplayDisabled = 0,
+        RvaDisplayRelative,
+        RvaDisplayModule,
+    };
+    RvaDisplayMode mRvaDisplayMode = RvaDisplayDisabled;
     duint mRvaDisplayBase;
     dsint mRvaDisplayPageBase;
     bool mHighlightingMode;

--- a/src/gui/Src/BasicView/Disassembly.h
+++ b/src/gui/Src/BasicView/Disassembly.h
@@ -256,7 +256,6 @@ protected:
     };
     RvaDisplayMode mRvaDisplayMode = RvaDisplayDisabled;
     duint mRvaDisplayBase;
-    dsint mRvaDisplayPageBase;
     bool mHighlightingMode;
     MemoryPage* mMemPage;
     QZydis* mDisasm;

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -92,7 +92,6 @@ void CPUDisassembly::mouseDoubleClickEvent(QMouseEvent* event)
         {
             mRvaDisplayMode = RvaDisplayRelative;
             mRvaDisplayBase = mSelectedVa;
-            mRvaDisplayPageBase = getBase();
         }
         else if(mRvaDisplayMode == RvaDisplayRelative)
             mRvaDisplayMode = RvaDisplayModule;

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -87,14 +87,17 @@ void CPUDisassembly::mouseDoubleClickEvent(QMouseEvent* event)
     case ColAddress: //address
     {
         dsint mSelectedVa = rvaToVa(getInitialSelection());
-        if(mRvaDisplayEnabled && mSelectedVa == mRvaDisplayBase)
-            mRvaDisplayEnabled = false;
-        else
+        // Cycle: Disabled -> Relative -> Module -> Disabled
+        if(mRvaDisplayMode == RvaDisplayDisabled || mSelectedVa != mRvaDisplayBase)
         {
-            mRvaDisplayEnabled = true;
+            mRvaDisplayMode = RvaDisplayRelative;
             mRvaDisplayBase = mSelectedVa;
             mRvaDisplayPageBase = getBase();
         }
+        else if(mRvaDisplayMode == RvaDisplayRelative)
+            mRvaDisplayMode = RvaDisplayModule;
+        else
+            mRvaDisplayMode = RvaDisplayDisabled;
         reloadData();
     }
     break;


### PR DESCRIPTION
Clicking two times on the address column now uses a module rva mode:
<img width="726" height="106" alt="image" src="https://github.com/user-attachments/assets/f369de7e-f4df-42be-b84d-b8d174deab0b" />

For addresses that have no module associated it will display a question mark:
<img width="697" height="65" alt="image" src="https://github.com/user-attachments/assets/57e8e303-43c1-4eba-8689-f4053b3016c4" />

For me this simplifies working with binaries that have dynamic image base enabled, sometimes I want to copy a couple rows of the disassembly to keep track of things and if it holds the absolute address it was rather annoying to find location again with a new base address, also simplifies documenting disassembly in reports, typically don't want to use absolute address on those.

It also preserves the mode now rather than resetting it when navigating to another module or memory page, the relative mode can now be used to quickly compute the relative jump address with this, enable relative at where you jump, navigate to where you want the jump head to, and thats your relative address.