### PR TITLE
Fix #2575: Track patches from Fill/memset command

### DIFF
--- a/src/dbg/commands/cmd-memory-operations.cpp
+++ b/src/dbg/commands/cmd-memory-operations.cpp
@@ -14,11 +14,17 @@ static bool FillDebugMemory(duint addr, duint size, uint8_t value)
     if(size == 0)
         return true;
 
+    constexpr duint patchTrackThreshold = 0x100;
+    const bool trackPatches = size <= patchTrackThreshold;
+
     std::vector<uint8_t> buffer(std::min<duint>(size, PAGE_SIZE), value);
     for(duint offset = 0; offset < size; offset += buffer.size())
     {
         const auto chunkSize = std::min<duint>(duint(buffer.size()), size - offset);
-        if(!MemWrite(addr + offset, buffer.data(), chunkSize))
+        const bool ok = trackPatches
+                        ? MemPatch(addr + offset, buffer.data(), chunkSize)
+                        : MemWrite(addr + offset, buffer.data(), chunkSize);
+        if(!ok)
             return false;
     }
     return true;


### PR DESCRIPTION
Fixes #2575.

`FillDebugMemory` calls `MemWrite` directly, so bytes written via the `Fill`/`memset` command are not registered with `PatchSet` and never show up in the Patches view. The GUI `Binary -> Fill` already goes through `MemPatch` via `MemoryPage::write`, this just brings the command path in line.

Introduced in 9a1fe10a ("Move Fill out of TitanEngine").

Verified locally: before, `Fill cip, 90, 10` leaves the Patches view empty; after, it shows 16 entries.