### PR TITLE
Fix sidebar breakpoint bullet color priority when HW BP is active

### DIFF
--- a/src/gui/Src/Gui/CPUSideBar.cpp
+++ b/src/gui/Src/Gui/CPUSideBar.cpp
@@ -222,7 +222,13 @@ void CPUSideBar::paintEvent(QPaintEvent* event)
         duint instrVAEnd = instrVA + instr.length;
 
         // draw bullet
-        drawBullets(&painter, line, DbgGetBpxTypeAt(instrVA) != bp_none, DbgIsBpDisabled(instrVA), DbgGetBookmarkAt(instrVA));
+        // If a disabled software breakpoint and an enabled hardware breakpoint
+        // exist on the same line, keep the "enabled breakpoint" bullet color.
+        const auto bpType = DbgGetBpxTypeAt(instrVA);
+        const bool hasBreakpoint = bpType != bp_none;
+        const bool hasEnabledHardwareBp = Breakpoints::BPState(bp_hardware, instrVA) == bp_enabled;
+        const bool showDisabledBreakpointColor = hasBreakpoint && DbgIsBpDisabled(instrVA) && !hasEnabledHardwareBp;
+        drawBullets(&painter, line, hasBreakpoint, showDisabledBreakpointColor, DbgGetBookmarkAt(instrVA));
 
         if(isJump(line)) //handle jumps
         {


### PR DESCRIPTION
## Summary
- adjust CPU sidebar bullet logic when multiple breakpoint types are present on one address
- keep the bullet in enabled-breakpoint color if a hardware breakpoint is enabled
- avoid showing disabled-breakpoint color just because a disabled software breakpoint also exists

## Why
This fixes the case from #1914:
when both breakpoints are on the same line and only the software one is disabled, the UI currently shows the disabled color even though execution still breaks due to active hardware breakpoint.

## Scope
- UI-only behavior change in `CPUSideBar` bullet state calculation
- no debugger backend behavior change
