### PR TITLE
Add GuiLogGet to read log window contents as a string

### DIFF
--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -2279,6 +2279,11 @@ BRIDGE_IMPEXP void GuiFlushLog()
     _gui_sendmessage(GUI_FLUSH_LOG, nullptr, nullptr);
 }
 
+BRIDGE_IMPEXP void GuiLogGet(char** text)
+{
+    _gui_sendmessage(GUI_GET_LOG, text, nullptr);
+}
+
 BRIDGE_IMPEXP void GuiReferenceAddCommand(const char* title, const char* command)
 {
     _gui_sendmessage(GUI_REF_ADDCOMMAND, (void*)title, (void*)command);

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -1393,6 +1393,7 @@ BRIDGE_IMPEXP bool DbgTypeVisit(const TYPEVISITDATA* data);
     msg(GUI_MENU_SET_NAME, int hMenu, const char* name) \
     msg(GUI_MENU_SET_ENTRY_NAME, int hEntry, const char* name) \
     msg(GUI_FLUSH_LOG, unused, unused) \
+    msg(GUI_GET_LOG, char** text, unused) \
     msg(GUI_MENU_SET_ENTRY_HOTKEY, int hEntry, const char* hack) \
     msg(GUI_REF_SEARCH_GETROWCOUNT, unused, unused) \
     msg(GUI_REF_SEARCH_GETCELLCONTENT, int row, int col) \
@@ -1595,6 +1596,7 @@ BRIDGE_IMPEXP void GuiTypeListUpdated();
 BRIDGE_IMPEXP void GuiUpdateTypeWidget();
 BRIDGE_IMPEXP void GuiCloseApplication();
 BRIDGE_IMPEXP void GuiFlushLog();
+BRIDGE_IMPEXP void GuiLogGet(char** text);
 BRIDGE_IMPEXP void GuiReferenceAddCommand(const char* title, const char* command);
 BRIDGE_IMPEXP void GuiUpdateTraceBrowser();
 BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);

--- a/src/gui/Src/Bridge/Bridge.cpp
+++ b/src/gui/Src/Bridge/Bridge.cpp
@@ -849,6 +849,14 @@ void* Bridge::processMessage(GUIMSG type, void* param1, void* param2)
     }
     break;
 
+    case GUI_GET_LOG:
+    {
+        BridgeResult result(BridgeResult::GetLog);
+        emit getLog(param1);
+        result.Wait();
+    }
+    break;
+
     case GUI_DUMP_AT_N:
         emit dumpAtN((duint)param1, (int)(duint)param2);
         break;

--- a/src/gui/Src/Bridge/Bridge.h
+++ b/src/gui/Src/Bridge/Bridge.h
@@ -158,6 +158,7 @@ signals:
     void getGlobalNotes(void* text);
     void setDebuggeeNotes(const QString text);
     void getDebuggeeNotes(void* text);
+    void getLog(void* text);
     void dumpAtN(duint va, int index);
     void displayWarning(QString title, QString text);
     void registerScriptLang(SCRIPTTYPEINFO* info);

--- a/src/gui/Src/Bridge/BridgeResult.h
+++ b/src/gui/Src/Bridge/BridgeResult.h
@@ -28,6 +28,7 @@ public:
         MenuSetEntryName,
         GetGlobalNotes,
         GetDebuggeeNotes,
+        GetLog,
         RegisterScriptLang,
         LoadGraph,
         GraphAt,

--- a/src/gui/Src/Gui/LogView.cpp
+++ b/src/gui/Src/Gui/LogView.cpp
@@ -42,6 +42,7 @@ LogView::LogView(QWidget* parent) : QTextBrowser(parent), logRedirection(NULL)
     connect(Bridge::getBridge(), SIGNAL(saveLogToFile(QString)), this, SLOT(saveToFileSlot(QString)));
     connect(Bridge::getBridge(), SIGNAL(redirectLogToFile(QString)), this, SLOT(redirectLogToFileSlot(QString)));
     connect(Bridge::getBridge(), SIGNAL(redirectLogStop()), this, SLOT(stopRedirectLogSlot()));
+    connect(Bridge::getBridge(), SIGNAL(getLog(void*)), this, SLOT(getLogSlot(void*)));
     connect(Bridge::getBridge(), SIGNAL(setLogEnabled(bool)), this, SLOT(setLoggingEnabled(bool)));
     connect(Bridge::getBridge(), SIGNAL(flushLog()), this, SLOT(flushLogSlot()));
     connect(this, SIGNAL(anchorClicked(QUrl)), this, SLOT(onAnchorClicked(QUrl)));
@@ -458,6 +459,19 @@ bool LogView::getLoggingEnabled()
 void LogView::autoScrollSlot()
 {
     autoScroll = !autoScroll;
+}
+
+void LogView::getLogSlot(void* ptr)
+{
+    QByteArray text = document()->toPlainText().toUtf8();
+    char* result = nullptr;
+    if(text.length())
+    {
+        result = (char*)BridgeAlloc(text.length() + 1);
+        strcpy_s(result, text.length() + 1, text.constData());
+    }
+    *(char**)ptr = result;
+    Bridge::getBridge()->setResult(BridgeResult::GetLog);
 }
 
 void LogView::saveToFileSlot(QString fileName)

--- a/src/gui/Src/Gui/LogView.h
+++ b/src/gui/Src/Gui/LogView.h
@@ -23,6 +23,7 @@ public slots:
     void addMsgToLogSlot(QByteArray msg); /* Non-HTML Log Function*/
     void addMsgToLogHtmlSlot(QByteArray msg); /* HTML accepting Log Function */
     void stopRedirectLogSlot();
+    void getLogSlot(void* text);
     void redirectLogToFileSlot(QString filename);
     void redirectLogSlot();
     void setLoggingEnabled(bool enabled);


### PR DESCRIPTION
Follows the same BridgeResult pattern as GuiGetGlobalNotes/GuiGetDebuggeeNotes: GUI_GET_LOG emits a queued signal to LogView, which allocates the log text via BridgeAlloc and signals completion synchronously via BridgeResult::GetLog. Caller frees the returned buffer with BridgeFree.