### PR TITLE
Improve db/dw/dd/dq instructions

### DIFF
--- a/src/dbg/datainst_helper.cpp
+++ b/src/dbg/datainst_helper.cpp
@@ -161,25 +161,70 @@ bool tryassembledata(duint addr, unsigned char* dest, int destsize, int* size, c
     switch(di.type)
     {
     case enc_byte:
+        // For "db" only, a single all-hex operand longer than one byte is "packed" into
+        // several bytes, e.g. "db 11223344" (four bytes). An odd number of digits treats
+        // the leading digit as a half byte, e.g. "db 123" -> 01 23. An operand that is not
+        // pure hex (e.g. a leading minus) falls through to the per-item handling below.
+        if(di.operand.size() > 2 &&
+                di.operand.find_first_not_of("0123456789abcdefABCDEF") == String::npos)
+        {
+            const String & packed = di.operand;
+            size_t i = 0;
+            if(packed.size() % 2 != 0)
+            {
+                // the leading nibble forms a single byte
+                unsigned long long result = 0;
+                convertLongLongNumber(packed.substr(0, 1).c_str(), result, 16);
+                buffer.append((char*)&result, 1);
+                i++;
+            }
+            for(; i < packed.size(); i += 2)
+            {
+                unsigned long long result = 0;
+                convertLongLongNumber(packed.substr(i, 2).c_str(), result, 16);
+                buffer.append((char*)&result, 1);
+            }
+            retsize = buffer.size();
+            break;
+        }
+        [[fallthrough]];
     case enc_word:
     case enc_dword:
     case enc_fword:
     case enc_qword:
     {
-        unsigned long long result = 0;
-        if(!convertLongLongNumber(di.operand.c_str(), result, 16))
+        // Split the operand into whitespace-delimited items. Each item is a hex value
+        // that must fit in the data size, e.g. "db 1 2 3", "dd 12345678 1" or "db -11".
+        auto items = StringUtils::Split(di.operand, " \t");
+
+        // one or more values, each must fit in the data size (signed or unsigned)
+        for(const auto & item : items)
         {
-            strcpy_s(error, MAX_ERROR_SIZE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Failed to convert operand")));
-            return false;
-        }
-        auto buf = (char*)&result;
-        for(auto i = retsize; i < sizeof(result); i++)
-            if(buf[i])
+            unsigned long long result = 0;
+            if(!convertLongLongNumber(item.c_str(), result, 16))
+            {
+                strcpy_s(error, MAX_ERROR_SIZE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Failed to convert operand")));
+                return false;
+            }
+            // the bytes above the data size must be a valid zero- or sign-extension
+            auto buf = (unsigned char*)&result;
+            bool allZero = true, allOnes = true;
+            for(auto i = retsize; i < sizeof(result); i++)
+            {
+                if(buf[i] != 0x00)
+                    allZero = false;
+                if(buf[i] != 0xff)
+                    allOnes = false;
+            }
+            bool negative = (buf[retsize - 1] & 0x80) != 0;
+            if(!allZero && !(allOnes && negative))
             {
                 strcpy_s(error, MAX_ERROR_SIZE, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Operand value too big")));
                 return false;
             }
-        buffer = String(buf, retsize);
+            buffer.append((char*)&result, retsize); //store the value little-endian
+        }
+        retsize = buffer.size();
     }
     break;
 

--- a/src/dbg/stringutils.cpp
+++ b/src/dbg/stringutils.cpp
@@ -52,6 +52,33 @@ StringList StringUtils::Split(const String & s, char delim)
     return elems;
 }
 
+void StringUtils::Split(const String & s, const String & delims, std::vector<String> & elems)
+{
+    elems.clear();
+    String item;
+    item.reserve(s.length());
+    for(size_t i = 0; i < s.length(); i++)
+    {
+        if(delims.find(s[i]) != String::npos)
+        {
+            if(!item.empty())
+                elems.push_back(item);
+            item.clear();
+        }
+        else
+            item.push_back(s[i]);
+    }
+    if(!item.empty())
+        elems.push_back(std::move(item));
+}
+
+StringList StringUtils::Split(const String & s, const String & delims)
+{
+    std::vector<String> elems;
+    Split(s, delims, elems);
+    return elems;
+}
+
 //https://github.com/lefticus/presentations/blob/master/PracticalPerformancePractices.md#smaller-code-is-faster-code-11
 String StringUtils::Escape(unsigned char ch, bool escapeSafe)
 {

--- a/src/dbg/stringutils.h
+++ b/src/dbg/stringutils.h
@@ -24,6 +24,8 @@ class StringUtils
 public:
     static void Split(const String & s, char delim, std::vector<String> & elems);
     static StringList Split(const String & s, char delim);
+    static void Split(const String & s, const String & delims, std::vector<String> & elems);
+    static StringList Split(const String & s, const String & delims);
     static String Escape(unsigned char ch, bool escapeSafe = true);
     static String Escape(const String & s, bool escapeSafe = true);
     static bool Unescape(const String & s, String & result, bool quoted = true);


### PR DESCRIPTION
Allow multiple values, negative values, and packed bytes.

Previously implemented:
```assembly
db 12 ; single 0x12 byte
dw 1234 ; single 0x1234 word
```

This PR implements:
```assembly
db -2 ; one byte: 0xFE
db 12 34 ; two bytes: 0x12 0x34
dw 1234 56 ; two words: 0x1234 0x0056
db 123456 ; three bytes: 0x12 0x34 0x56
db 123 ; two bytes: 0x01 0x23
```

The packed syntax (no spaces) is only implemented for `db`.

Context: https://github.com/m417z/Multiline-Ultimate-Assembler/issues/13.

Note: The total size is still limited to 16 bytes. This also revealed an existing issue - some commands don't work, e.g. `ymmword 0`.