### PR TITLE
Expose the process memory map over the ElfBug C API

### DIFF
--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
@@ -25,7 +25,7 @@ struct ElfBugDebugger : ElfBug::Debugger
     struct MemRegion
     {
         uint64_t start, end;
-        bool executable;
+        bool read, write, execute, shared;
         std::string pathname;
     };
     mutable std::mutex mapMutex;
@@ -93,7 +93,8 @@ struct ElfBugDebugger : ElfBug::Debugger
                 }
             }
 
-            newMaps.push_back({start, end, perms[2] == 'x', std::move(pathname)});
+            newMaps.push_back({start, end, perms[0] == 'r', perms[1] == 'w',
+                               perms[2] == 'x', perms[3] == 's', std::move(pathname)});
         }
         fclose(f);
 
@@ -491,7 +492,7 @@ extern "C" {
 
         std::lock_guard lock(dbg->mapMutex);
         const auto* region = dbg->findRegion(addr);
-        return region && region->executable;
+        return region && region->execute;
     }
 
     bool ElfBugMemIsValidPtr(const ElfBugDebugger* dbg, const uint64_t addr)
@@ -503,6 +504,33 @@ extern "C" {
 
         std::lock_guard lock(dbg->mapMutex);
         return dbg->findRegion(addr) != nullptr;
+    }
+
+    size_t ElfBugGetMemoryMap(const ElfBugDebugger* dbg, ElfBugMemRegion* out, const size_t maxCount)
+    {
+        if(!dbg)
+            return 0;
+        if(!dbg->active.load(std::memory_order_acquire))
+            return 0;
+
+        std::lock_guard lock(dbg->mapMutex);
+        const size_t total = dbg->memoryMap.size();
+        const size_t n = out ? std::min(total, maxCount) : 0;
+        for(size_t i = 0; i < n; ++i)
+        {
+            const auto & r = dbg->memoryMap[i];
+            ElfBugMemRegion & o = out[i];
+            o.start = r.start;
+            o.end = r.end;
+            o.read = r.read;
+            o.write = r.write;
+            o.execute = r.execute;
+            o.shared = r.shared;
+            const size_t len = std::min(r.pathname.size(), sizeof(o.path) - 1);
+            memcpy(o.path, r.pathname.data(), len);
+            o.path[len] = '\0';
+        }
+        return total;
     }
 
     bool ElfBugModBaseFromAddr(const ElfBugDebugger* dbg, const uint64_t addr, uint64_t* base)

--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
@@ -7,6 +7,7 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <mutex>
 #include <set>
 #include <shared_mutex>
@@ -53,31 +54,30 @@ struct ElfBugDebugger : ElfBug::Debugger
             return;
         }
 
-        char path[64];
-        snprintf(path, sizeof(path), "/proc/%d/maps", mProcess->pid);
-        FILE* f = fopen(path, "r");
-        if(!f)
+        std::ifstream maps("/proc/" + std::to_string(mProcess->pid) + "/maps");
+        if(!maps)
         {
             std::lock_guard lock(mapMutex);
             memoryMap.clear();
             return;
         }
 
-        char line[512];
-        while(fgets(line, sizeof(line), f))
+        // Read whole lines: a maps pathname can be longer than any fixed buffer.
+        std::string line;
+        while(std::getline(maps, line))
         {
             uint64_t start = 0, end = 0;
             char perms[8] = {};
             int pathOffset = 0;
             // %n captures the byte offset after the fixed prefix so we can take the pathname verbatim (it may contain spaces).
-            if(sscanf(line, "%" SCNx64 "-%" SCNx64 " %4s %*x %*x:%*x %*u %n",
+            if(sscanf(line.c_str(), "%" SCNx64 "-%" SCNx64 " %4s %*x %*x:%*x %*u %n",
                       &start, &end, perms, &pathOffset) < 3)
                 continue;
 
             std::string pathname;
-            if(pathOffset > 0 && pathOffset < static_cast<int>(sizeof(line)))
+            if(pathOffset > 0 && pathOffset <= static_cast<int>(line.size()))
             {
-                const char* p = line + pathOffset;
+                const char* p = line.c_str() + pathOffset;
                 while(*p == ' ' || *p == '\t') ++p;
                 size_t len = strlen(p);
                 while(len > 0 && (p[len - 1] == '\n' || p[len - 1] == '\r' || p[len - 1] == ' '))
@@ -96,7 +96,10 @@ struct ElfBugDebugger : ElfBug::Debugger
             newMaps.push_back({start, end, perms[0] == 'r', perms[1] == 'w',
                                perms[2] == 'x', perms[3] == 's', std::move(pathname)});
         }
-        fclose(f);
+        // findRegion() binary-searches this, so keep it sorted by start address
+        // rather than relying on the kernel emitting /proc/<pid>/maps in order.
+        std::sort(newMaps.begin(), newMaps.end(),
+        [](const MemRegion & a, const MemRegion & b) { return a.start < b.start; });
 
         std::lock_guard lock(mapMutex);
         memoryMap = std::move(newMaps);

--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.h
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <sys/types.h>
 
 #ifdef __cplusplus
@@ -75,6 +76,24 @@ ELFBUG_EXPORT bool ElfBugMemWrite(const ElfBugDebugger* dbg, uint64_t addr, cons
 ELFBUG_EXPORT bool ElfBugMemFindBaseAddr(const ElfBugDebugger* dbg, uint64_t addr, uint64_t* base, uint64_t* size);
 ELFBUG_EXPORT bool ElfBugMemIsCodePtr(const ElfBugDebugger* dbg, uint64_t addr);
 ELFBUG_EXPORT bool ElfBugMemIsValidPtr(const ElfBugDebugger* dbg, uint64_t addr);
+
+#define ELFBUG_MAX_PATH 4096
+
+// One region from /proc/<pid>/maps (snapshot refreshed on every stop).
+typedef struct
+{
+    uint64_t start;
+    uint64_t end;
+    bool read;
+    bool write;
+    bool execute;
+    bool shared;                // true = shared ('s'), false = private ('p')
+    char path[ELFBUG_MAX_PATH]; // empty for anonymous/[heap]/[stack]/... regions
+} ElfBugMemRegion;
+
+// Copies up to `maxCount` address-ordered regions into `out` (pass null to query
+// the count) and returns the total number of regions in the map.
+ELFBUG_EXPORT size_t ElfBugGetMemoryMap(const ElfBugDebugger* dbg, ElfBugMemRegion* out, size_t maxCount);
 
 // Lowest mapped start address of the module containing `addr`, or 0 if the
 // region is anonymous (heap/stack/vdso/etc).

--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.h
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.h
@@ -91,8 +91,8 @@ typedef struct
     char path[ELFBUG_MAX_PATH]; // empty for anonymous/[heap]/[stack]/... regions
 } ElfBugMemRegion;
 
-// Copies up to `maxCount` address-ordered regions into `out` (pass null to query
-// the count) and returns the total number of regions in the map.
+// Copies up to `maxCount` regions into `out` (pass null to query the count) and
+// returns the total number of regions in the map. Regions are sorted by start address.
 ELFBUG_EXPORT size_t ElfBugGetMemoryMap(const ElfBugDebugger* dbg, ElfBugMemRegion* out, size_t maxCount);
 
 // Lowest mapped start address of the module containing `addr`, or 0 if the

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -1,14 +1,22 @@
 #include <catch2/catch_test_macros.hpp>
 #include "TestHarness.h"
 #include "SymbolHelper.h"
+#include <ElfBug/api/elfbug_api.h>
 #include <string>
 #include <chrono>
+#include <cinttypes>
+#include <condition_variable>
 #include <csignal>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
 #include <future>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <thread>
+#include <vector>
 #include <unistd.h>
 
 #define FIXTURE(name) (std::string(ELFBUG_TESTS_TARGETS_DIR "/") + (name))
@@ -54,6 +62,53 @@ namespace
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
         return false;
+    }
+
+    // Reference parse of /proc/<pid>/maps, normalized the same way the engine
+    // normalizes pathnames, so an exact line-by-line comparison is meaningful.
+    std::vector<ElfBugMemRegion> ParseProcMaps(const pid_t pid)
+    {
+        std::vector<ElfBugMemRegion> out;
+        std::ifstream f("/proc/" + std::to_string(pid) + "/maps");
+        std::string line;
+        while(std::getline(f, line))
+        {
+            uint64_t start = 0, end = 0;
+            char perms[8] = {};
+            int pathOffset = 0;
+            if(sscanf(line.c_str(), "%" SCNx64 "-%" SCNx64 " %4s %*x %*x:%*x %*u %n",
+                      &start, &end, perms, &pathOffset) < 3)
+                continue;
+
+            ElfBugMemRegion r{};
+            r.start = start;
+            r.end = end;
+            r.read = perms[0] == 'r';
+            r.write = perms[1] == 'w';
+            r.execute = perms[2] == 'x';
+            r.shared = perms[3] == 's';
+
+            std::string pathname;
+            if(pathOffset > 0 && pathOffset < static_cast<int>(line.size()))
+            {
+                const char* p = line.c_str() + pathOffset;
+                while(*p == ' ' || *p == '\t') ++p;
+                size_t len = strlen(p);
+                while(len > 0 && (p[len - 1] == '\n' || p[len - 1] == '\r' || p[len - 1] == ' '))
+                    --len;
+                if(len > 0 && p[0] != '[')
+                    pathname.assign(p, len);
+
+                const std::string deletedSuffix = " (deleted)";
+                if(pathname.size() >= deletedSuffix.size() &&
+                        pathname.compare(pathname.size() - deletedSuffix.size(), deletedSuffix.size(), deletedSuffix) == 0)
+                    pathname.resize(pathname.size() - deletedSuffix.size());
+            }
+
+            std::snprintf(r.path, sizeof(r.path), "%s", pathname.c_str());
+            out.push_back(r);
+        }
+        return out;
     }
 }
 
@@ -476,4 +531,87 @@ TEST_CASE("Reuse Debugger instance after exit", "[init]")
     REQUIRE(dbg.count(EventType::ExitProcess) == 2);
     REQUIRE(dbg.count(EventType::SystemBreakpoint) == 2);
     REQUIRE(dbg.count(EventType::InternalError) == 0);
+}
+
+TEST_CASE("Memory map matches /proc/<pid>/maps with permissions", "[memmap]")
+{
+    struct MemMapSync
+    {
+        std::mutex m;
+        std::condition_variable cv;
+        bool systemBreakpoint = false;
+    } sync;
+
+    ElfBugCallbacks cb = {};
+    cb.userdata = &sync;
+    cb.onSystemBreakpoint = [](void* userdata)
+    {
+        auto* s = static_cast<MemMapSync*>(userdata);
+        {
+            std::lock_guard<std::mutex> lock(s->m);
+            s->systemBreakpoint = true;
+        }
+        s->cv.notify_all();
+    };
+
+    ElfBugDebugger* dbg = ElfBugCreate(&cb);
+    REQUIRE(dbg != nullptr);
+    REQUIRE(ElfBugInit(dbg, FIXTURE("hello_elfbug").c_str()));
+
+    std::thread loop([&] { ElfBugStart(dbg); });
+
+    {
+        std::unique_lock<std::mutex> lock(sync.m);
+        REQUIRE(sync.cv.wait_for(lock, std::chrono::seconds(5),
+                                 [&] { return sync.systemBreakpoint; }));
+    }
+
+    // The tracee is stopped at the system breakpoint, so its maps cannot change
+    // between the engine's snapshot and our own read of /proc below.
+    const pid_t pid = ElfBugGetPid(dbg);
+    REQUIRE(pid > 0);
+
+    const size_t count = ElfBugGetMemoryMap(dbg, nullptr, 0);
+    REQUIRE(count > 0);
+
+    std::vector<ElfBugMemRegion> regions(count);
+    REQUIRE(ElfBugGetMemoryMap(dbg, regions.data(), regions.size()) == count);
+
+    const auto expected = ParseProcMaps(pid);
+    REQUIRE(regions.size() == expected.size());
+
+    bool sawExecutable = false;
+    bool sawWritable = false;
+    bool sawFixture = false;
+    for(size_t i = 0; i < regions.size(); ++i)
+    {
+        INFO("region " << i);
+        REQUIRE(regions[i].start == expected[i].start);
+        REQUIRE(regions[i].end == expected[i].end);
+        REQUIRE(regions[i].read == expected[i].read);
+        REQUIRE(regions[i].write == expected[i].write);
+        REQUIRE(regions[i].execute == expected[i].execute);
+        REQUIRE(regions[i].shared == expected[i].shared);
+        REQUIRE(std::string(regions[i].path) == std::string(expected[i].path));
+
+        sawExecutable = sawExecutable || regions[i].execute;
+        sawWritable = sawWritable || regions[i].write;
+        sawFixture = sawFixture || std::string(regions[i].path).find("hello_elfbug") != std::string::npos;
+    }
+    REQUIRE(sawExecutable);
+    REQUIRE(sawWritable);
+    REQUIRE(sawFixture);
+
+    // Capacity contract: a short buffer still reports the full total and fills only what fits.
+    std::vector<ElfBugMemRegion> partial(1);
+    REQUIRE(ElfBugGetMemoryMap(dbg, partial.data(), partial.size()) == count);
+    REQUIRE(partial[0].start == regions[0].start);
+
+    ElfBugContinue(dbg);
+    loop.join();
+
+    // The map is cleared once the inferior exits.
+    REQUIRE(ElfBugGetMemoryMap(dbg, nullptr, 0) == 0);
+
+    ElfBugDestroy(dbg);
 }

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <optional>
 #include <set>
+#include <sstream>
 #include <thread>
 #include <vector>
 #include <unistd.h>
@@ -64,51 +65,65 @@ namespace
         return false;
     }
 
-    // Reference parse of /proc/<pid>/maps, normalized the same way the engine
-    // normalizes pathnames, so an exact line-by-line comparison is meaningful.
-    std::vector<ElfBugMemRegion> ParseProcMaps(const pid_t pid)
+    struct RawMapsLine
     {
-        std::vector<ElfBugMemRegion> out;
+        uint64_t start = 0;
+        uint64_t end = 0;
+        bool read = false, write = false, execute = false, shared = false;
+        std::string rawPath; // exactly as the kernel printed it, no normalization
+    };
+
+    // Independent reference parser for /proc/<pid>/maps. It deliberately shares
+    // neither code nor technique with the engine's refreshMemoryMap: it splits
+    // the line into raw whitespace fields and parses each by hand (no sscanf/%n),
+    // so a bug in the engine's field extraction shows up as a mismatch instead of
+    // being reproduced identically on both sides.
+    std::vector<RawMapsLine> ParseProcMapsRaw(const pid_t pid)
+    {
+        std::vector<RawMapsLine> out;
         std::ifstream f("/proc/" + std::to_string(pid) + "/maps");
         std::string line;
         while(std::getline(f, line))
         {
-            uint64_t start = 0, end = 0;
-            char perms[8] = {};
-            int pathOffset = 0;
-            if(sscanf(line.c_str(), "%" SCNx64 "-%" SCNx64 " %4s %*x %*x:%*x %*u %n",
-                      &start, &end, perms, &pathOffset) < 3)
+            std::istringstream iss(line);
+            std::string range, perms, offset, dev, inode;
+            if(!(iss >> range >> perms >> offset >> dev >> inode))
                 continue;
 
-            ElfBugMemRegion r{};
-            r.start = start;
-            r.end = end;
-            r.read = perms[0] == 'r';
-            r.write = perms[1] == 'w';
-            r.execute = perms[2] == 'x';
-            r.shared = perms[3] == 's';
+            const auto dash = range.find('-');
+            if(dash == std::string::npos)
+                continue;
 
-            std::string pathname;
-            if(pathOffset > 0 && pathOffset < static_cast<int>(line.size()))
-            {
-                const char* p = line.c_str() + pathOffset;
-                while(*p == ' ' || *p == '\t') ++p;
-                size_t len = strlen(p);
-                while(len > 0 && (p[len - 1] == '\n' || p[len - 1] == '\r' || p[len - 1] == ' '))
-                    --len;
-                if(len > 0 && p[0] != '[')
-                    pathname.assign(p, len);
+            RawMapsLine r;
+            r.start = std::stoull(range.substr(0, dash), nullptr, 16);
+            r.end = std::stoull(range.substr(dash + 1), nullptr, 16);
+            r.read = perms.size() > 0 && perms[0] == 'r';
+            r.write = perms.size() > 1 && perms[1] == 'w';
+            r.execute = perms.size() > 2 && perms[2] == 'x';
+            r.shared = perms.size() > 3 && perms[3] == 's';
 
-                const std::string deletedSuffix = " (deleted)";
-                if(pathname.size() >= deletedSuffix.size() &&
-                        pathname.compare(pathname.size() - deletedSuffix.size(), deletedSuffix.size(), deletedSuffix) == 0)
-                    pathname.resize(pathname.size() - deletedSuffix.size());
-            }
-
-            std::snprintf(r.path, sizeof(r.path), "%s", pathname.c_str());
+            // The pathname is the remainder after the five fixed fields; it may
+            // contain spaces, so take everything past the inode column verbatim.
+            std::getline(iss >> std::ws, r.rawPath);
             out.push_back(r);
         }
         return out;
+    }
+
+    // The engine's documented path contract, applied to a raw kernel pathname:
+    // bracketed pseudo-paths ([heap]/[stack]/[vdso]/...) and anonymous regions
+    // report an empty path, and a trailing " (deleted)" marker is stripped.
+    std::string ExpectedEnginePath(const std::string & rawPath)
+    {
+        if(rawPath.empty() || rawPath.front() == '[')
+            return "";
+
+        const std::string deleted = " (deleted)";
+        if(rawPath.size() >= deleted.size() &&
+                rawPath.compare(rawPath.size() - deleted.size(), deleted.size(), deleted) == 0)
+            return rawPath.substr(0, rawPath.size() - deleted.size());
+
+        return rawPath;
     }
 }
 
@@ -577,7 +592,7 @@ TEST_CASE("Memory map matches /proc/<pid>/maps with permissions", "[memmap]")
     std::vector<ElfBugMemRegion> regions(count);
     REQUIRE(ElfBugGetMemoryMap(dbg, regions.data(), regions.size()) == count);
 
-    const auto expected = ParseProcMaps(pid);
+    const auto expected = ParseProcMapsRaw(pid);
     REQUIRE(regions.size() == expected.size());
 
     bool sawExecutable = false;
@@ -592,7 +607,7 @@ TEST_CASE("Memory map matches /proc/<pid>/maps with permissions", "[memmap]")
         REQUIRE(regions[i].write == expected[i].write);
         REQUIRE(regions[i].execute == expected[i].execute);
         REQUIRE(regions[i].shared == expected[i].shared);
-        REQUIRE(std::string(regions[i].path) == std::string(expected[i].path));
+        REQUIRE(std::string(regions[i].path) == ExpectedEnginePath(expected[i].rawPath));
 
         sawExecutable = sawExecutable || regions[i].execute;
         sawWritable = sawWritable || regions[i].write;


### PR DESCRIPTION
## Summary

The Linux port's Memory Map feature needs the process memory layout from the engine, but ElfBug only exposed whether a region was executable. It already parsed `/proc/<pid>/maps` internally on every stop, yet kept a single `executable` bool per region and offered no way to read the list back out.

This extends the engine's internal region records to capture the full `rwxp` permissions (read/write/execute plus shared/private) and adds `ElfBugGetMemoryMap` to the C API, which copies the address-ordered region list (start, end, permissions, pathname) across the C ABI. It is the engine layer of the Memory Map vertical slice; the adapter, the Bridge shim, and the MemoryMapView widget build on top of it.

Decisions worth calling out:

- **Two-call count contract.** `ElfBugGetMemoryMap` returns the total region count and fills up to a caller-supplied capacity, with a null buffer to query the count first. This mirrors the out-parameter style of the surrounding C API and lets a caller size its buffer without guessing.
- **Fixed pathname buffer.** Each region carries its pathname inline in a fixed `char[ELFBUG_MAX_PATH]`, keeping the result a flat POD array with no ownership or lifetime concerns across the ABI.

The new Catch2 test drives the C API against a live fixture and checks the returned regions line-by-line against an independent parse of `/proc/<pid>/maps` (addresses, r/w/x and shared/private flags, pathname), plus the capacity-truncation and post-exit-cleared behavior.
