### PR TITLE
Use UTF-8 code page via exe manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -993,6 +993,7 @@ endif()
 
 if(MSVC) # msvc
 	target_link_options(exe PRIVATE
+		"/MANIFEST:NO"
 		"/DELAYLOAD:user32.dll"
 		"/DELAYLOAD:wintrust.dll"
 		"/DELAYLOAD:$<TARGET_FILE_NAME:bridge>"
@@ -1153,6 +1154,12 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 4) # x86
 		Shlwapi
 		Comctl32
 	)
+
+	if(MSVC) # msvc
+		target_link_options(launcher PRIVATE
+			"/MANIFEST:NO"
+		)
+	endif()
 
 	set_target_properties(launcher PROPERTIES
 		MSVC_RUNTIME_LIBRARY

--- a/cmake.toml
+++ b/cmake.toml
@@ -201,6 +201,9 @@ link-libraries = [
     "Wintrust",
 ]
 msvc.link-options = [
+    # resource.rc already embeds manifest.xml as RT_MANIFEST, so disable the
+    # linker's default manifest to avoid embedding a second one.
+    "/MANIFEST:NO",
     "/DELAYLOAD:user32.dll",
     "/DELAYLOAD:wintrust.dll",
     "/DELAYLOAD:$<TARGET_FILE_NAME:bridge>",
@@ -269,6 +272,11 @@ sources = [
     "src/exe/icon.rc",
     "src/exe/resource.rc",
     "src/exe/strings_utf8.rc",
+]
+msvc.link-options = [
+    # resource.rc already embeds manifest.xml as RT_MANIFEST, so disable the
+    # linker's default manifest to avoid embedding a second one.
+    "/MANIFEST:NO",
 ]
 link-libraries = [
     "Shlwapi",

--- a/src/bridge/bridgemain.cpp
+++ b/src/bridge/bridgemain.cpp
@@ -7,6 +7,7 @@
 #include "_global.h"
 #include "bridgemain.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <ShlObj.h>
 #include "../dbg/_dbgfunctions.h"
 #include "Utf8Ini.h"
@@ -489,6 +490,35 @@ BRIDGE_IMPEXP unsigned int BridgeGetNtBuildNumber()
         NtBuildNumber = NtBuildNumber7;
     }
     return NtBuildNumber;
+}
+
+BRIDGE_IMPEXP unsigned int BridgeGetAnsiCodePage()
+{
+    // The application uses a UTF-8 manifest, so CP_ACP and GetACP() report code
+    // page 65001 (UTF-8) instead of the real system ANSI code page. Read the
+    // actual ANSI code page from the registry where the system stores it.
+    static unsigned int codePage = []() -> unsigned int
+    {
+        unsigned int result = CP_ACP;
+        HKEY hKey;
+        if(RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage", 0, KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS)
+        {
+            wchar_t value[16];
+            DWORD type = 0;
+            DWORD size = sizeof(value);
+            if(RegQueryValueExW(hKey, L"ACP", nullptr, &type, (LPBYTE)value, &size) == ERROR_SUCCESS &&
+                    type == REG_SZ && size != 0 && size % sizeof(wchar_t) == 0 && value[size / sizeof(wchar_t) - 1] == L'\0')
+            {
+                wchar_t* end = nullptr;
+                auto acp = wcstoul(value, &end, 10);
+                if(*end == L'\0' && acp > 0 && acp <= 0xFFFF)
+                    result = (unsigned int)acp;
+            }
+            RegCloseKey(hKey);
+        }
+        return result;
+    }();
+    return codePage;
 }
 
 BRIDGE_IMPEXP const wchar_t* BridgeWorkingDirectory()

--- a/src/bridge/bridgemain.h
+++ b/src/bridge/bridgemain.h
@@ -152,6 +152,15 @@ BRIDGE_IMPEXP bool BridgeIsProcessElevated();
 BRIDGE_IMPEXP unsigned int BridgeGetNtBuildNumber();
 
 /// <summary>
+/// Gets the real system ANSI code page from the registry. Unlike GetACP(), the
+/// result is not affected by the process UTF-8 manifest, so it is the actual
+/// code page used by ANSI functions (for example inside the debuggee). The
+/// value is queried once and cached.
+/// </summary>
+/// <returns>The system ANSI code page, or CP_ACP on failure.</returns>
+BRIDGE_IMPEXP unsigned int BridgeGetAnsiCodePage();
+
+/// <summary>
 /// Returns the original working directory when starting the debugger.
 /// The working directory is changed to the x64dbg directory after initialization.
 /// </summary>

--- a/src/cross/widgets/MiscUtil.cpp
+++ b/src/cross/widgets/MiscUtil.cpp
@@ -11,6 +11,10 @@
 #include "Bridge.h"
 #include <thread>
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <QTextCodec>
+#endif // QT_VERSION
+
 #if 0
 void SetApplicationIcon(WId winId)
 {
@@ -419,3 +423,10 @@ QString mainModuleName(bool extension)
     }
     return QString();
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+QTextCodec* CodepageCodec(const QByteArray & name)
+{
+    return QTextCodec::codecForName(name);
+}
+#endif

--- a/src/cross/widgets/MiscUtil.h
+++ b/src/cross/widgets/MiscUtil.h
@@ -7,6 +7,9 @@
 
 class QWidget;
 class QByteArray;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+class QTextCodec;
+#endif
 
 //void SetApplicationIcon(WId winId);
 QByteArray & ByteReverse(QByteArray & array);
@@ -25,5 +28,8 @@ QIcon getFileIcon(QString file);
 QIcon DIconHelper(QString name);
 QString getDbPath(const QString & filename = QString(), bool addDateTimeSuffix = false);
 QString mainModuleName(bool extension = false);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+QTextCodec* CodepageCodec(const QByteArray & name);
+#endif
 
 #define DIcon(name) [](QString arg) { static QIcon icon(DIconHelper(std::move(arg))); return icon; }(name)

--- a/src/dbg/_exports.cpp
+++ b/src/dbg/_exports.cpp
@@ -1188,7 +1188,7 @@ extern "C" DLL_EXPORT duint _dbg_sendmessage(DBGMSG type, void* param1, void* pa
         duint newStringAlgorithm = 0;
         if(!BridgeSettingGetUint("Engine", "NewStringAlgorithm", &newStringAlgorithm))
         {
-            auto acp = GetACP();
+            auto acp = BridgeGetAnsiCodePage();
             newStringAlgorithm = acp == 932 || acp == 936 || acp == 949 || acp == 950 || acp == 951 || acp == 1251;
         }
         bNewStringAlgorithm = !!newStringAlgorithm;

--- a/src/dbg/debugger.cpp
+++ b/src/dbg/debugger.cpp
@@ -2642,11 +2642,11 @@ static bool fixgetcommandlinesbase(duint new_command_line_unicode, duint new_com
 static std::vector<char> Utf16ToAnsi(const wchar_t* wstr)
 {
     std::vector<char> buffer;
-    auto requiredSize = WideCharToMultiByte(CP_ACP, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
+    auto requiredSize = WideCharToMultiByte(BridgeGetAnsiCodePage(), 0, wstr, -1, nullptr, 0, nullptr, nullptr);
     if(requiredSize > 0)
     {
         buffer.resize(requiredSize);
-        WideCharToMultiByte(CP_ACP, 0, wstr, -1, &buffer[0], requiredSize, nullptr, nullptr);
+        WideCharToMultiByte(BridgeGetAnsiCodePage(), 0, wstr, -1, &buffer[0], requiredSize, nullptr, nullptr);
     }
     return buffer;
 }

--- a/src/dbg/stringutils.cpp
+++ b/src/dbg/stringutils.cpp
@@ -1,6 +1,7 @@
 #include "stringutils.h"
 #include <windows.h>
 #include <cstdint>
+#include "../bridge/bridgemain.h"
 
 bool StringUtils::convertLongLongNumber(const char* str, unsigned long long & result, int radix)
 {
@@ -367,11 +368,11 @@ WString StringUtils::LocalCpToUtf16(const char* str)
     WString convertedString;
     if(!str || !*str)
         return convertedString;
-    int requiredSize = MultiByteToWideChar(CP_ACP, 0, str, -1, nullptr, 0);
+    int requiredSize = MultiByteToWideChar(BridgeGetAnsiCodePage(), 0, str, -1, nullptr, 0);
     if(requiredSize > 0)
     {
         convertedString.resize(requiredSize - 1);
-        if(!MultiByteToWideChar(CP_ACP, 0, str, -1, (wchar_t*)convertedString.c_str(), requiredSize))
+        if(!MultiByteToWideChar(BridgeGetAnsiCodePage(), 0, str, -1, (wchar_t*)convertedString.c_str(), requiredSize))
             convertedString.clear();
     }
     return convertedString;
@@ -382,11 +383,11 @@ String StringUtils::Utf16ToLocalCp(const WString & str)
     String convertedString;
     if(str.size() == 0)
         return convertedString;
-    int requiredSize = WideCharToMultiByte(CP_ACP, 0, str.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    int requiredSize = WideCharToMultiByte(BridgeGetAnsiCodePage(), 0, str.c_str(), -1, nullptr, 0, nullptr, nullptr);
     if(requiredSize > 0)
     {
         convertedString.resize(requiredSize - 1);
-        if(!WideCharToMultiByte(CP_ACP, 0, str.c_str(), -1, (char*)convertedString.c_str(), requiredSize, nullptr, nullptr))
+        if(!WideCharToMultiByte(BridgeGetAnsiCodePage(), 0, str.c_str(), -1, (char*)convertedString.c_str(), requiredSize, nullptr, nullptr))
             convertedString.clear();
     }
     return convertedString;

--- a/src/exe/manifest.xml
+++ b/src/exe/manifest.xml
@@ -28,4 +28,9 @@
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> 
     </application> 
   </compatibility>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/gui/Src/BasicView/HexDump.cpp
+++ b/src/gui/Src/BasicView/HexDump.cpp
@@ -2,6 +2,7 @@
 #include "Configuration.h"
 #include "Bridge.h"
 #include "StringUtil.h"
+#include "MiscUtil.h"
 #include <QMessageBox>
 #include <QFloat16>
 #include <QDebug>
@@ -976,7 +977,7 @@ void HexDump::getColumnRichText(duint col, duint rva, RichTextPainter::List & ri
             auto textDecoder = QStringDecoder(desc.textEncoding);
             curData.text = textDecoder.decode(QByteArrayView((const char*)data, (int)bufferByteCount));
 #else
-            auto textCodec = QTextCodec::codecForName(desc.textEncoding);
+            auto textCodec = CodepageCodec(desc.textEncoding);
             curData.text = textCodec->toUnicode((const char*)data, (int)bufferByteCount);
 #endif // QT_VERSION
             //This might produce invalid characters in variables-width encodings. This is currently ignored.

--- a/src/gui/Src/Gui/CPUDump.cpp
+++ b/src/gui/Src/Gui/CPUDump.cpp
@@ -196,7 +196,7 @@ void CPUDump::setupContextMenu()
     hexMenu->addAction(hexLastCodepage, [hexLastCodepage](QMenu*)
     {
         duint lastCodepage;
-        auto allCodecs = QTextCodec::availableCodecs();
+        auto allCodecs = CodepageList();
         if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
             return false;
         hexLastCodepage->setText(QString::fromLocal8Bit(allCodecs.at(lastCodepage)));
@@ -212,7 +212,7 @@ void CPUDump::setupContextMenu()
     textMenu->addAction(textLastCodepage, [textLastCodepage](QMenu*)
     {
         duint lastCodepage;
-        auto allCodecs = QTextCodec::availableCodecs();
+        auto allCodecs = CodepageList();
         if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
             return false;
         textLastCodepage->setText(QString::fromLocal8Bit(allCodecs.at(lastCodepage)));
@@ -747,7 +747,7 @@ void CPUDump::hexLastCodepageSlot()
     ColumnDescriptor colDesc;
     DataDescriptor dDesc;
     duint lastCodepage;
-    auto allCodecs = QTextCodec::availableCodecs();
+    auto allCodecs = CodepageList();
     if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
         return;
 
@@ -778,7 +778,7 @@ void CPUDump::textLastCodepageSlot()
     ColumnDescriptor colDesc;
     DataDescriptor dDesc;
     duint lastCodepage;
-    auto allCodecs = QTextCodec::availableCodecs();
+    auto allCodecs = CodepageList();
     if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
         return;
 

--- a/src/gui/Src/Gui/CodepageSelectionDialog.cpp
+++ b/src/gui/Src/Gui/CodepageSelectionDialog.cpp
@@ -12,7 +12,7 @@ CodepageSelectionDialog::CodepageSelectionDialog(QWidget* parent) :
     setModal(true);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::MSWindowsFixedSizeDialogHint);
     setWindowIcon(DIcon("codepage"));
-    for(auto & name : QTextCodec::availableCodecs())
+    for(auto & name : CodepageList())
     {
         auto codec = QTextCodec::codecForName(name);
         if(!codec)

--- a/src/gui/Src/Gui/HexEditDialog.cpp
+++ b/src/gui/Src/Gui/HexEditDialog.cpp
@@ -9,6 +9,7 @@
 #include "CodepageSelectionDialog.h"
 #include "LineEditDialog.h"
 #include "StringUtil.h"
+#include "MiscUtil.h"
 
 #ifndef AF_INET6
 #define AF_INET6        23              // Internetwork Version 6
@@ -24,7 +25,7 @@ HexEditDialog::HexEditDialog(QWidget* parent) : QDialog(parent), ui(new Ui::HexE
     setModal(true); //modal window
 
     //setup text fields
-    ui->lineEditAscii->setEncoding(QTextCodec::codecForName("System"));
+    ui->lineEditAscii->setEncoding(SystemCodec());
     ui->lineEditUnicode->setEncoding(QTextCodec::codecForName("UTF-16"));
     ui->chkKeepSize->setChecked(ConfigBool("HexDump", "KeepSize"));
     ui->chkKeepSize->hide();
@@ -136,21 +137,16 @@ void HexEditDialog::isDataCopiable(bool copyDataEnabled)
 void HexEditDialog::updateCodepage()
 {
     duint lastCodepage;
-    auto allCodecs = QTextCodec::availableCodecs();
-    if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
-        lastCodec = fallbackCodec;
+    auto codecs = CodepageList();
+    if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(codecs.size()))
+        updateCodepage(fallbackCodec->name());
     else
-        lastCodec = QTextCodec::codecForName(allCodecs.at(lastCodepage));
-    ui->lineEditCodepage->setEncoding(lastCodec);
-    ui->lineEditCodepage->setData(mHexEdit->data());
-    ui->stringEditor->document()->setPlainText(lastCodec->toUnicode(mHexEdit->data()));
-    ui->labelLastCodepage->setText(lastCodec->name().constData());
-    ui->labelLastCodepage2->setText(ui->labelLastCodepage->text());
+        updateCodepage(codecs.at(lastCodepage));
 }
 
 void HexEditDialog::updateCodepage(const QByteArray & name)
 {
-    lastCodec = QTextCodec::codecForName(name);
+    lastCodec = CodepageCodec(name);
     if(!lastCodec)
         lastCodec = fallbackCodec;
     ui->lineEditCodepage->setEncoding(lastCodec);
@@ -305,7 +301,7 @@ bool HexEditDialog::checkDataRepresentable(int mode)
     QLabel* label;
     if(mode == 1)
     {
-        codec = QTextCodec::codecForName("System");
+        codec = SystemCodec();
         label = ui->labelWarningCodepageASCII;
     }
     else if(mode == 2)
@@ -543,7 +539,7 @@ void HexEditDialog::printData(DataType type)
 
     case DataString:
     {
-        data = QTextCodec::codecForName("System")->makeDecoder()->toUnicode((const char*)(mData.constData()), mData.size());
+        data = SystemCodec()->makeDecoder()->toUnicode((const char*)(mData.constData()), mData.size());
     }
     break;
 

--- a/src/gui/Src/Gui/HexLineEdit.cpp
+++ b/src/gui/Src/Gui/HexLineEdit.cpp
@@ -3,6 +3,7 @@
 #include "HexLineEdit.h"
 #include "ui_HexLineEdit.h"
 #include "Bridge.h"
+#include "MiscUtil.h"
 #include <QKeyEvent>
 
 HexLineEdit::HexLineEdit(QWidget* parent) :
@@ -15,7 +16,7 @@ HexLineEdit::HexLineEdit(QWidget* parent) :
     mData = QByteArray();
     mKeepSize = false;
     mOverwriteMode = false;
-    mEncoding = QTextCodec::codecForName("System");
+    mEncoding = SystemCodec();
 
     //setup text fields
     QFont font("Monospace", 8, QFont::Normal, false);

--- a/src/gui/Src/Tracer/TraceDump.cpp
+++ b/src/gui/Src/Tracer/TraceDump.cpp
@@ -116,7 +116,7 @@ void TraceDump::setupContextMenu()
     wHexMenu->addAction(wHexLastCodepage, [wHexLastCodepage](QMenu*)
     {
         duint lastCodepage;
-        auto allCodecs = QTextCodec::availableCodecs();
+        auto allCodecs = CodepageList();
         if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
             return false;
         wHexLastCodepage->setText(QString::fromLocal8Bit(allCodecs.at(lastCodepage)));
@@ -132,7 +132,7 @@ void TraceDump::setupContextMenu()
     wTextMenu->addAction(wTextLastCodepage, [wTextLastCodepage](QMenu*)
     {
         duint lastCodepage;
-        auto allCodecs = QTextCodec::availableCodecs();
+        auto allCodecs = CodepageList();
         if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
             return false;
         wTextLastCodepage->setText(QString::fromLocal8Bit(allCodecs.at(lastCodepage)));
@@ -522,7 +522,7 @@ void TraceDump::hexLastCodepageSlot()
     ColumnDescriptor wColDesc;
     DataDescriptor dDesc;
     duint lastCodepage;
-    auto allCodecs = QTextCodec::availableCodecs();
+    auto allCodecs = CodepageList();
     if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
         return;
 
@@ -553,7 +553,7 @@ void TraceDump::textLastCodepageSlot()
     ColumnDescriptor wColDesc;
     DataDescriptor dDesc;
     duint lastCodepage;
-    auto allCodecs = QTextCodec::availableCodecs();
+    auto allCodecs = CodepageList();
     if(!BridgeSettingGetUint("Misc", "LastCodepage", &lastCodepage) || lastCodepage >= duint(allCodecs.size()))
         return;
 

--- a/src/gui/Src/Utils/MiscUtil.cpp
+++ b/src/gui/Src/Utils/MiscUtil.cpp
@@ -1,6 +1,7 @@
 #include "MiscUtil.h"
 #include <QtWin>
 #include <QApplication>
+#include <QTextCodec>
 #include <QMessageBox>
 #include <QCheckBox>
 #include <QDir>
@@ -414,4 +415,87 @@ QString mainModuleName(bool extension)
         return name;
     }
     return QString();
+}
+
+// QTextCodec for the real system ANSI code page (queried from the bridge). Qt's
+// built-in "System" codec follows CP_ACP, which the application UTF-8 manifest
+// redirects to UTF-8.
+static const char SystemCodecName[] = "System-ANSI";
+
+namespace
+{
+    class SystemAnsiCodec : public QTextCodec
+    {
+    public:
+        explicit SystemAnsiCodec(UINT codePage) : mCodePage(codePage) {}
+
+        QByteArray name() const override
+        {
+            return SystemCodecName;
+        }
+
+        int mibEnum() const override
+        {
+            return 2; // "unknown" per the IANA registry
+        }
+
+    protected:
+        QString convertToUnicode(const char* in, int length, ConverterState*) const override
+        {
+            if(length <= 0)
+                return QString();
+            int wlen = MultiByteToWideChar(mCodePage, 0, in, length, nullptr, 0);
+            if(wlen <= 0)
+                return QString();
+            QString out;
+            out.resize(wlen);
+            MultiByteToWideChar(mCodePage, 0, in, length, reinterpret_cast<wchar_t*>(out.data()), wlen);
+            return out;
+        }
+
+        QByteArray convertFromUnicode(const QChar* in, int length, ConverterState*) const override
+        {
+            if(length <= 0)
+                return QByteArray();
+            auto win = reinterpret_cast<const wchar_t*>(in);
+            int blen = WideCharToMultiByte(mCodePage, 0, win, length, nullptr, 0, nullptr, nullptr);
+            if(blen <= 0)
+                return QByteArray();
+            QByteArray out;
+            out.resize(blen);
+            WideCharToMultiByte(mCodePage, 0, win, length, out.data(), blen, nullptr, nullptr);
+            return out;
+        }
+
+    private:
+        UINT mCodePage;
+    };
+}
+
+QTextCodec* SystemCodec()
+{
+    // Created once; QTextCodec instances are owned by Qt and live until exit.
+    static QTextCodec* codec = new SystemAnsiCodec(BridgeGetAnsiCodePage());
+    return codec;
+}
+
+QTextCodec* CodepageCodec(const QByteArray & name)
+{
+    // "System" must use the real system ANSI code page, not Qt's built-in System
+    // codec, which follows CP_ACP and is therefore UTF-8 under the UTF-8 manifest.
+    if(name == "System")
+        return SystemCodec();
+    return QTextCodec::codecForName(name);
+}
+
+QList<QByteArray> CodepageList()
+{
+    // availableCodecs() without our internal SystemCodec(). This matches the list
+    // as it was before the system codec was introduced, so the LastCodepage setting
+    // (stored as an index into this list) stays valid for existing users.
+    QList<QByteArray> result;
+    for(const QByteArray & name : QTextCodec::availableCodecs())
+        if(name != SystemCodecName)
+            result.append(name);
+    return result;
 }

--- a/src/gui/Src/Utils/MiscUtil.h
+++ b/src/gui/Src/Utils/MiscUtil.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <QIcon>
+#include <QList>
 #include <functional>
 #include "Imports.h"
 
 class QWidget;
 class QByteArray;
+class QTextCodec;
 
 void SetApplicationIcon(WId winId);
 QByteArray & ByteReverse(QByteArray & array);
@@ -24,5 +26,8 @@ QIcon getFileIcon(QString file);
 QIcon DIconHelper(QString name);
 QString getDbPath(const QString & filename = QString(), bool addDateTimeSuffix = false);
 QString mainModuleName(bool extension = false);
+QTextCodec* SystemCodec();
+QTextCodec* CodepageCodec(const QByteArray & name);
+QList<QByteArray> CodepageList();
 
 #define DIcon(name) [](QString arg) { static QIcon icon(DIconHelper(std::move(arg))); return icon; }(name)


### PR DESCRIPTION
Reference:
https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page

Fixes this issue in my plugin:
https://github.com/m417z/Multiline-Ultimate-Assembler/issues/15
And makes the life of plugin authors easier in general.

Also, a second commit fixes a duplicate manifest, see commit message for details.