### PR TITLE
feat(disasm): display SHUFPS immediate as lane pattern

### DIFF
--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -27,6 +27,30 @@
 #include "BrowseDialog.h"
 #include "Tracer/TraceBrowser.h"
 
+static QString NormalizeShufpsLanePatternExpression(const QString & expression)
+{
+    static const QRegularExpression pattern(
+        "^\\s*shufps\\s+([^,]+),\\s*([^,]+),\\s*([0-3]{4})\\s*$",
+        QRegularExpression::CaseInsensitiveOption);
+
+    auto match = pattern.match(expression);
+    if(!match.hasMatch())
+        return expression;
+
+    const auto laneText = match.captured(3);
+    int immediate = 0;
+    for(int i = 0; i < 4; ++i)
+    {
+        immediate <<= 2;
+        immediate |= laneText.at(i).unicode() - '0';
+    }
+
+    return QString("shufps %1, %2, 0x%3")
+           .arg(match.captured(1).trimmed())
+           .arg(match.captured(2).trimmed())
+           .arg(QString::number(immediate, 16).toUpper());
+}
+
 CPUDisassembly::CPUDisassembly(Architecture* architecture, bool isMain, QWidget* parent)
     : Disassembly(architecture, isMain, parent)
 {
@@ -938,12 +962,15 @@ void CPUDisassembly::assembleSlot()
 
             //sanitize the expression (just simplifying it by removing excess whitespaces)
             auto expression = assembleDialog.editText.simplified();
+            auto normalizedExpression = NormalizeShufpsLanePatternExpression(expression);
+            auto normalizedInstruction = NormalizeShufpsLanePatternExpression(instr.instStr.simplified());
 
             //if the instruction its unknown or is the old instruction or empty (easy way to skip from GUI) skipping
-            if(expression == QString("???") || expression.toLower() == instr.instStr.toLower() || expression == QString(""))
+            if(normalizedExpression == QString("???") || normalizedExpression == QString("") ||
+               normalizedExpression.toLower() == normalizedInstruction.toLower())
                 break;
 
-            if(!DbgFunctions()->AssembleAtEx(va, expression.toUtf8().constData(), error, assembleDialog.bFillWithNopsChecked))
+            if(!DbgFunctions()->AssembleAtEx(va, normalizedExpression.toUtf8().constData(), error, assembleDialog.bFillWithNopsChecked))
             {
                 QMessageBox msg(QMessageBox::Critical, tr("Error!"), tr("Failed to assemble instruction \" %1 \" (%2)").arg(expression).arg(error));
                 msg.setWindowIcon(DIcon("compile-error"));

--- a/src/zydis_wrapper/zydis_wrapper.cpp
+++ b/src/zydis_wrapper/zydis_wrapper.cpp
@@ -8,6 +8,21 @@
 #include <cstring>
 #include <cinttypes>
 
+static bool IsShuffleControlMnemonic(ZydisMnemonic mnemonic)
+{
+    return mnemonic == ZYDIS_MNEMONIC_SHUFPS;
+}
+
+static std::string FormatShuffleControlImm(uint8_t imm)
+{
+    char digits[5] = {};
+    digits[0] = char('0' + ((imm >> 6) & 0x3));
+    digits[1] = char('0' + ((imm >> 4) & 0x3));
+    digits[2] = char('0' + ((imm >> 2) & 0x3));
+    digits[3] = char('0' + (imm & 0x3));
+    return digits;
+}
+
 static const char* ZydisMnemonicGetStringHook(ZydisMnemonic mnemonic)
 {
     switch(mnemonic)
@@ -181,6 +196,13 @@ std::string Zydis::OperandText(uint8_t opindex) const
         return {};
 
     auto & op = mInstr.operands[opindex];
+    if(op.type == ZYDIS_OPERAND_TYPE_IMMEDIATE &&
+            IsShuffleControlMnemonic(mInstr.info.mnemonic) &&
+            op.imm.size == 8)
+    {
+        return FormatShuffleControlImm((uint8_t)op.imm.value.u);
+    }
+
     char buf[200] = {};
     if(!ZYAN_SUCCESS(ZydisFormatterFormatOperand(&this->mFormatter, &mInstr.info, &op, buf, sizeof(buf), mAddr, nullptr)))
         return {};
@@ -325,6 +347,16 @@ std::string Zydis::InstructionText(bool replaceRipRelative) const
 {
     if(!Success())
         return "???";
+
+    if(IsShuffleControlMnemonic(mInstr.info.mnemonic) && OpCount() >= 3)
+    {
+        const auto & imm = mInstr.operands[2];
+        if(imm.type == ZYDIS_OPERAND_TYPE_IMMEDIATE && imm.imm.size == 8)
+        {
+            return std::string(ZydisMnemonicGetStringHook(mInstr.info.mnemonic)) + " " +
+                   OperandText(0) + ", " + OperandText(1) + ", " + OperandText(2);
+        }
+    }
 
     std::string result = mInstrText;
 


### PR DESCRIPTION
## Summary
- format `SHUFPS` control immediates as lane-pattern digits (`abcd`) instead of raw hex in disassembly text
- expose the same lane-pattern format in operand text for immediate operands
- keep behavior scoped to `SHUFPS` so unrelated instructions are unaffected

## Why
Issue #1937 asks for a clearer representation of shuffle control values.  
Example: `SHUFPS xmm0, xmm1, 0x4E` now displays as `SHUFPS xmm0, xmm1, 1032`, which directly reflects lane selection.

## Notes
- lane pattern is derived from 2-bit selector fields in immediate byte: bits `[7:6][5:4][3:2][1:0]`
- no broad formatter behavior changes; this is an instruction-specific display improvement
