### PR TITLE
Don't overwrite explicit command line with DB-loaded one on launch

### DIFF
--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2871,9 +2871,9 @@ static void debugLoopFunction(INIT_STRUCT* init)
 
     if(!init->attach)
     {
-        // Load command line if it exists in DB
+        // Load command line if it exists in DB, but only if none was explicitly provided
         DbLoad(DbLoadSaveType::CommandLine);
-        if(!isCmdLineEmpty())
+        if(!isCmdLineEmpty() && init->commandline.empty())
         {
             char* commandLineArguments = NULL;
             commandLineArguments = getCommandLineArgs();

--- a/src/tests/cmdline_init/plugin.cpp
+++ b/src/tests/cmdline_init/plugin.cpp
@@ -83,6 +83,59 @@ namespace
             return false;
         return _plugin_testassert(contains(commandLine, L"beta"), "expected command line to contain 'beta'");
     }
+
+    bool cbCmdlineDbOverrideAssert(int, char**)
+    {
+        LONG ready = 0;
+        int crtArgc = 0;
+        int winArgc = 0;
+        wchar_t commandLine[512];
+        wchar_t crtArgv1[128];
+        wchar_t crtArgv2[128];
+        wchar_t winArgv1[128];
+        wchar_t winArgv2[128];
+
+        const char* module = "cmdline_init";
+        if(!_plugin_testassert(readValue(module, "ObservedReady", ready), "failed to read ObservedReady"))
+            return false;
+        if(!_plugin_testassert(readValue(module, "ObservedCrtArgc", crtArgc), "failed to read ObservedCrtArgc"))
+            return false;
+        if(!_plugin_testassert(readValue(module, "ObservedWinArgc", winArgc), "failed to read ObservedWinArgc"))
+            return false;
+        if(!_plugin_testassert(readWide(module, "ObservedCommandLine", commandLine), "failed to read ObservedCommandLine"))
+            return false;
+        if(!_plugin_testassert(readWide(module, "ObservedCrtArgv1", crtArgv1), "failed to read ObservedCrtArgv1"))
+            return false;
+        if(!_plugin_testassert(readWide(module, "ObservedCrtArgv2", crtArgv2), "failed to read ObservedCrtArgv2"))
+            return false;
+        if(!_plugin_testassert(readWide(module, "ObservedWinArgv1", winArgv1), "failed to read ObservedWinArgv1"))
+            return false;
+        if(!_plugin_testassert(readWide(module, "ObservedWinArgv2", winArgv2), "failed to read ObservedWinArgv2"))
+            return false;
+
+        if(!_plugin_testassert(ready == 1, "target did not reach the observation point"))
+            return false;
+        if(!_plugin_testassert(crtArgc == 3, "expected CRT argc=3, got %d", crtArgc))
+            return false;
+        if(!_plugin_testassert(winArgc == 3, "expected WIN argc=3, got %d", winArgc))
+            return false;
+        // Explicit args must win over the DB-saved "alpha"/"beta" from the first run
+        if(!_plugin_testassert(wcscmp(crtArgv1, L"gamma") == 0, "expected CRT argv[1]='gamma' (DB-saved 'alpha' must not override explicit command line)"))
+            return false;
+        if(!_plugin_testassert(wcscmp(crtArgv2, L"delta") == 0, "expected CRT argv[2]='delta' (DB-saved 'beta' must not override explicit command line)"))
+            return false;
+        if(!_plugin_testassert(wcscmp(winArgv1, L"gamma") == 0, "expected WIN argv[1]='gamma'"))
+            return false;
+        if(!_plugin_testassert(wcscmp(winArgv2, L"delta") == 0, "expected WIN argv[2]='delta'"))
+            return false;
+        if(!_plugin_testassert(contains(commandLine, L"gamma"), "expected command line to contain 'gamma'"))
+            return false;
+        if(!_plugin_testassert(contains(commandLine, L"delta"), "expected command line to contain 'delta'"))
+            return false;
+        if(!_plugin_testassert(!contains(commandLine, L"alpha"), "command line must not contain DB-saved argument 'alpha'"))
+            return false;
+        return _plugin_testassert(!contains(commandLine, L"beta"), "command line must not contain DB-saved argument 'beta'");
+    }
 }
 
 extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
@@ -92,6 +145,7 @@ extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
     strncpy_s(initStruct->pluginName, sizeof(initStruct->pluginName), "CmdlineInit", _TRUNCATE);
     gPluginHandle = initStruct->pluginHandle;
     _plugin_registercommand(gPluginHandle, "cmdlineassert", cbCmdlineAssert, true);
+    _plugin_registercommand(gPluginHandle, "cmdlinedboverrideassert", cbCmdlineDbOverrideAssert, true);
     return true;
 }
 

--- a/src/tests/cmdline_init/test.txt
+++ b/src/tests/cmdline_init/test.txt
@@ -2,3 +2,7 @@ settingset Events, EntryBreakpoint, 0
 init tests/cmdline_init.exe, "\"alpha\" \"beta\""
 run
 cmdlineassert
+dbsave
+init tests/cmdline_init.exe, "\"gamma\" \"delta\""
+run
+cmdlinedboverrideassert


### PR DESCRIPTION
When a command line is explicitly provided at startup, skip loading the saved command line from the database so the explicit one is used.