### PR TITLE
Add mnemonic search to the Search for menu

### DIFF
--- a/src/dbg/commands/cmd-searching.cpp
+++ b/src/dbg/commands/cmd-searching.cpp
@@ -460,6 +460,200 @@ bool cbInstrFindAsm(int argc, char* argv[])
     return true;
 }
 
+// A pattern is "mnemonic" or "mnemonic operands", with '*' and '?' wildcards in either
+// half and '|' between alternatives. The mnemonic half is anchored, so "xor" cannot drift
+// into "xorps"; the operand half carries an implicit trailing wildcard, so "xor eax"
+// matches "xor eax, eax".
+struct MnemonicPattern
+{
+    struct Alternative
+    {
+        String mnemonic;
+        String operands; //empty means match the mnemonic only
+    };
+    std::vector<Alternative> alternatives;
+    bool needsOperands = false; //formatting operands is only worth it when a pattern uses them
+
+    // Case-insensitive glob with '*' and '?'.
+    static bool globMatch(const char* pat, const char* str)
+    {
+        const char* starPat = nullptr;
+        const char* starStr = nullptr;
+        while(*str)
+        {
+            if(*pat == '?' || tolower(*pat) == tolower(*str))
+            {
+                pat++;
+                str++;
+            }
+            else if(*pat == '*')
+            {
+                starPat = pat++;
+                starStr = str;
+            }
+            else if(starPat)
+            {
+                pat = starPat + 1;
+                str = ++starStr;
+            }
+            else
+                return false;
+        }
+        while(*pat == '*')
+            pat++;
+        return !*pat;
+    }
+
+    // Drop whitespace after a comma and collapse the rest to a single space, so that
+    // "eax,  eax", "eax, eax" and "eax,eax" all compare equal.
+    static String normalize(const String & text)
+    {
+        String out;
+        bool pendingSpace = false;
+        for(size_t i = 0; i < text.size(); i++)
+        {
+            const char ch = text[i];
+            if(isspace((unsigned char)ch))
+            {
+                pendingSpace = !out.empty();
+                continue;
+            }
+            if(pendingSpace && ch != ',' && !out.empty() && out[out.size() - 1] != ',')
+                out.push_back(' ');
+            pendingSpace = false;
+            out.push_back(ch);
+        }
+        return out;
+    }
+
+    bool parse(const String & text)
+    {
+        alternatives.clear();
+        needsOperands = false;
+        size_t start = 0;
+        while(start <= text.size())
+        {
+            size_t bar = text.find('|', start);
+            String piece = text.substr(start, bar == String::npos ? String::npos : bar - start);
+            start = bar == String::npos ? text.size() + 1 : bar + 1;
+
+            size_t first = piece.find_first_not_of(" \t");
+            if(first == String::npos)
+                continue;
+            size_t space = piece.find_first_of(" \t", first);
+
+            Alternative alt;
+            alt.mnemonic = piece.substr(first, space == String::npos ? String::npos : space - first);
+            if(alt.mnemonic.empty())
+                continue;
+            if(space != String::npos)
+            {
+                alt.operands = normalize(piece.substr(space));
+                if(!alt.operands.empty())
+                {
+                    if(alt.operands[alt.operands.size() - 1] != '*')
+                        alt.operands.push_back('*'); //"xor eax" means "xor eax..."
+                    needsOperands = true;
+                }
+            }
+            alternatives.push_back(alt);
+        }
+        return !alternatives.empty();
+    }
+
+    bool match(const char* mnemonic, const String & operands) const
+    {
+        for(size_t i = 0; i < alternatives.size(); i++)
+        {
+            const Alternative & alt = alternatives[i];
+            if(!globMatch(alt.mnemonic.c_str(), mnemonic))
+                continue;
+            if(alt.operands.empty() || globMatch(alt.operands.c_str(), operands.c_str()))
+                return true;
+        }
+        return false;
+    }
+};
+
+static bool cbFindMnem(Zydis* disasm, BASIC_INSTRUCTION_INFO* basicinfo, REFINFO* refinfo)
+{
+    if(!disasm || !basicinfo) //initialize
+    {
+        GuiReferenceInitialize(refinfo->name);
+        GuiReferenceAddColumn(2 * sizeof(duint), GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Address")));
+        GuiReferenceAddColumn(0, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Disassembly")));
+        GuiReferenceSetRowCount(0);
+        GuiReferenceReloadData();
+        return true;
+    }
+
+    // findasm compares the whole formatted instruction with _stricmp. This matches the
+    // mnemonic and the operands separately, so "xor" finds every xor.
+    const auto pattern = (const MnemonicPattern*)refinfo->userinfo;
+    const auto mnemonic = disasm->Mnemonic();
+
+    String operands;
+    if(pattern->needsOperands)
+    {
+        // Everything after the mnemonic, which also skips a prefix such as "lock".
+        const auto text = disasm->InstructionText();
+        const auto at = text.find(mnemonic);
+        if(at != String::npos)
+            operands = MnemonicPattern::normalize(text.substr(at + mnemonic.size()));
+    }
+
+    bool found = pattern->match(mnemonic.c_str(), operands);
+    if(found)
+    {
+        char addrText[20] = "";
+        sprintf_s(addrText, "%p", (void*)(duint)disasm->Address());
+        GuiReferenceSetRowCount(refinfo->refcount + 1);
+        GuiReferenceSetCellContent(refinfo->refcount, 0, addrText);
+        char disassembly[GUI_MAX_DISASSEMBLY_SIZE] = "";
+        if(GuiGetDisassembly((duint)disasm->Address(), disassembly))
+            GuiReferenceSetCellContent(refinfo->refcount, 1, disassembly);
+        else
+            GuiReferenceSetCellContent(refinfo->refcount, 1, disasm->InstructionText().c_str());
+    }
+    return found;
+}
+
+bool cbInstrFindMnem(int argc, char* argv[])
+{
+    if(IsArgumentsLessThan(argc, 2))
+        return false;
+
+    duint addr = 0;
+    if(argc < 3 || !valfromstring(argv[2], &addr))
+        addr = GetContextDataEx(hActiveThread, UE_CIP);
+    duint size = 0;
+    if(argc >= 4)
+        if(!valfromstring(argv[3], &size))
+            size = 0;
+
+    duint refFindType = CURRENT_REGION;
+    if(argc >= 5 && valfromstring(argv[4], &refFindType, true))
+        if(refFindType != CURRENT_REGION && refFindType != CURRENT_MODULE && refFindType != USER_MODULES && refFindType != SYSTEM_MODULES && refFindType != ALL_MODULES)
+            refFindType = CURRENT_REGION;
+
+    auto patternText = stringformatinline(argv[1]);
+    MnemonicPattern pattern;
+    if(!pattern.parse(patternText))
+    {
+        dputs(QT_TRANSLATE_NOOP("DBG", "Empty mnemonic pattern!"));
+        return false;
+    }
+
+    SearchTimer ticks;
+    char title[256] = "";
+    sprintf_s(title, GuiTranslateText(QT_TRANSLATE_NOOP("DBG", "Mnemonic: \"%s\"")), patternText.c_str());
+    int found = RefFind(addr, size, cbFindMnem, &pattern, false, title, (REFFINDTYPE)refFindType, true);
+    ticks.StopTimer();
+    dprintf(QT_TRANSLATE_NOOP("DBG", "%u result(s) in %ums\n"), DWORD(found), ticks.GetTicks());
+    varset("$result", found, false);
+    return true;
+}
+
 bool cbInstrRefFind(int argc, char* argv[])
 {
     if(IsArgumentsLessThan(argc, 2))

--- a/src/dbg/commands/cmd-searching.h
+++ b/src/dbg/commands/cmd-searching.h
@@ -6,6 +6,7 @@ bool cbInstrFind(int argc, char* argv[]);
 bool cbInstrFindAll(int argc, char* argv[]);
 bool cbInstrFindAllMem(int argc, char* argv[]);
 bool cbInstrFindAsm(int argc, char* argv[]);
+bool cbInstrFindMnem(int argc, char* argv[]);
 bool cbInstrRefFind(int argc, char* argv[]);
 bool cbInstrRefFindRange(int argc, char* argv[]);
 bool cbInstrRefStr(int argc, char* argv[]);

--- a/src/dbg/x64dbg.cpp
+++ b/src/dbg/x64dbg.cpp
@@ -322,6 +322,7 @@ static void registercommands()
     dbgcmdnew("findall", cbInstrFindAll, true); //find all patterns
     dbgcmdnew("findallmem,findmemall", cbInstrFindAllMem, true); //memory map pattern find
     dbgcmdnew("findasm,asmfind", cbInstrFindAsm, true); //find instruction
+    dbgcmdnew("findmnem,mnemfind", cbInstrFindMnem, true); //find instruction by mnemonic
     dbgcmdnew("reffind,findref,ref", cbInstrRefFind, true); //find references to a value
     dbgcmdnew("reffindrange,findrefrange,refrange", cbInstrRefFindRange, true);
     dbgcmdnew("refstr,strref", cbInstrRefStr, true); //find string references

--- a/src/gui/Src/Gui/CPUDisassembly.cpp
+++ b/src/gui/Src/Gui/CPUDisassembly.cpp
@@ -596,12 +596,14 @@ void CPUDisassembly::setupRightClickContextMenu()
 
     // Search in Current Region menu
     mFindCommandRegion = makeShortcutAction(DIcon("search_for_command"), tr("C&ommand"), SLOT(findCommandSlot()), "ActionFind");
+    mFindMnemonicRegion = makeAction(DIcon("search_for_command"), tr("&Mnemonic"), SLOT(findMnemonicSlot()));
     mFindConstantRegion = makeAction(DIcon("search_for_constant"), tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsRegion = makeAction(DIcon("search_for_string"), tr("&String references"), SLOT(findStringsSlot()));
     mFindCallsRegion = makeAction(DIcon("call"), tr("&Intermodular calls"), SLOT(findCallsSlot()));
     mFindPatternRegion = makeShortcutAction(DIcon("search_for_pattern"), tr("&Pattern"), SLOT(findPatternSlot()), "ActionFindPattern");
     mFindGUIDRegion = makeAction(DIcon("guid"), tr("&GUID"), SLOT(findGUIDSlot()));
     mSearchRegionMenu->addAction(mFindCommandRegion);
+    mSearchRegionMenu->addAction(mFindMnemonicRegion);
     mSearchRegionMenu->addAction(mFindConstantRegion);
     mSearchRegionMenu->addAction(mFindStringsRegion);
     mSearchRegionMenu->addAction(mFindCallsRegion);
@@ -610,6 +612,7 @@ void CPUDisassembly::setupRightClickContextMenu()
 
     // Search in Current Module menu
     mFindCommandModule = makeShortcutAction(DIcon("search_for_command"), tr("C&ommand"), SLOT(findCommandSlot()), "ActionFindInModule");
+    mFindMnemonicModule = makeAction(DIcon("search_for_command"), tr("&Mnemonic"), SLOT(findMnemonicSlot()));
     mFindConstantModule = makeAction(DIcon("search_for_constant"), tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsModule = makeShortcutAction(DIcon("search_for_string"), tr("&String references"), SLOT(findStringsSlot()), "ActionFindStringsModule");
     mFindCallsModule = makeAction(DIcon("call"), tr("&Intermodular calls"), SLOT(findCallsSlot()));
@@ -617,6 +620,7 @@ void CPUDisassembly::setupRightClickContextMenu()
     mFindGUIDModule = makeAction(DIcon("guid"), tr("&GUID"), SLOT(findGUIDSlot()));
     mFindNamesModule = makeShortcutAction(DIcon("names"), tr("&Names"), SLOT(findNamesSlot()), "ActionFindNamesInModule");
     mSearchModuleMenu->addAction(mFindCommandModule);
+    mSearchModuleMenu->addAction(mFindMnemonicModule);
     mSearchModuleMenu->addAction(mFindConstantModule);
     mSearchModuleMenu->addAction(mFindStringsModule);
     mSearchModuleMenu->addAction(mFindCallsModule);
@@ -626,12 +630,14 @@ void CPUDisassembly::setupRightClickContextMenu()
 
     // Search in Current Function menu
     mFindCommandFunction = makeAction(DIcon("search_for_command"), tr("C&ommand"), SLOT(findCommandSlot()));
+    mFindMnemonicFunction = makeAction(DIcon("search_for_command"), tr("&Mnemonic"), SLOT(findMnemonicSlot()));
     mFindConstantFunction = makeAction(DIcon("search_for_constant"), tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsFunction = makeAction(DIcon("search_for_string"), tr("&String references"), SLOT(findStringsSlot()));
     mFindCallsFunction = makeAction(DIcon("call"), tr("&Intermodular calls"), SLOT(findCallsSlot()));
     mFindPatternFunction = makeAction(DIcon("search_for_pattern"), tr("&Pattern"), SLOT(findPatternSlot()));
     mFindGUIDFunction = makeAction(DIcon("guid"), tr("&GUID"), SLOT(findGUIDSlot()));
     mSearchFunctionMenu->addAction(mFindCommandFunction);
+    mSearchFunctionMenu->addAction(mFindMnemonicFunction);
     mSearchFunctionMenu->addAction(mFindConstantFunction);
     mSearchFunctionMenu->addAction(mFindStringsFunction);
     mSearchFunctionMenu->addAction(mFindCallsFunction);
@@ -640,12 +646,14 @@ void CPUDisassembly::setupRightClickContextMenu()
 
     // Search in All User Modules menu
     mFindCommandAllUser = makeAction(DIcon("search_for_command"), tr("C&ommand"), SLOT(findCommandSlot()));
+    mFindMnemonicAllUser = makeAction(DIcon("search_for_command"), tr("&Mnemonic"), SLOT(findMnemonicSlot()));
     mFindConstantAllUser = makeAction(DIcon("search_for_constant"), tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsAllUser = makeAction(DIcon("search_for_string"), tr("&String references"), SLOT(findStringsSlot()));
     mFindCallsAllUser = makeAction(DIcon("call"), tr("&Intermodular calls"), SLOT(findCallsSlot()));
     mFindPatternAllUser = makeAction(DIcon("search_for_pattern"), tr("&Pattern"), SLOT(findPatternSlot()));
     mFindGUIDAllUser = makeAction(DIcon("guid"), tr("&GUID"), SLOT(findGUIDSlot()));
     mSearchAllUserMenu->addAction(mFindCommandAllUser);
+    mSearchAllUserMenu->addAction(mFindMnemonicAllUser);
     mSearchAllUserMenu->addAction(mFindConstantAllUser);
     mSearchAllUserMenu->addAction(mFindStringsAllUser);
     mSearchAllUserMenu->addAction(mFindCallsAllUser);
@@ -654,12 +662,14 @@ void CPUDisassembly::setupRightClickContextMenu()
 
     // Search in All System Modules menu
     mFindCommandAllSystem = makeAction(DIcon("search_for_command"), tr("C&ommand"), SLOT(findCommandSlot()));
+    mFindMnemonicAllSystem = makeAction(DIcon("search_for_command"), tr("&Mnemonic"), SLOT(findMnemonicSlot()));
     mFindConstantAllSystem = makeAction(DIcon("search_for_constant"), tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsAllSystem = makeAction(DIcon("search_for_string"), tr("&String references"), SLOT(findStringsSlot()));
     mFindCallsAllSystem = makeAction(DIcon("call"), tr("&Intermodular calls"), SLOT(findCallsSlot()));
     mFindPatternAllSystem = makeAction(DIcon("search_for_pattern"), tr("&Pattern"), SLOT(findPatternSlot()));
     mFindGUIDAllSystem = makeAction(DIcon("guid"), tr("&GUID"), SLOT(findGUIDSlot()));
     mSearchAllSystemMenu->addAction(mFindCommandAllSystem);
+    mSearchAllSystemMenu->addAction(mFindMnemonicAllSystem);
     mSearchAllSystemMenu->addAction(mFindConstantAllSystem);
     mSearchAllSystemMenu->addAction(mFindStringsAllSystem);
     mSearchAllSystemMenu->addAction(mFindCallsAllSystem);
@@ -668,12 +678,14 @@ void CPUDisassembly::setupRightClickContextMenu()
 
     // Search in All Modules menu
     mFindCommandAll = makeAction(DIcon("search_for_command"), tr("C&ommand"), SLOT(findCommandSlot()));
+    mFindMnemonicAll = makeAction(DIcon("search_for_command"), tr("&Mnemonic"), SLOT(findMnemonicSlot()));
     mFindConstantAll = makeAction(DIcon("search_for_constant"), tr("&Constant"), SLOT(findConstantSlot()));
     mFindStringsAll = makeAction(DIcon("search_for_string"), tr("&String references"), SLOT(findStringsSlot()));
     mFindCallsAll = makeAction(DIcon("call"), tr("&Intermodular calls"), SLOT(findCallsSlot()));
     mFindPatternAll = makeAction(DIcon("search_for_pattern"), tr("&Pattern"), SLOT(findPatternSlot()));
     mFindGUIDAll = makeAction(DIcon("guid"), tr("&GUID"), SLOT(findGUIDSlot()));
     mSearchAllMenu->addAction(mFindCommandAll);
+    mSearchAllMenu->addAction(mFindMnemonicAll);
     mSearchAllMenu->addAction(mFindConstantAll);
     mSearchAllMenu->addAction(mFindStringsAll);
     mSearchAllMenu->addAction(mFindCallsAll);
@@ -1847,6 +1859,67 @@ void CPUDisassembly::findCommandSlot()
         duint start, end;
         if(DbgFunctionGet(va, &start, &end))
             DbgCmdExec(QString("findasm \"%1\", %2, .%3, 0").arg(mLineEdit.editText).arg(ToPtrString(start)).arg(ToPtrString(end - start)));
+    }
+
+    emit displayReferencesWidget();
+}
+
+void CPUDisassembly::findMnemonicSlot()
+{
+    if(!DbgIsDebugging())
+        return;
+
+    int refFindType = 0;
+    if(sender() == mFindMnemonicRegion)
+        refFindType = 0;
+    else if(sender() == mFindMnemonicModule)
+        refFindType = 1;
+    else if(sender() == mFindMnemonicAll)
+        refFindType = 2;
+    else if(sender() == mFindMnemonicAllUser)
+        refFindType = 3;
+    else if(sender() == mFindMnemonicAllSystem)
+        refFindType = 4;
+    else if(sender() == mFindMnemonicFunction)
+        refFindType = -1;
+
+    duint va = rvaToVa(getInitialSelection());
+
+    LineEditDialog mLineEdit(this);
+    mLineEdit.setWindowTitle(tr("Find Mnemonic"));
+    mLineEdit.setPlaceholderText(tr("Mnemonic and operands, with * ? wildcards and | alternatives"));
+
+    // Offer the mnemonic under the cursor, which is what you usually want when
+    // you right-click an instruction.
+    BASIC_INSTRUCTION_INFO basicinfo;
+    memset(&basicinfo, 0, sizeof(basicinfo));
+    DbgDisasmFastAt(va, &basicinfo);
+    QString mnemonic = QString(basicinfo.instruction).section(' ', 0, 0);
+    if(!mnemonic.isEmpty())
+    {
+        mLineEdit.setText(mnemonic);
+        mLineEdit.selectAllText();
+    }
+
+    if(mLineEdit.exec() != QDialog::Accepted || mLineEdit.editText.isEmpty())
+        return;
+
+    if(refFindType != -1)
+    {
+        DbgCmdExec(QString("findmnem \"%1\", %2, .%3, %4")
+                   .arg(mLineEdit.editText)
+                   .arg(ToPtrString(mMemPage->getBase()))
+                   .arg(mMemPage->getSize())
+                   .arg(refFindType));
+    }
+    else
+    {
+        duint start, end;
+        if(DbgFunctionGet(va, &start, &end))
+            DbgCmdExec(QString("findmnem \"%1\", %2, .%3, 0")
+                       .arg(mLineEdit.editText)
+                       .arg(ToPtrString(start))
+                       .arg(ToPtrString(end - start)));
     }
 
     emit displayReferencesWidget();

--- a/src/gui/Src/Gui/CPUDisassembly.h
+++ b/src/gui/Src/Gui/CPUDisassembly.h
@@ -85,6 +85,7 @@ public slots:
     void copyDisassemblySlot();
     void labelCopySlot();
     void findCommandSlot();
+    void findMnemonicSlot();
     void openSourceSlot();
     void mnemonicHelpSlot();
     void mnemonicBriefSlot();
@@ -126,6 +127,7 @@ private:
     // Actions
     QAction* mReferenceSelectedAddressAction;
     QAction* mFindCommandRegion;
+    QAction* mFindMnemonicRegion;
     QAction* mFindConstantRegion;
     QAction* mFindStringsRegion;
     QAction* mFindCallsRegion;
@@ -133,6 +135,7 @@ private:
     QAction* mFindGUIDRegion;
 
     QAction* mFindCommandModule;
+    QAction* mFindMnemonicModule;
     QAction* mFindConstantModule;
     QAction* mFindStringsModule;
     QAction* mFindCallsModule;
@@ -141,6 +144,7 @@ private:
     QAction* mFindNamesModule;
 
     QAction* mFindCommandFunction;
+    QAction* mFindMnemonicFunction;
     QAction* mFindConstantFunction;
     QAction* mFindStringsFunction;
     QAction* mFindCallsFunction;
@@ -148,6 +152,7 @@ private:
     QAction* mFindGUIDFunction;
 
     QAction* mFindCommandAllUser;
+    QAction* mFindMnemonicAllUser;
     QAction* mFindConstantAllUser;
     QAction* mFindStringsAllUser;
     QAction* mFindCallsAllUser;
@@ -155,6 +160,7 @@ private:
     QAction* mFindGUIDAllUser;
 
     QAction* mFindCommandAllSystem;
+    QAction* mFindMnemonicAllSystem;
     QAction* mFindConstantAllSystem;
     QAction* mFindStringsAllSystem;
     QAction* mFindCallsAllSystem;
@@ -162,6 +168,7 @@ private:
     QAction* mFindGUIDAllSystem;
 
     QAction* mFindCommandAll;
+    QAction* mFindMnemonicAll;
     QAction* mFindConstantAll;
     QAction* mFindStringsAll;
     QAction* mFindCallsAll;


### PR DESCRIPTION
## Problem

There is no way to search for an instruction unless you already know its exact operands.
`findasm` assembles the text you type and compares the whole formatted instruction:

https://github.com/x64dbg/x64dbg/blob/development/src/dbg/commands/cmd-searching.cpp#L406

```cpp
bool found = !_stricmp(instruction, basicinfo->instruction);
```

So `xor` matches nothing, and it cannot even be entered, because `xor` on its own does not
assemble. Finding every `xor` in a module today means knowing which encodings the compiler
picked and searching byte patterns instead, which is the workaround suggested in #779:

> The byte pattern for `xor eax, eax` is `33 C0` ... `83F0` equivalent to `xor eax, ?`,
> `83F1` equivalent to `xor ecx, ?`

That needs a table of encodings per search, and it does not generalise to "every jump" or
"every write to eax".

## What this adds

A `findmnem` command (alias `mnemfind`) that matches the mnemonic and the operands
separately, with `*` and `?` wildcards in either half and `|` between alternatives.

| Pattern | Matches |
| --- | --- |
| `xor` | every xor, whatever the operands |
| `j*` | every jump |
| `jmp\|call` | jumps and calls |
| `cmov??` | `cmovz`, `cmovnz` |
| `xor eax` | xor whose first operand is eax |
| `xor *eax*` | any xor mentioning eax |
| `mov *,*[*` | mov reading from memory |

The mnemonic half is anchored, so `xor` does not drift into `xorps`; `xor*` does. The
operand half carries an implicit trailing wildcard, so `xor eax` matches `xor eax, eax`
without needing to spell out the rest. Operand spacing is normalized, so `xor eax,eax` and
`xor eax, eax` are the same pattern. Matching is case insensitive and runs against
`Zydis::Mnemonic()` and the formatted operand text, so it agrees with the CPU view.

Operands are only formatted when a pattern actually asks for them, so a plain `xor` search
costs no more than before.

The disassembly context menu gets a **Mnemonic** entry next to **Command** in every scope
submenu. The dialog is pre-filled with the mnemonic under the cursor, so right clicking an
instruction and pressing Enter finds every other instruction like it.

<img width="820" height="494" alt="Screenshot 2026-08-21 174219" src="https://github.com/user-attachments/assets/a870ff8e-09b8-48d3-83b1-2534a41724ca" />
<img width="415" height="104" alt="Screenshot 2026-08-21 182621" src="https://github.com/user-attachments/assets/0636d1b7-e3fc-4eec-a1f1-56efd1443822" />
<img width="434" height="720" alt="Screenshot 2026-08-21 182559" src="https://github.com/user-attachments/assets/5a368200-1ca3-45f8-bb20-d66cef030322" />


## Implementation

`cbInstrFindMnem` follows `cbInstrFindAsm` and hands a match callback to `RefFind()`, so
every existing scope works with no extra code: current region, current module, current
function, all user modules, all system modules, all modules. Progress, threading, the
reference view and the `$result` variable all come from the existing machinery.

Signature matches the surrounding commands:

```
findmnem "pattern"[, addr[, size[, refFindType]]]
```

No new dependencies. 194 lines in `src/dbg`, 80 in `src/gui`.

## Relation to existing issues

#779 (2016) and #1686 (2017) both ask for this. The approach follows what was suggested in
#1686:

> A regex search could be implemented quite easily, see here for how `findasm` is
> implemented. This could be extended with a regex parameter or (perhaps better) a new
> command could be added.

and what was suggested most recently in #779:

> InterObfu never goes production, may be we need a simple string-based instruction search?

Glob was chosen over regex because it covers the cases asked for in those threads, cannot
throw on a malformed pattern, and needs no escaping for the characters that appear in
operands. Full regex over the instruction text stays open under #1686 and would fit later
as an extra argument or a sibling command without changing anything here.

## Testing

- Builds clean for x64 and x86, Release, no new warnings.
- `.github/format/AStyleHelper.exe Silent` produces no changes.
- The pattern matcher was exercised standalone over 25 cases covering anchoring
  (`xor` vs `xorps`), wildcards, alternation, operand prefixes, spacing normalization and
  the negatives (`xor eax` must not match `xor ebx, eax`).
- Verified by hand on x64 and x32: the menu entry appears in each scope submenu, the dialog
  pre-fills from the cursor, and searching populates the reference view with results that
  navigate correctly on click.
