### PR TITLE
Move toggle FPU button into menu

### DIFF
--- a/src/gui/Src/Gui/CPUWidget.cpp
+++ b/src/gui/Src/Gui/CPUWidget.cpp
@@ -69,14 +69,9 @@ CPUWidget::CPUWidget(Architecture* architecture, QWidget* parent)
     mGeneralRegs->setFrameShape(QFrame::NoFrame);
     mGeneralRegs->ShowFPU(true);
 
-    QPushButton* button_changeview = new QPushButton("", this);
-    connect(button_changeview, SIGNAL(clicked()), mGeneralRegs, SLOT(onChangeFPUViewAction()));
-    mGeneralRegs->SetChangeButton(button_changeview);
-
     ui->mTopRightVSplitter->setCollapsible(1, true); //allow collapsing of the ArgumentWidget
     connect(ui->mTopRightVSplitter, SIGNAL(splitterMoved(int, int)), this, SLOT(splitterMoved(int, int)));
 
-    ui->mTopRightUpperFrameLayout->addWidget(button_changeview);
     ui->mTopRightUpperFrameLayout->addWidget(mGeneralRegs);
     ui->mTopHSplitter->setCollapsible(1, true); // allow collapsing of the RegisterView
 

--- a/src/gui/Src/Gui/RegistersView.cpp
+++ b/src/gui/Src/Gui/RegistersView.cpp
@@ -77,12 +77,6 @@ int RegistersView::getEstimateHeight()
     return mRowsNeeded * mRowHeight;
 }
 
-void RegistersView::SetChangeButton(QPushButton* push_button)
-{
-    mChangeViewButton = push_button;
-    fontsUpdatedSlot();
-}
-
 void RegistersView::InitMappings()
 {
     // create mapping from internal id to name
@@ -994,7 +988,6 @@ QAction* RegistersView::setupAction(const QString & text)
 RegistersView::RegistersView(QWidget* parent) : QScrollArea(parent), mVScrollOffset(0)
 {
     setAccessibleName(tr("Registers"));
-    mChangeViewButton = NULL;
     mShowFpu = false;
     mSelected = UNKNOWN;
     mFpuMode = 0;
@@ -1583,8 +1576,6 @@ void RegistersView::fontsUpdatedSlot()
 {
     auto font = ConfigFont("Registers");
     setFont(font);
-    if(mChangeViewButton)
-        mChangeViewButton->setFont(font);
     //update metrics information
     int rowHeight = QFontMetrics(this->font()).height();
     rowHeight = (rowHeight * 105) / 100;
@@ -1938,14 +1929,6 @@ void RegistersView::updateCanvasSize()
 
 void RegistersView::paintRegisters(QPainter* p, const QRect & clip)
 {
-    if(mChangeViewButton != NULL)
-    {
-        if(mShowFpu)
-            mChangeViewButton->setText(tr("Hide FPU"));
-        else
-            mChangeViewButton->setText(tr("Show FPU"));
-    }
-
     p->setClipRect(clip);
     p->setFont(font());
     p->fillRect(mCanvas ? mCanvas->rect() : clip, QBrush(ConfigColor("RegistersBackgroundColor")));

--- a/src/gui/Src/Gui/RegistersView.h
+++ b/src/gui/Src/Gui/RegistersView.h
@@ -143,7 +143,6 @@ public slots:
     void reload();
     void ShowFPU(bool set_showfpu);
     void onChangeFPUViewAction();
-    void SetChangeButton(QPushButton* push_button);
 
 signals:
     void refresh();
@@ -202,7 +201,6 @@ protected slots:
     void onCopyAllAction();
 protected:
     bool isActive;
-    QPushButton* mChangeViewButton;
     bool mShowFpu;
     int mVScrollOffset;
     int mRowsNeeded;

--- a/src/gui/Src/Tracer/TraceRegisters.cpp
+++ b/src/gui/Src/Tracer/TraceRegisters.cpp
@@ -131,6 +131,7 @@ void TraceRegisters::displayCustomContextMenuSlot(QPoint pos)
             menu.addAction(mDisplayx87rX);
         if(mFpuMode != 2)
             menu.addAction(mDisplayMMX);
+        menu.exec(this->mapToGlobal(pos));
     }
 }
 

--- a/src/gui/Src/Tracer/TraceWidget.cpp
+++ b/src/gui/Src/Tracer/TraceWidget.cpp
@@ -50,17 +50,11 @@ TraceWidget::TraceWidget(Architecture* architecture, const QString & fileName, Q
     mGeneralRegs->setFrameShape(QFrame::NoFrame);
     mGeneralRegs->ShowFPU(true);
 
-    QPushButton* button_changeview = new QPushButton("", this);
-    button_changeview->setStyleSheet("Text-align:left;padding: 4px;padding-left: 10px;");
-    connect(button_changeview, SIGNAL(clicked()), mGeneralRegs, SLOT(onChangeFPUViewAction()));
     connect(mTraceBrowser, SIGNAL(selectionChanged(TRACEINDEX)), this, SLOT(traceSelectionChanged(TRACEINDEX)));
     connect(mTraceBrowser, SIGNAL(displayLogWidget()), this, SLOT(displayLogWidgetSlot()));
     connect(mTraceFile, SIGNAL(parseFinished()), this, SLOT(parseFinishedSlot()));
     connect(mTraceBrowser, SIGNAL(closeFile()), this, SLOT(closeFileSlot()));
 
-    mGeneralRegs->SetChangeButton(button_changeview);
-
-    ui->mTopRightUpperFrameLayout->addWidget(button_changeview);
     ui->mTopRightUpperFrameLayout->addWidget(mGeneralRegs);
     ui->mTopHSplitter->setCollapsible(1, true); // allow collapsing the RegisterView
 


### PR DESCRIPTION
## Issue

The CPU/Registers and Trace views expose a "Change view" button for toggling FPU visibility. This is redundant because the same functionality already exists in the registers context menu (onChangeFPUViewAction), and the button introduces an inconsistent element in the view header.

Fixes #2621.

## Changes

**CPU / Registers View**

- Removed the "Hide/Show FPU" button from the registers view header and its associated UI wiring.
- Kept the existing context menu action as the single entry point for toggling FPU visibility.

**Trace View**

- Removed the "Hide/Show FPU" button from the trace registers view header and its associated UI wiring.
- Fixed missing right-click context menu in trace registers view by ensuring it is executed at the cursor position.

## Result

FPU visibility is now toggled only via the context menu in both CPU/Register and Trace views, which removes redundancy and keeps UI behavior consistent.