### PR TITLE
Fix command argument escaping and GUI round trips

### DIFF
--- a/docs/commands/conditional-breakpoint-control/SetBreakpointCondition.md
+++ b/docs/commands/conditional-breakpoint-control/SetBreakpointCondition.md
@@ -6,7 +6,11 @@ Sets the software breakpoint condition. When this condition is set, it is evalua
 
 `arg1` The address of the breakpoint.
 
-`[arg2]` The condition expression.
+`[arg2]` The condition expression. Quote and escape the command argument when the expression contains commas or string literals. For example, the following condition compares against a path ending in a backslash:
+
+```
+SetBreakpointCondition 401000, "streq(utf8(rax), \"C:\directory\\\")"
+```
 
 ## result
 

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -1,17 +1,69 @@
 Commands
 ========
 
-Commands have the following format (notice the arguments are **comma separated**):
+Syntax
+------
+
+Commands have the following format:
 
 ``command arg1, arg2, argN``
 
-FAQ:
+The first space separates the command name from its arguments. Commas, not spaces, separate arguments. Spaces outside quoted arguments are ignored, so ``log hello world`` passes ``helloworld`` as one argument. A semicolon separates multiple commands unless it appears inside a quoted argument.
 
-- Please note that all integer constants are represented in hex. For example, after executing the following command, ``$i`` will be 256 (0x100): ``mov $i, 100`` . This also means a variable cannot begin with letters from A to F.
-- Throughout this documentation, ``[arg1]`` (argument with a square bracket) represents an optional argument. ``arg1`` (argument without a square bracket) represents an mandatory argument. "[" and "]" represent memory reference operation in expression evaluation for the argument. If you don't want to refer to the content in the memory pointer, don't add "[" and "]".
-- For commands with two or more arguments, a comma (,) is used to separate these arguments. Do not use a space to separate the arguments.
-- x64dbg only supports integer in expressions. Strings, Floating point numbers and SSE/AVX data is not supported. Therefore you cannot use ``[eax]=="abcd"`` operator to compare strings. Instead, you can compare the first DWORD/QWORD of the string, or use an appropriate plugin which provides such feature.
-- The "==" operator is used to test if both operands are equal. The "=" operator is used to transfer the value of the expression to the destination.
+For example:
+
+.. code-block:: text
+
+   savedata "C:\Program Files\dump.bin", 401000, 1000
+
+Quoted arguments
+----------------
+
+Wrap an argument in double quotes when it contains commas, semicolons, or significant spaces. The surrounding quotes group the argument and are not passed to the command itself. Backslashes before ordinary characters are preserved verbatim, so Windows path separators and UNC paths do not need to be doubled.
+
+When a command argument contains an expression with commas or string literals, quote the complete command argument and escape the expression's quotes:
+
+.. code-block:: text
+
+   SetBreakpointCondition 401000, "streq(utf8(rax), \"hello\")"
+
+The outer quotes keep the condition together as one command argument. Each ``\"`` becomes a literal quote in the condition passed to the expression parser.
+
+Escaping special characters
+---------------------------
+
+Outside a quoted argument, a backslash can escape a space, comma, or double quote. For example, ``one\ two`` is passed as ``one two`` and ``one\,two`` is passed as ``one,two``.
+
+Inside a quoted argument:
+
+- ``\"`` produces a literal double quote.
+- ``\{`` produces a literal opening brace without entering string-formatting mode.
+- A backslash before any other character is preserved, for example ``C:\data\file.db``.
+
+Runs of backslashes immediately before a double quote follow the Windows quoting rule:
+
+- ``2N`` backslashes produce ``N`` literal backslashes, and the quote ends the quoted section.
+- ``2N+1`` backslashes produce ``N`` literal backslashes followed by a literal quote.
+
+Consequently, a quoted argument ending in ``C:\directory\`` is written as ``"C:\directory\\"``. A literal backslash followed by a literal quote is written as ``\\\"`` inside the quoted argument.
+
+String formatting
+-----------------
+
+An unescaped ``{`` inside a quoted argument starts a :doc:`string-formatting expression <../introduction/Formatting>`. Quotes inside the formatting expression remain part of that expression until its matching ``}``, which permits commands such as:
+
+.. code-block:: text
+
+   log "is jmp: {streq(dis.mnemonic(dis.sel()), "jmp")}"
+
+Use ``\{`` when the opening brace should be literal instead. Runs of backslashes before ``{`` use the same even/odd rule as backslashes before a quote: an even run enters formatting mode, while an odd run makes the brace literal.
+
+Notes
+-----
+
+- All integer constants are represented in hexadecimal. For example, after ``mov $i, 100``, ``$i`` is 0x100 (256 decimal). This also means a variable cannot begin with a letter from A through F.
+- Throughout this documentation, ``[arg1]`` means that an argument is optional, while ``arg1`` means it is required. In expressions, ``[`` and ``]`` perform a memory dereference; omit them when the pointer value itself is wanted.
+- Expressions do not support string comparison through numeric operators such as ``[eax] == "abcd"``. Use the appropriate :doc:`string expression function <../introduction/Expression-functions>` instead.
 
 **Contents:**
 

--- a/src/dbg/_dbgfunctions.cpp
+++ b/src/dbg/_dbgfunctions.cpp
@@ -33,6 +33,7 @@
 #include "dbghelp_safe.h"
 #include "types.h"
 #include "label.h"
+#include "commandparser.h"
 
 static DBGFUNCTIONS _dbgfunctions;
 
@@ -564,5 +565,15 @@ void dbgfunctionsinit()
     _dbgfunctions.BpSetFieldText = [](const BP_REF * ref, BP_FIELD field, const char* value)
     {
         return BpSetFieldText(*ref, field, value);
+    };
+    _dbgfunctions.CommandEscape = [](const char* argument, char* result, size_t resultSize)
+    {
+        if(argument == nullptr || result == nullptr)
+            return false;
+        auto escaped = Command::Escape(argument);
+        if(resultSize <= escaped.size())
+            return false;
+        memcpy(result, escaped.c_str(), escaped.size() + 1);
+        return true;
     };
 }

--- a/src/dbg/_dbgfunctions.h
+++ b/src/dbg/_dbgfunctions.h
@@ -283,6 +283,8 @@ typedef struct DBGFUNCTIONS_
     bool (*BpSetFieldNumber)(const BP_REF* ref, BP_FIELD field, duint value);
     bool (*BpGetFieldText)(const BP_REF* ref, BP_FIELD field, CBSTRING callback, void* userdata);
     bool (*BpSetFieldText)(const BP_REF* ref, BP_FIELD field, const char* value);
+    // Escapes argument contents for insertion between double quotes in a debugger command.
+    bool (*CommandEscape)(const char* argument, char* result, size_t resultSize);
 } DBGFUNCTIONS;
 
 #ifdef __cplusplus

--- a/src/dbg/commandparser.cpp
+++ b/src/dbg/commandparser.cpp
@@ -4,6 +4,11 @@ Command::Command(const String & command)
 {
     ParseState state = Default;
     int len = (int)command.length();
+    auto appendBackslashes = [this](int count)
+    {
+        while(count-- > 0)
+            dataAppend('\\');
+    };
     for(int i = 0; i < len; i++)
     {
         char ch = command[i];
@@ -21,8 +26,52 @@ Command::Command(const String & command)
                 dataFinish();
                 break;
             case '\\':
-                state = Escaped;
+            {
+                int slashCount = 1;
+                while(i + slashCount < len && command[i + slashCount] == '\\')
+                    slashCount++;
+                auto nextch = i + slashCount < len ? command[i + slashCount] : '\0';
+                if(nextch == '\"')
+                {
+                    appendBackslashes(slashCount / 2);
+                    i += slashCount; // Also consume nextch.
+                    if(slashCount % 2)
+                        dataAppend(nextch);
+                    else
+                        state = Text;
+                }
+                else
+                {
+                    // Preserve the legacy escape behavior for spaces, commas and ordinary characters.
+                    appendBackslashes(slashCount / 2 * 2);
+                    if(slashCount % 2 == 0)
+                        i += slashCount - 1;
+                    else if(nextch == '\0')
+                    {
+                        dataAppend('\\');
+                        i += slashCount - 1;
+                    }
+                    else
+                    {
+                        i += slashCount; // Also consume nextch.
+                        switch(nextch)
+                        {
+                        case '\t':
+                        case ' ':
+                            dataAppend(' ');
+                            break;
+                        case ',':
+                            dataAppend(nextch);
+                            break;
+                        default:
+                            dataAppend('\\');
+                            dataAppend(nextch);
+                            break;
+                        }
+                    }
+                }
                 break;
+            }
             case '\"':
                 state = Text;
                 break;
@@ -31,32 +80,37 @@ Command::Command(const String & command)
                 break;
             }
             break;
-        case Escaped:
-            switch(ch)
-            {
-            case '\t':
-            case ' ':
-                dataAppend(' ');
-                break;
-            case ',':
-                dataAppend(ch);
-                break;
-            case '\"':
-                dataAppend(ch);
-                break;
-            default:
-                dataAppend('\\');
-                dataAppend(ch);
-                break;
-            }
-            state = Default;
-            break;
         case Text:
             switch(ch)
             {
             case '\\':
-                state = TextEscaped;
+            {
+                int slashCount = 1;
+                while(i + slashCount < len && command[i + slashCount] == '\\')
+                    slashCount++;
+                auto nextch = i + slashCount < len ? command[i + slashCount] : '\0';
+                if(nextch == '\"' || nextch == '{')
+                {
+                    appendBackslashes(slashCount / 2);
+                    i += slashCount; // Also consume nextch.
+                    if(nextch == '{')
+                    {
+                        dataAppend(nextch);
+                        if(slashCount % 2 == 0)
+                            state = StringFormat;
+                    }
+                    else if(slashCount % 2)
+                        dataAppend(nextch);
+                    else
+                        state = Default;
+                }
+                else
+                {
+                    appendBackslashes(slashCount);
+                    i += slashCount - 1;
+                }
                 break;
+            }
             case '\"':
                 state = Default;
                 break;
@@ -68,22 +122,6 @@ Command::Command(const String & command)
                 dataAppend(ch);
                 break;
             }
-            break;
-        case TextEscaped:
-            switch(ch)
-            {
-            case '\"':
-                dataAppend(ch);
-                break;
-            case '{':
-                dataAppend(ch);
-                break;
-            default:
-                dataAppend('\\');
-                dataAppend(ch);
-                break;
-            }
-            state = Text;
             break;
         case StringFormat:
         {
@@ -136,9 +174,52 @@ Command::Command(const String & command)
         break;
         }
     }
-    if(state == Escaped || state == TextEscaped)
-        dataAppend('\\');
     dataFinish();
+}
+
+String Command::Escape(const String & argument)
+{
+    String result;
+    result.reserve(argument.size() * 2 + 1);
+    auto appendBackslashes = [&result](size_t count)
+    {
+        result.append(count, '\\');
+    };
+
+    for(size_t i = 0; i < argument.size();)
+    {
+        auto ch = argument[i];
+        if(ch != '\\')
+        {
+            if(ch == '\"' || ch == '{')
+                result.push_back('\\');
+            result.push_back(ch);
+            i++;
+            continue;
+        }
+
+        auto slashStart = i;
+        while(i < argument.size() && argument[i] == '\\')
+            i++;
+        auto slashCount = i - slashStart;
+        if(i == argument.size())
+        {
+            // The caller adds the closing quote, so protect trailing slashes from it.
+            appendBackslashes(slashCount * 2);
+        }
+        else if(argument[i] == '\"' || argument[i] == '{')
+        {
+            // 2N+1 slashes decode to N slashes followed by a literal special character.
+            appendBackslashes(slashCount * 2 + 1);
+            result.push_back(argument[i++]);
+        }
+        else
+        {
+            // Backslashes before ordinary characters are always preserved verbatim.
+            appendBackslashes(slashCount);
+        }
+    }
+    return result;
 }
 
 const String Command::GetText()

--- a/src/dbg/commandparser.h
+++ b/src/dbg/commandparser.h
@@ -7,6 +7,7 @@ class Command
 {
 public:
     Command(const String & command);
+    static String Escape(const String & argument);
     const String GetText();
     const String GetArg(const int argnum);
     const int GetArgCount();
@@ -18,9 +19,7 @@ private:
     enum ParseState
     {
         Default,
-        Escaped,
         Text,
-        TextEscaped,
         StringFormat,
     };
 

--- a/src/gui/Src/Utils/StringUtil.cpp
+++ b/src/gui/Src/Utils/StringUtil.cpp
@@ -306,10 +306,18 @@ bool GetCommentFormat(duint addr, QString & comment, bool* autoComment)
 
 QString DbgCmdEscape(QString argument)
 {
-    // TODO: implement this properly
+    auto commandEscape = DbgFunctions()->CommandEscape;
+    if(commandEscape)
+    {
+        auto utf8 = argument.toUtf8();
+        QByteArray escaped(utf8.size() * 2 + 1, '\0');
+        if(commandEscape(utf8.constData(), escaped.data(), escaped.size()))
+            return QString::fromUtf8(escaped.constData());
+    }
+
+    // Compatibility fallback for partially initialized or mismatched components.
     argument.replace("\"", "\\\"");
     argument.replace("{", "\\{");
-
     return argument;
 }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -171,6 +171,7 @@ function(x64dbg_add_membp_test)
 endfunction()
 
 set(X64DBG_STANDARD_TESTS
+    commandparser
     issue3803
     issue3808
     issue3865

--- a/src/tests/commandparser/plugin.cpp
+++ b/src/tests/commandparser/plugin.cpp
@@ -1,0 +1,369 @@
+#include <Windows.h>
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "_plugins.h"
+#include "bridgemain.h"
+
+namespace
+{
+    int gPluginHandle = 0;
+    std::string gExpected;
+    std::vector<std::string> gExpectedArgs;
+
+    // Frozen copy of the parser from before issue #3921 was fixed. The
+    // differential tests below use it to identify accidental compatibility
+    // changes separately from the intentional backslash/quote changes.
+    std::vector<std::string> legacyParse(const std::string & command)
+    {
+        enum ParseState
+        {
+            Default,
+            Escaped,
+            Text,
+            TextEscaped,
+            StringFormat,
+        } state = Default;
+
+        std::vector<std::string> tokens;
+        std::string data;
+        auto finish = [&]()
+        {
+            tokens.push_back(data);
+            data.clear();
+        };
+
+        const auto len = (int)command.length();
+        for(int i = 0; i < len; i++)
+        {
+            const auto ch = command[i];
+            switch(state)
+            {
+            case Default:
+                switch(ch)
+                {
+                case '\t':
+                case ' ':
+                    if(tokens.empty())
+                        finish();
+                    break;
+                case ',':
+                    finish();
+                    break;
+                case '\\':
+                    state = Escaped;
+                    break;
+                case '\"':
+                    state = Text;
+                    break;
+                default:
+                    data += ch;
+                    break;
+                }
+                break;
+            case Escaped:
+                switch(ch)
+                {
+                case '\t':
+                case ' ':
+                    data += ' ';
+                    break;
+                case ',':
+                case '\"':
+                    data += ch;
+                    break;
+                default:
+                    data += '\\';
+                    data += ch;
+                    break;
+                }
+                state = Default;
+                break;
+            case Text:
+                switch(ch)
+                {
+                case '\\':
+                    state = TextEscaped;
+                    break;
+                case '\"':
+                    state = Default;
+                    break;
+                case '{':
+                    state = StringFormat;
+                    data += ch;
+                    break;
+                default:
+                    data += ch;
+                    break;
+                }
+                break;
+            case TextEscaped:
+                switch(ch)
+                {
+                case '\"':
+                case '{':
+                    data += ch;
+                    break;
+                default:
+                    data += '\\';
+                    data += ch;
+                    break;
+                }
+                state = Text;
+                break;
+            case StringFormat:
+            {
+                const auto nextch = i + 1 < len ? command[i + 1] : '\0';
+                switch(ch)
+                {
+                case '{':
+                    data += ch;
+                    if(nextch == '{')
+                        data += command[++i];
+                    break;
+                case '}':
+                    data += ch;
+                    if(nextch == '}')
+                        data += command[++i];
+                    else
+                        state = Text;
+                    break;
+                case '\\':
+                    if(nextch == '\"' || nextch == '\\')
+                        data += command[++i];
+                    else
+                        data += ch;
+                    break;
+                default:
+                    data += ch;
+                    break;
+                }
+                break;
+            }
+            }
+        }
+        if(state == Escaped || state == TextEscaped)
+            data += '\\';
+        finish();
+        return tokens;
+    }
+
+    bool cbCapture(int argc, char* argv[])
+    {
+        if(!_plugin_testassert(argc == 2, "commandparsercapture expected 1 argument, got %d", argc - 1))
+            return false;
+        return _plugin_testassert(gExpected == argv[1], "command parser round trip mismatch: expected '%s', got '%s'", gExpected.c_str(), argv[1]);
+    }
+
+    bool cbCompare(int argc, char* argv[])
+    {
+        bool success = _plugin_testassert((size_t)argc == gExpectedArgs.size(),
+                                          "differential argument count mismatch: expected %zu, got %d",
+                                          gExpectedArgs.size() - 1, argc - 1);
+        const auto count = std::min((size_t)argc, gExpectedArgs.size());
+        for(size_t i = 0; i < count; i++)
+        {
+            if(!_plugin_testassert(gExpectedArgs[i] == argv[i],
+                                   "differential mismatch at argv[%zu]: expected '%s', got '%s'",
+                                   i, gExpectedArgs[i].c_str(), argv[i]))
+                success = false;
+        }
+        return success;
+    }
+
+    bool dispatchAndCompare(const std::string & argumentText, const std::vector<std::string> & expected)
+    {
+        const auto command = std::string("commandparsercompare ") + argumentText;
+        gExpectedArgs = expected;
+        return _plugin_testassert(DbgCmdExecDirect(command.c_str()), "differential command failed: %s", command.c_str());
+    }
+
+    bool compareWithLegacy(const std::string & argumentText)
+    {
+        const auto command = std::string("commandparsercompare ") + argumentText;
+        auto expected = legacyParse(command);
+        expected[0] = command; // Command callbacks receive the original command in argv[0].
+        return dispatchAndCompare(argumentText, expected);
+    }
+
+    bool cbDifferential(int, char**)
+    {
+        const std::vector<std::string> compatibilityCorpus =
+        {
+            "plain",
+            "one,two,three",
+            R"(one\,two\ three)",
+            R"(C:\data\file.db)",
+            R"(\\server\share\file.exe)",
+            R"cmd("C:\Program Files\x64dbg\x64dbg.exe")cmd",
+            R"cmd("\\server\share with spaces\file.exe")cmd",
+            R"cmd("commas, semicolons; and spaces")cmd",
+            R"(mod.fromname(\"user32\") + 90B0)",
+            R"cmd("literal \{ brace")cmd",
+            R"cmd("is jmp: {streq(dis.mnemonic(dis.sel()), "jmp")}")cmd",
+            R"cmd("nested {ansi(rax), \"text\"}")cmd",
+        };
+        for(const auto & argumentText : compatibilityCorpus)
+            if(!compareWithLegacy(argumentText))
+                return false;
+
+        // Exercise legacy-compatible slash runs before ordinary characters,
+        // separators, whitespace, and the end of an unquoted argument.
+        for(size_t count = 0; count <= 6; count++)
+        {
+            const auto slashes = std::string(count, '\\');
+            if(!compareWithLegacy("before" + slashes + "x"))
+                return false;
+            if(!compareWithLegacy("before" + slashes + ",after"))
+                return false;
+            if(!compareWithLegacy("before" + slashes + " after"))
+                return false;
+            if(!compareWithLegacy("trailing" + slashes))
+                return false;
+            if(!compareWithLegacy("\"before" + slashes + "x after\""))
+                return false;
+        }
+
+        // These are intentional differences. First prove that the legacy
+        // parser does not produce the desired result, then check the new one.
+        const std::string issue3921 = R"cmd("streq(\"a\",\"C:\directory\\\")")cmd";
+        std::vector<std::string> issue3921Expected =
+        {
+            "commandparsercompare",
+            R"cmd(streq("a","C:\directory\"))cmd",
+        };
+        const auto issue3921Command = "commandparsercompare " + issue3921;
+        if(!_plugin_testassert(legacyParse(issue3921Command) != issue3921Expected,
+                               "issue #3921 unexpectedly matches the legacy parser"))
+            return false;
+        issue3921Expected[0] = issue3921Command;
+        if(!dispatchAndCompare(issue3921, issue3921Expected))
+            return false;
+
+        const std::string trailingSlash = R"cmd("C:\directory\\")cmd";
+        std::vector<std::string> trailingSlashExpected =
+        {
+            "commandparsercompare",
+            R"(C:\directory\)",
+        };
+        const auto trailingSlashCommand = "commandparsercompare " + trailingSlash;
+        if(!_plugin_testassert(legacyParse(trailingSlashCommand) != trailingSlashExpected,
+                               "quoted trailing slash unexpectedly matches the legacy parser"))
+            return false;
+        trailingSlashExpected[0] = trailingSlashCommand;
+        return dispatchAndCompare(trailingSlash, trailingSlashExpected);
+    }
+
+    bool roundTrip(const std::string & value)
+    {
+        auto commandEscape = DbgFunctions()->CommandEscape;
+        if(!_plugin_testassert(commandEscape != nullptr, "CommandEscape is unavailable"))
+            return false;
+
+        std::vector<char> escaped(value.size() * 2 + 1);
+        if(!_plugin_testassert(commandEscape(value.c_str(), escaped.data(), escaped.size()), "CommandEscape failed for '%s'", value.c_str()))
+            return false;
+
+        gExpected = value;
+        auto command = std::string("commandparsercapture \"") + escaped.data() + "\"";
+        return _plugin_testassert(DbgCmdExecDirect(command.c_str()), "round-trip command failed: %s", command.c_str());
+    }
+
+    bool cbRoundTrip(int, char**)
+    {
+        const std::vector<std::string> values =
+        {
+            "",
+            "plain",
+            "spaces, commas; and semicolons",
+            "streq(\"a\", \"b\")",
+            "C:\\data\\file.db",
+            "\\\\server\\share\\file.exe",
+            "C:\\directory\\",
+            "streq(\"a\", \"C:\\directory\\\")",
+            "streq(utf16(arg(0)),\"D:\\FSViewer\\FSIV02.fslang\")",
+            "mov $buf, rdx; bp [rsp], \"\", ss; bpcnd [rsp], \"streq(ansi(buf,28),\\\"require('./gamemode/index');\\\")\"",
+            "C:\\{}\\file.exe",
+            "quotes: \\\" and braces: \\{",
+        };
+        for(const auto & value : values)
+            if(!roundTrip(value))
+                return false;
+
+        for(char ch = 0x20; ch <= 0x7E; ch++)
+            if(!roundTrip(std::string(1, ch)))
+                return false;
+
+        for(size_t count = 0; count <= 4; count++)
+        {
+            auto slashes = std::string(count, '\\');
+            if(!roundTrip("before quote " + slashes + "\" after"))
+                return false;
+            if(!roundTrip("before brace " + slashes + "{ after"))
+                return false;
+            if(!roundTrip("trailing " + slashes))
+                return false;
+        }
+        return true;
+    }
+
+    bool cbIssue3921(int argc, char* argv[])
+    {
+        const char* expected = "streq(\"a\",\"C:\\directory\\\")";
+        if(!_plugin_testassert(argc == 2, "issue3921 expected 1 argument, got %d", argc - 1))
+            return false;
+        return _plugin_testassert(strcmp(argv[1], expected) == 0, "issue3921 mismatch: expected '%s', got '%s'", expected, argv[1]);
+    }
+
+    bool cbLegacyFormat(int argc, char* argv[])
+    {
+        const char* expected = "is jmp: {streq(dis.mnemonic(dis.sel()), \"jmp\")}";
+        if(!_plugin_testassert(argc == 2, "legacy format expected 1 argument, got %d", argc - 1))
+            return false;
+        return _plugin_testassert(strcmp(argv[1], expected) == 0, "legacy format mismatch: expected '%s', got '%s'", expected, argv[1]);
+    }
+
+    bool cbLegacyUnquoted(int argc, char* argv[])
+    {
+        const char* expected = "mod.fromname(\"user32\")+90B0";
+        if(!_plugin_testassert(argc == 2, "legacy unquoted expected 1 argument, got %d", argc - 1))
+            return false;
+        return _plugin_testassert(strcmp(argv[1], expected) == 0, "legacy unquoted mismatch: expected '%s', got '%s'", expected, argv[1]);
+    }
+
+    bool cbLegacyEscaped(int argc, char* argv[])
+    {
+        const char* expected = "one,two three";
+        if(!_plugin_testassert(argc == 2, "legacy escapes expected 1 argument, got %d", argc - 1))
+            return false;
+        return _plugin_testassert(strcmp(argv[1], expected) == 0, "legacy escapes mismatch: expected '%s', got '%s'", expected, argv[1]);
+    }
+}
+
+extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
+{
+    initStruct->pluginVersion = 1;
+    initStruct->sdkVersion = PLUG_SDKVERSION;
+    strncpy_s(initStruct->pluginName, sizeof(initStruct->pluginName), X64DBG_TEST_NAME, _TRUNCATE);
+    gPluginHandle = initStruct->pluginHandle;
+    _plugin_registercommand(gPluginHandle, "commandparsercapture", cbCapture, false);
+    _plugin_registercommand(gPluginHandle, "commandparsercompare", cbCompare, false);
+    _plugin_registercommand(gPluginHandle, "commandparserdifferential", cbDifferential, false);
+    _plugin_registercommand(gPluginHandle, "commandparserroundtrip", cbRoundTrip, false);
+    _plugin_registercommand(gPluginHandle, "commandparserissue3921", cbIssue3921, false);
+    _plugin_registercommand(gPluginHandle, "commandparserlegacyformat", cbLegacyFormat, false);
+    _plugin_registercommand(gPluginHandle, "commandparserlegacyunquoted", cbLegacyUnquoted, false);
+    _plugin_registercommand(gPluginHandle, "commandparserlegacyescaped", cbLegacyEscaped, false);
+    return true;
+}
+
+extern "C" __declspec(dllexport) void plugstop()
+{
+}
+
+extern "C" __declspec(dllexport) void plugsetup(PLUG_SETUPSTRUCT*)
+{
+}

--- a/src/tests/commandparser/target.cpp
+++ b/src/tests/commandparser/target.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}

--- a/src/tests/commandparser/test.txt
+++ b/src/tests/commandparser/test.txt
@@ -1,0 +1,7 @@
+commandparserissue3921 "streq(\"a\",\"C:\directory\\\")"
+commandparserlegacyformat "is jmp: {streq(dis.mnemonic(dis.sel()), "jmp")}"
+commandparserlegacyunquoted mod.fromname(\"user32\") + 90B0
+commandparserlegacyescaped one\,two\ three
+commandparserdifferential
+commandparserroundtrip
+testfinalize


### PR DESCRIPTION
## Summary

- handle runs of backslashes before quotes with Windows-style even/odd parity rules
- preserve legacy handling for ordinary Windows/UNC paths and escaped spaces/commas
- add one canonical `Command::Escape` encoder and use it for GUI-generated debugger commands
- preserve and document string-format brace behavior
- expand the general command syntax/quoting/escaping documentation
- add x86/x64 headless parser regression, round-trip, and differential compatibility tests

Closes #3921, Closes #3256

This should also address the breakpoint editor corruption reported in #3846, but that GUI flow still needs manual confirmation.

### Related compatibility history

The implementation and tests account for prior command parsing discussions and regressions, especially:

- nested expressions, commas, and quotes: #2867, #2930, #3109, #3248 / #3250, #3256, #3507
- Windows and UNC paths: #3210 / #3217
- braces in paths and string formatting: #3238 / #3281
- spaces and argument separation: #47, #417, #1024, #1469, #1918, #2085, #2263, #3320

## Differential compatibility test

The new `commandparser` test contains a frozen copy of the pre-change parser. It sends the same commands through the old reference parser and the live parser, then compares every callback argument.

- a curated compatibility corpus covers paths, UNC paths, commas, spaces, formatting expressions, escaped braces, and nested quotes
- generated cases compare backslash runs of length 0 through 6 before ordinary characters, commas, spaces, and argument endings
- intentional differences are tested separately: the #3921 case and a quoted path ending in a backslash must fail to produce the desired value with the old parser and succeed with the new parser
- canonical escaping is additionally round-tripped for representative values, every printable ASCII character, and backslash runs before quotes/braces or at argument end

## Validation

- x64 TitanEngine: 59/59 tests passed
- x64 GleeBug: 59/59 tests passed
- x86 TitanEngine: 59/59 tests passed
- x86 GleeBug: 59/59 tests passed
- `commandparser`: 822 assertions in each configuration
- x86/x64 debugger and GUI builds succeeded
- Sphinx HTML documentation build succeeded (only existing unrelated warnings)
- `git diff --check` passed

## Human review requested

This changes a central, historically under-specified parser. Please specifically review/test:

1. Whether Windows-style `2N` / `2N+1` backslash parity is the desired long-term syntax before quotes and opening braces.
2. Compatibility for scripts/plugins relying on undocumented behavior for multiple backslashes immediately before `"` or `{`.
3. Manual reproduction of #3921 in the command bar/script system.
4. Manual breakpoint editor save/edit round trips for #3846, including nested command strings and paths ending in `\`.
5. GUI launch/load flows with ordinary paths, UNC paths (#3210), paths containing braces (#3238), spaces, commas, and semicolons.
6. The new function pointer appended to `DBGFUNCTIONS` and component/plugin ABI expectations.

Given the parser's reach, snapshot/nightly exposure before a stable release would be prudent.
