### PR TITLE
Show hotkeys in toolbar tooltips

### DIFF
--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -1099,7 +1099,8 @@ void MainWindow::setGlobalShortcut(QAction* action, const QKeySequence & key)
     action->setShortcutContext(Qt::ApplicationShortcut);
 
     QString tooltip = action->text().remove('&');
-    if (!key.isEmpty()) {
+    if(!key.isEmpty())
+    {
         tooltip = QStringLiteral("%1 (%2)").arg(tooltip, key.toString(QKeySequence::NativeText));
     }
     action->setToolTip(tooltip);

--- a/src/gui/Src/Gui/MainWindow.cpp
+++ b/src/gui/Src/Gui/MainWindow.cpp
@@ -1097,6 +1097,12 @@ void MainWindow::setGlobalShortcut(QAction* action, const QKeySequence & key)
 {
     action->setShortcut(key);
     action->setShortcutContext(Qt::ApplicationShortcut);
+
+    QString tooltip = action->text().remove('&');
+    if (!key.isEmpty()) {
+        tooltip = QStringLiteral("%1 (%2)").arg(tooltip, key.toString(QKeySequence::NativeText));
+    }
+    action->setToolTip(tooltip);
 }
 
 void MainWindow::refreshShortcuts()


### PR DESCRIPTION
## Issue

Toolbar tooltips do not display assigned keyboard shortcuts, making key bindings harder to discover and remember.

Fixes #3571.

## Changes

- Removed `&` mnemonic markers from tooltip text.
- If a keyboard shortcut is assigned, include it in the tooltip.

## Result

Toolbar tooltips now include assigned shortcuts where available.