### PR TITLE
fix: the pe file parser reads size_image and virtual... in...

### DIFF
--- a/src/cross/minidump/FileParser.cpp
+++ b/src/cross/minidump/FileParser.cpp
@@ -354,6 +354,8 @@ struct PeFileParser : FileParser, MemoryProvider
                 sectionAlignment = PAGE_SIZE;
             mImageBase = pnth->optional_header.image_base;
             mSizeOfImage = ROUND_TO_PAGES(pnth->optional_header.size_image); // TODO: shouldn't this be regions?
+            if(mSizeOfImage > 0x80000000ULL)
+                mSizeOfImage = 0;
             mEntryPoint = pnth->optional_header.entry_point;
             if(mEntryPoint > 0 || !pnth->file_header.characteristics.dll_file)
                 mEntryPoint += mImageBase;
@@ -403,9 +405,12 @@ struct PeFileParser : FileParser, MemoryProvider
                 if(i + 1 == pnth->file_header.num_sections && sectionAlignment < PAGE_SIZE)
                 {
                     auto totalSize = s.addr + s.size;
-                    totalSize -= mImageBase;
-                    if(mSizeOfImage > totalSize)
-                        s.size += mSizeOfImage - totalSize;
+                    if(totalSize >= mImageBase)
+                    {
+                        totalSize -= mImageBase;
+                        if(mSizeOfImage > totalSize)
+                            s.size += mSizeOfImage - totalSize;
+                    }
                 }
 
                 // TODO: check alignment


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/cross/minidump/FileParser.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/cross/minidump/FileParser.cpp:247` |
| **Assessment** | Likely exploitable |

**Description**: The PE file parser reads size_image and virtual_size directly from PE file headers without validating them against reasonable bounds. A crafted PE file can specify extremely large values for these fields. While the ROUND_TO_PAGES macro uses uint64_t, subsequent arithmetic operations (s.addr + s.size, totalSize -= mImageBase) can overflow or produce unexpected values when combined with a crafted ImageBase. The section size calculation uses these unchecked values to determine memory regions for read operations, potentially allowing out-of-bounds reads.

## Evidence

**Exploitation scenario**: An attacker crafts a PE file with malicious optional_header.size_image value (e.g., 0xFFFFFFFF) and section virtual_size values near UINT32_MAX.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `src/cross/minidump/FileParser.cpp`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
