### PR TITLE
feat: assemble multiple instructions in the *Assemble* window

### DIFF
--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -137,12 +137,14 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
                 // Return false if an unrelated error has occured
                 return false;
             }
-            
+
             if(!nextInstruction)
             {
                 break;
             }
+         
             currentInstruction = nextInstruction + 1;
+            destIndex += destSize;
         }
     }
     else

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -106,8 +106,8 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
     
     if (split)
     {
-        char* currentInstruction = instruction;
-        char* nextInstruction;
+        const char* currentInstruction = instruction;
+        const char* nextInstruction;
         char tempInstruction[XEDPARSE_MAXBUFSIZE+1];
         
         int destIndex = 0;

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -98,21 +98,65 @@ static bool isInstructionPointingToExMemory(duint addr, const unsigned char* des
     return !dbgisdepenabled();
 }
 
-bool assembleat(duint addr, const char* instruction, int* size, char* error, bool fillnop)
+bool assembleat(duint addr, const char* instruction, int* size, char* error, bool fillnop, bool split)
 {
     int destSize = 0;
     Memory<unsigned char*> dest(16 * sizeof(unsigned char), "AssembleBuffer");
     unsigned char* newbuffer = nullptr;
-    if(!assemble(addr, dest(), 16, &destSize, instruction, error))
+    
+    if (split)
     {
-        if(destSize > 16)
+        char* currentInstruction = instruction;
+        char* nextInstruction;
+        char tempInstruction[XEDPARSE_MAXBUFSIZE+1];
+        
+        int destIndex = 0;
+        while(true)
         {
-            dest.realloc(destSize);
-            if(!assemble(addr, dest(), destSize, &destSize, instruction, error))
+            nextInstruction = strchr(currentInstruction, ';');
+            if(nextInstruction)
+            {
+                int instructionLength = nextInstruction - currentInstruction;
+                memcpy(tempInstruction, currentInstruction, instructionLength);
+                tempInstruction[instructionLength] = '\0';
+            }
+            else
+            {
+                strcpy_s(tempInstruction, currentInstruction);
+            }
+            
+            while(!assemble(addr + destIndex, dest() + destIndex, dest.size() - destIndex, &destSize, tempInstruction, error))
+            {
+                // Extend the memory buffer if the new instruction does not fit
+                if(destSize > dest.size() - destIndex)
+                    dest.realloc(dest.size() + 16);
+                    continue;
+
+                // Return false if an unrelated error has occured
+                return false;
+            }
+            
+            origLen += disasmgetsize(addr + destIndex);
+            if(!nextInstruction) {
+                break;
+            }
+            currentInstruction = nextInstruction + 1;
+        }
+    }
+    else {
+        if(!assemble(addr, dest(), 16, &destSize, instruction, error))
+        {
+            if(destSize > 16)
+            {
+                dest.realloc(destSize);
+                if(!assemble(addr, dest(), destSize, &destSize, instruction, error))
+                    return false;
+            }
+            
+            // Return false if an unrelated error has occured
+            else
                 return false;
         }
-        else
-            return false;
     }
 
     //calculate the number of NOPs to insert

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -104,7 +104,7 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
     Memory<unsigned char*> dest(16 * sizeof(unsigned char), "AssembleBuffer");
     unsigned char* newbuffer = nullptr;
     
-    if (split)
+    if(split)
     {
         const char* currentInstruction = instruction;
         const char* nextInstruction;
@@ -137,7 +137,8 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
             }
             
             origLen += disasmgetsize(addr + destIndex);
-            if(!nextInstruction) {
+            if(!nextInstruction)
+            {
                 break;
             }
             currentInstruction = nextInstruction + 1;

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -136,7 +136,6 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
                 return false;
             }
             
-            origLen += disasmgetsize(addr + destIndex);
             if(!nextInstruction)
             {
                 break;

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -143,7 +143,8 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
             currentInstruction = nextInstruction + 1;
         }
     }
-    else {
+    else
+    {
         if(!assemble(addr, dest(), 16, &destSize, instruction, error))
         {
             if(destSize > 16)

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -76,7 +76,7 @@ bool assemble(duint addr, unsigned char* dest, int destsize, int* size, const ch
 
 bool assemble(duint addr, unsigned char* dest, int* size, const char* instruction, char* error)
 {
-    return assemble(addr, dest, 16, size, instruction, error);
+    return assemble(addr, dest, XEDPARSE_MAXASMSIZE, size, instruction, error);
 }
 
 static bool isInstructionPointingToExMemory(duint addr, const unsigned char* dest)

--- a/src/dbg/assemble.cpp
+++ b/src/dbg/assemble.cpp
@@ -129,8 +129,10 @@ bool assembleat(duint addr, const char* instruction, int* size, char* error, boo
             {
                 // Extend the memory buffer if the new instruction does not fit
                 if(destSize > dest.size() - destIndex)
+                {
                     dest.realloc(dest.size() + 16);
                     continue;
+                }
 
                 // Return false if an unrelated error has occured
                 return false;

--- a/src/dbg/assemble.h
+++ b/src/dbg/assemble.h
@@ -13,6 +13,6 @@ enum class AssemblerEngine
 extern AssemblerEngine assemblerEngine;
 
 bool assemble(duint addr, unsigned char* dest, int* size, const char* instruction, char* error);
-bool assembleat(duint addr, const char* instruction, int* size, char* error, bool fillnop);
+bool assembleat(duint addr, const char* instruction, int* size, char* error, bool fillnop, bool split = false);
 
 #endif // _ASSEMBLE_H

--- a/src/dbg/assemble.h
+++ b/src/dbg/assemble.h
@@ -13,6 +13,6 @@ enum class AssemblerEngine
 extern AssemblerEngine assemblerEngine;
 
 bool assemble(duint addr, unsigned char* dest, int* size, const char* instruction, char* error);
-bool assembleat(duint addr, const char* instruction, int* size, char* error, bool fillnop, bool split = false);
+bool assembleat(duint addr, const char* instruction, int* size, char* error, bool fillnop, bool split = true);
 
 #endif // _ASSEMBLE_H

--- a/src/gui/Src/Gui/AssembleDialog.cpp
+++ b/src/gui/Src/Gui/AssembleDialog.cpp
@@ -145,7 +145,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         // SizeDifference < 0 <=> Typed instruction is smaller
         else if(sizeDifference < 0)
         {
-            QString message = tr("<font color='#00cc00'><b>Instruction smaller by %1 %2...</b></font>")
+            QString message = tr("<font color='#00cc00'><b>Instruction(s) smaller by %1 %2...</b></font>")
                               .arg(-sizeDifference)
                               .arg(sizeDifference == -1 ? tr("byte") : tr("bytes")).append(tr("<br>Bytes: %1").arg(data));
 
@@ -155,7 +155,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
         // SizeDifference == 0 <=> Both instruction have same size
         else
         {
-            QString message = tr("<font color='#00cc00'><b>Instruction is same size!</b></font>").append(tr("<br>Bytes: %1").arg(data));
+            QString message = tr("<font color='#00cc00'><b>Instruction(s) unchanged in size!</b></font>").append(tr("<br>Bytes: %1").arg(data));
 
             setKeepSizeLabel(message);
             setOkButtonEnabled(true);
@@ -163,7 +163,7 @@ void AssembleDialog::instructionChangedSlot(dsint sizeDifference, QString data)
     }
     else
     {
-        QString message = tr("<font color='#00cc00'><b>Instruction encoded successfully!</b></font>").append(tr("<br>Bytes: %1").arg(data));
+        QString message = tr("<font color='#00cc00'><b>Instruction(s) encoded successfully!</b></font>").append(tr("<br>Bytes: %1").arg(data));
 
         setKeepSizeLabel(message);
         setOkButtonEnabled(true);


### PR DESCRIPTION
## Summary

Should be able to use the *Assemble* GUI window to assemble multiple sequential instructions separated by semicolons.

## Why?

I write patching guides which require the user to input instructions one at a time.  Adding support for parsing multiple instructions at a time will save poeple's time making sure that their lines are in order.

## Tests?

None as of 2026-05-14 08:41 UTC.