### PR TITLE
Disable linker manifest generation for exe and launcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -993,6 +993,7 @@ endif()
 
 if(MSVC) # msvc
 	target_link_options(exe PRIVATE
+		"/MANIFEST:NO"
 		"/DELAYLOAD:user32.dll"
 		"/DELAYLOAD:wintrust.dll"
 		"/DELAYLOAD:$<TARGET_FILE_NAME:bridge>"
@@ -1154,6 +1155,12 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 4) # x86
 		Shlwapi
 		Comctl32
 	)
+
+	if(MSVC) # msvc
+		target_link_options(launcher PRIVATE
+			"/MANIFEST:NO"
+		)
+	endif()
 
 	set_target_properties(launcher PROPERTIES
 		MSVC_RUNTIME_LIBRARY

--- a/cmake.toml
+++ b/cmake.toml
@@ -201,6 +201,9 @@ link-libraries = [
     "Wintrust",
 ]
 msvc.link-options = [
+    # resource.rc already embeds manifest.xml as RT_MANIFEST, so disable the
+    # linker's default manifest to avoid embedding a second one.
+    "/MANIFEST:NO",
     "/DELAYLOAD:user32.dll",
     "/DELAYLOAD:wintrust.dll",
     "/DELAYLOAD:$<TARGET_FILE_NAME:bridge>",
@@ -275,6 +278,11 @@ sources = [
     "src/exe/icon.rc",
     "src/exe/resource.rc",
     "src/exe/strings_utf8.rc",
+]
+msvc.link-options = [
+    # resource.rc already embeds manifest.xml as RT_MANIFEST, so disable the
+    # linker's default manifest to avoid embedding a second one.
+    "/MANIFEST:NO",
 ]
 link-libraries = [
     "Shlwapi",


### PR DESCRIPTION
The non-UTF-8 fix from https://github.com/x64dbg/x64dbg/pull/3887.

---

resource.rc already embeds manifest.xml as an RT_MANIFEST resource. With the MSVC linker's default manifest generation left on, the linker embeds its own minimal manifest too, producing two RT_MANIFEST resources in the PE (the rich rc one at language 0 and the linker default at language 1033). They coexist because resource identity is (type, name, language).

The old Visual Studio projects suppressed this via GenerateManifest=false (commit a339dd2d), but that setting was lost when the projects were removed in favor of CMake (commit df110dc0). Restore it by adding /MANIFEST:NO to the link options of the two targets that embed the manifest, so only the resource.rc manifest is kept.