### PR TITLE
Fix #3862: Copy stack argument values

### DIFF
--- a/src/gui/Src/Gui/CPUArgumentWidget.cpp
+++ b/src/gui/Src/Gui/CPUArgumentWidget.cpp
@@ -99,10 +99,11 @@ void CPUArgumentWidget::refreshData()
         duint argOffset = mStackOffset + i * sizeof(duint);
         QString expr = argOffset ? QString("%1+%2").arg(stackLocation).arg(ToHexString(argOffset)) : stackLocation;
 
-        QString format = defaultArgFormat("", QString("[%1]").arg(expr));
+        QString valueExpr = QString("[%1]").arg(expr);
+        QString format = defaultArgFormat("", valueExpr);
         auto data = StringFormatInline(format);
         auto text = defaultArgFieldFormat(defaultArgName("", argCount + i + 1), data);
-        mArgumentValues.push_back(DbgValFromString(expr.toUtf8().constData()));
+        mArgumentValues.push_back(DbgValFromString(valueExpr.toUtf8().constData()));
         mTable->setCellContent(argCount + i, 0, text);
     }
 


### PR DESCRIPTION
Fixes #3862.

Summary:
- Use the same dereferenced stack argument expression for the stored argument value that the widget displays.
- Makes Copy Value copy the value at `[rsp+offset]` instead of the stack slot address.

Checks:
- `/tmp/x64dbg-format-venv/bin/python .github/format/AStyleHelper.py Check`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- src/gui/Src/Gui/CPUArgumentWidget.cpp`