### PR TITLE
fix(cpu): correct mixed breakpoint bullet color state

### DIFF
--- a/src/gui/Src/Gui/CPUSideBar.cpp
+++ b/src/gui/Src/Gui/CPUSideBar.cpp
@@ -5,6 +5,17 @@
 #include "CachedFontMetrics.h"
 #include <QToolTip>
 
+static bool hasEnabledBreakpointAt(duint va, BPXTYPE bpxtype)
+{
+    const BPXTYPE candidates[] = {bp_normal, bp_hardware, bp_memory, bp_dll, bp_exception};
+    for(const auto type : candidates)
+    {
+        if((bpxtype & type) != 0 && Breakpoints::BPState(type, va) == bp_enabled)
+            return true;
+    }
+    return false;
+}
+
 CPUSideBar::CPUSideBar(CPUDisassembly* disassembly, QWidget* parent)
     : QAbstractScrollArea(parent)
 {
@@ -221,8 +232,14 @@ void CPUSideBar::paintEvent(QPaintEvent* event)
         duint instrVA = instr.rva + mDisassembly->getBase();
         duint instrVAEnd = instrVA + instr.length;
 
+        const auto bpxtype = DbgGetBpxTypeAt(instrVA);
+        const bool hasBreakpoint = bpxtype != bp_none;
+        bool isBreakpointDisabled = hasBreakpoint && DbgIsBpDisabled(instrVA);
+        if(isBreakpointDisabled && hasEnabledBreakpointAt(instrVA, bpxtype))
+            isBreakpointDisabled = false;
+
         // draw bullet
-        drawBullets(&painter, line, DbgGetBpxTypeAt(instrVA) != bp_none, DbgIsBpDisabled(instrVA), DbgGetBookmarkAt(instrVA));
+        drawBullets(&painter, line, hasBreakpoint, isBreakpointDisabled, DbgGetBookmarkAt(instrVA));
 
         if(isJump(line)) //handle jumps
         {


### PR DESCRIPTION
## Summary
- fix CPU sidebar breakpoint bullet color resolution when multiple breakpoint types exist on the same address
- compute disabled bullet state using effective enabled status across breakpoint types
- keep disabled (green) bullet only when all present breakpoints are disabled

## Why
Issue #1914 reports the breakpoint indicator showing green when a disabled software breakpoint coexists with an enabled hardware breakpoint on the same line.  
In that case, the line should still be shown as active breakpoint state (red), not disabled.

## Implementation
- in `CPUSideBar`, derive `bpxtype` once per instruction row
- determine `isBreakpointDisabled` from `DbgIsBpDisabled(addr)` but override it when any breakpoint type at the address is still enabled (`Breakpoints::BPState(...)`)
- use that effective disabled value when drawing bullets
