### PR TITLE
Fix run trace desync when thread id is written without blockFlags 0x80

### DIFF
--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -330,9 +330,10 @@ void TraceRecordManager::TraceExecuteRecord(const Zydis & newInstruction)
             if(rtOldContext.regword[i] != newContext.regword[i] || rtOldContextChanged[i] || ((rtRecordedInstructions - 1) % MAX_INSTRUCTIONS_TRACED_FULL_REG_DUMP == 0))
                 changed++;
         }
-        unsigned char blockFlags = 0;
-        if(newThreadId != rtOldThreadId || ((rtRecordedInstructions - 1) % MAX_INSTRUCTIONS_TRACED_FULL_REG_DUMP == 0))
-            blockFlags = 0x80;
+        const bool writeThreadId = newThreadId != rtOldThreadId
+            || rtNeedThreadId
+            || ((rtRecordedInstructions - 1) % MAX_INSTRUCTIONS_TRACED_FULL_REG_DUMP == 0);
+        unsigned char blockFlags = writeThreadId ? 0x80 : 0;
         blockFlags |= rtOldOpcodeSize;
 
         unsigned char blockType = 0;
@@ -341,7 +342,7 @@ void TraceRecordManager::TraceExecuteRecord(const Zydis & newInstruction)
         WriteBufferPtr[2] = rtOldMemoryArrayCount; //1byte: memory accesses count
         WriteBufferPtr[3] = blockFlags; //1byte: flags and opcode size
         WriteBufferPtr += 4;
-        if(newThreadId != rtOldThreadId || rtNeedThreadId || ((rtRecordedInstructions - 1) % MAX_INSTRUCTIONS_TRACED_FULL_REG_DUMP == 0))
+        if(writeThreadId)
         {
             memcpy(WriteBufferPtr, &rtOldThreadId, sizeof(rtOldThreadId));
             WriteBufferPtr += sizeof(rtOldThreadId);

--- a/src/dbg/TraceRecord.cpp
+++ b/src/dbg/TraceRecord.cpp
@@ -331,8 +331,8 @@ void TraceRecordManager::TraceExecuteRecord(const Zydis & newInstruction)
                 changed++;
         }
         const bool writeThreadId = newThreadId != rtOldThreadId
-            || rtNeedThreadId
-            || ((rtRecordedInstructions - 1) % MAX_INSTRUCTIONS_TRACED_FULL_REG_DUMP == 0);
+                                   || rtNeedThreadId
+                                   || ((rtRecordedInstructions - 1) % MAX_INSTRUCTIONS_TRACED_FULL_REG_DUMP == 0);
         unsigned char blockFlags = writeThreadId ? 0x80 : 0;
         blockFlags |= rtOldOpcodeSize;
 


### PR DESCRIPTION
In run-trace recording, `blockFlags` bit `0x80` must match whether a thread id payload is written. Previously the flag ignored `rtNeedThreadId` while the write path did not, so the instruction after a thread switch wrote a tid with no `0x80` bit and desynced every reader (seen as RegisterChangePosition overflow / bad block type).

Reproduced trace: [20260730-151202.trace32.txt](https://github.com/user-attachments/files/30551358/20260730-151202.trace32.txt). (Added .txt extension due to github restriction)

Unify both checks behind a single `writeThreadId` condition in `TraceRecordManager::TraceExecuteRecord`.