### PR TITLE
Preserve batched callback order during reentrancy

### DIFF
--- a/src/dbg/database_cb_batcher.cpp
+++ b/src/dbg/database_cb_batcher.cpp
@@ -83,29 +83,29 @@ void DbCallbackBatcher::add(DbOperation & op, bool loading)
 
 void DbCallbackBatcher::flush()
 {
-    if(mOperations.empty())
+    if(mFlushing)
         return;
 
-    mOpList.resize(mOperations.size());
-    for(size_t i = 0; i < mOperations.size(); i++)
-        mOpList[i] = &mOperations[i];
+    mFlushing = true;
+    while(!mOperations.empty())
+    {
+        std::vector<DbOperation> operations;
+        std::deque<std::string> strings;
+        operations.swap(mOperations);
+        strings.swap(mStrings);
 
-    PLUG_CB_DBOPERATION info;
-    info.operations = mOpList.data();
-    info.count = mOpList.size();
-    info.batchId = mBatchId;
+        std::vector<const DbOperation*> opList(operations.size());
+        for(size_t i = 0; i < operations.size(); i++)
+            opList[i] = &operations[i];
 
-    // Do not let reentrant database callbacks append to the batch being delivered.
-    auto activeBatcher = DbCallbackBatcher::tActiveBatcher;
-    if(activeBatcher == this)
-        DbCallbackBatcher::tActiveBatcher = mPrevious;
+        PLUG_CB_DBOPERATION info;
+        info.operations = opList.data();
+        info.count = opList.size();
+        info.batchId = mBatchId;
 
-    plugincbcall(mLoading ? CB_DBLOADOPERATION : CB_DBOPERATION, &info);
-
-    if(activeBatcher == this)
-        DbCallbackBatcher::tActiveBatcher = activeBatcher;
-
-    mOperations.clear();
-    mOpList.clear();
-    mStrings.clear();
+        // Reentrant operations append to the now-empty member containers and
+        // are delivered by the next iteration after this callback completes.
+        plugincbcall(mLoading ? CB_DBLOADOPERATION : CB_DBOPERATION, &info);
+    }
+    mFlushing = false;
 }

--- a/src/dbg/database_cb_batcher.cpp
+++ b/src/dbg/database_cb_batcher.cpp
@@ -31,17 +31,14 @@ DbCallbackBatcher::~DbCallbackBatcher()
 
 bool DbCallbackBatcher::IsActive(bool loading)
 {
-    if(tActiveBatcher)
-    {
-        ASSERT_ALWAYS(loading == tActiveBatcher->mLoading);
+    if(tActiveBatcher && loading == tActiveBatcher->mLoading)
         return tActiveBatcher->mActive;
-    }
     return !plugincbempty(loading ? CB_DBLOADOPERATION : CB_DBOPERATION);
 }
 
 void DbCallbackBatcher::Add(DbOperation & op, bool loading)
 {
-    if(tActiveBatcher != nullptr)
+    if(tActiveBatcher != nullptr && loading == tActiveBatcher->mLoading)
     {
         tActiveBatcher->add(op, loading);
     }
@@ -60,7 +57,7 @@ void DbCallbackBatcher::Add(DbOperation & op, bool loading)
 
 void DbCallbackBatcher::add(DbOperation & op, bool loading)
 {
-    ASSERT_ALWAYS(loading == mLoading);
+    ASSERT_TRUE(loading == mLoading);
 
     // NOTE: bad, we already paid the DbOperation construction
     if(!mActive)
@@ -84,7 +81,11 @@ void DbCallbackBatcher::add(DbOperation & op, bool loading)
 void DbCallbackBatcher::flush()
 {
     if(mFlushing)
+    {
+        // The outer flush drains reentrant operations after callback delivery.
+        // In this rare case the pending batch may exceed the normal size limit.
         return;
+    }
 
     mFlushing = true;
     while(!mOperations.empty())

--- a/src/dbg/database_cb_batcher.h
+++ b/src/dbg/database_cb_batcher.h
@@ -19,11 +19,11 @@ private:
     void flush();
 
     std::vector<DbOperation> mOperations;
-    std::vector<const DbOperation*> mOpList;
     std::deque<std::string> mStrings;
     DbCallbackBatcher* mPrevious = nullptr;
     uint32_t mBatchId = 0;
     bool mLoading = false;
     bool mActive = false;
+    bool mFlushing = false;
     bool mOwner = false; // if a batcher is defined in a thread where there's already a batcher on the stack, this is set to false
 };

--- a/src/tests/database_callbacks/README.md
+++ b/src/tests/database_callbacks/README.md
@@ -83,6 +83,15 @@ Validates that batch label operations emit bulk callbacks.
 
 ---
 
+## Database Load Tests
+
+### `db-load-reentrant`
+
+Validates that a regular mutation triggered from `CB_DBLOADOPERATION` is emitted as
+`CB_DBOPERATION`. Cross-type callback ordering is intentionally not asserted.
+
+---
+
 ## Loop Tests
 
 Loops are range items (start/end) that additionally carry a nesting `depth` and a

--- a/src/tests/database_callbacks/README.md
+++ b/src/tests/database_callbacks/README.md
@@ -64,6 +64,11 @@ Validates that singular comment operations emit exactly one non-bulk callback.
 
 Validates that batch comment operations emit bulk callbacks.
 
+### `comment-reentrant`
+
+Validates that an operation triggered reentrantly by a batch callback is delivered only
+after the in-flight batch completes.
+
 ---
 
 ## Label Tests

--- a/src/tests/database_callbacks/plugin.cpp
+++ b/src/tests/database_callbacks/plugin.cpp
@@ -23,10 +23,14 @@ namespace
     int gPluginHandle = 0;
     std::vector<TestOperation> operations;
     bool gOpLogEnabled = false;
+    bool gReentrantCommentSetPending = false;
+    duint gReentrantCommentAddress = 0;
+    std::string gReentrantCommentText;
 
     void resetState()
     {
         operations.clear();
+        gReentrantCommentSetPending = false;
     }
 
     void printOperation(const DbOperation & op, bool dbLoad)
@@ -114,6 +118,14 @@ namespace
         if(cbType == CB_DBOPERATION || cbType == CB_DBLOADOPERATION)
         {
             auto info = (PLUG_CB_DBOPERATION*) callbackInfo;
+
+            if(cbType == CB_DBOPERATION && gReentrantCommentSetPending)
+            {
+                gReentrantCommentSetPending = false;
+                char command[MAX_SETTING_SIZE];
+                sprintf_s(command, "commentset 0x%llX, \"%s\"", (unsigned long long)gReentrantCommentAddress, gReentrantCommentText.c_str());
+                _plugin_testassert(DbgCmdExecDirect(command), "reentrant command failed: %s", command);
+            }
 
             for(size_t i = 0; i < info->count; i ++)
             {
@@ -265,6 +277,17 @@ namespace
         _plugin_logprintf("oplog state: %s\n", gOpLogEnabled ? "on" : "off");
         return true;
     }
+
+    bool cbReentrantCommentSet(int argc, char** argv)
+    {
+        if(argc != 3)
+            return false;
+
+        gReentrantCommentAddress = evalExpr(argv[1]);
+        gReentrantCommentText = argv[2];
+        gReentrantCommentSetPending = true;
+        return _plugin_testassert(gReentrantCommentAddress != 0, "failed to resolve reentrant comment address '%s'", argv[1]);
+    }
 }
 
 extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
@@ -278,6 +301,7 @@ extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
     _plugin_registercallback(gPluginHandle, CB_INITDEBUG, cbPlugin);
     _plugin_registercommand(gPluginHandle, "dbreset", cbReset, false);
     _plugin_registercommand(gPluginHandle, "dboplog", cbOpLog, false);
+    _plugin_registercommand(gPluginHandle, "dbreentrantcommentset", cbReentrantCommentSet, false);
     _plugin_registercommand(gPluginHandle, "assertlastop", cbAssertLastOperation, false);
     _plugin_registercommand(gPluginHandle, "assertopsize", cbAssertOperationsSize, false);
     return true;

--- a/src/tests/database_callbacks/plugin.cpp
+++ b/src/tests/database_callbacks/plugin.cpp
@@ -26,11 +26,22 @@ namespace
     bool gReentrantCommentSetPending = false;
     duint gReentrantCommentAddress = 0;
     std::string gReentrantCommentText;
+    bool gDbLoadCommentSetPending = false;
+    bool gDbLoadCommentSetSeen = false;
+    duint gDbLoadCommentAddress = 0;
+    std::string gDbLoadCommentText;
 
-    void resetState()
+    void resetState(bool preserveDbLoadCommentSet = false)
     {
         operations.clear();
         gReentrantCommentSetPending = false;
+        gDbLoadCommentSetSeen = false;
+        if(!preserveDbLoadCommentSet)
+        {
+            gDbLoadCommentSetPending = false;
+            gDbLoadCommentAddress = 0;
+            gDbLoadCommentText.clear();
+        }
     }
 
     void printOperation(const DbOperation & op, bool dbLoad)
@@ -111,7 +122,7 @@ namespace
     {
         if(cbType == CB_INITDEBUG)
         {
-            resetState();
+            resetState(true);
             return;
         }
 
@@ -127,9 +138,25 @@ namespace
                 _plugin_testassert(DbgCmdExecDirect(command), "reentrant command failed: %s", command);
             }
 
+            if(cbType == CB_DBLOADOPERATION && gDbLoadCommentSetPending)
+            {
+                gDbLoadCommentSetPending = false;
+                char command[MAX_SETTING_SIZE];
+                sprintf_s(command, "commentset 0x%llX, \"%s\"", (unsigned long long)gDbLoadCommentAddress, gDbLoadCommentText.c_str());
+                _plugin_testassert(DbgCmdExecDirect(command), "database-load reentrant command failed: %s", command);
+            }
+
             for(size_t i = 0; i < info->count; i ++)
             {
                 const DbOperation & operation = *info->operations[i];
+
+                auto expectedAddress = gDbLoadCommentAddress;
+                if(operation.modhash != 0)
+                    expectedAddress -= DbgFunctions()->ModBaseFromAddr(expectedAddress);
+                if(cbType == CB_DBOPERATION && operation.opType == DbOperationTypeAdd &&
+                        operation.itemType == DbItemTypeComment && operation.address == expectedAddress &&
+                        operation.text != nullptr && gDbLoadCommentText == operation.text)
+                    gDbLoadCommentSetSeen = true;
 
                 if(gOpLogEnabled)
                     printOperation(operation, cbType == CB_DBLOADOPERATION);
@@ -288,6 +315,24 @@ namespace
         gReentrantCommentSetPending = true;
         return _plugin_testassert(gReentrantCommentAddress != 0, "failed to resolve reentrant comment address '%s'", argv[1]);
     }
+
+    bool cbDbLoadCommentSet(int argc, char** argv)
+    {
+        if(argc != 3)
+            return false;
+
+        gDbLoadCommentAddress = evalExpr(argv[1]);
+        gDbLoadCommentText = argv[2];
+        gDbLoadCommentSetPending = true;
+        gDbLoadCommentSetSeen = false;
+        return _plugin_testassert(gDbLoadCommentAddress != 0, "failed to resolve database-load comment address '%s'", argv[1]);
+    }
+
+    bool cbAssertDbLoadCommentSet(int, char**)
+    {
+        return _plugin_testassert(!gDbLoadCommentSetPending, "database-load callback was not triggered") &&
+               _plugin_testassert(gDbLoadCommentSetSeen, "regular database operation was not emitted as CB_DBOPERATION");
+    }
 }
 
 extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
@@ -302,6 +347,8 @@ extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct)
     _plugin_registercommand(gPluginHandle, "dbreset", cbReset, false);
     _plugin_registercommand(gPluginHandle, "dboplog", cbOpLog, false);
     _plugin_registercommand(gPluginHandle, "dbreentrantcommentset", cbReentrantCommentSet, false);
+    _plugin_registercommand(gPluginHandle, "dbloadcommentset", cbDbLoadCommentSet, false);
+    _plugin_registercommand(gPluginHandle, "assertdbloadcommentset", cbAssertDbLoadCommentSet, false);
     _plugin_registercommand(gPluginHandle, "assertlastop", cbAssertLastOperation, false);
     _plugin_registercommand(gPluginHandle, "assertopsize", cbAssertOperationsSize, false);
     return true;

--- a/src/tests/database_callbacks/test.comment-reentrant.txt
+++ b/src/tests/database_callbacks/test.comment-reentrant.txt
@@ -1,0 +1,15 @@
+init tests/database_callbacks.exe
+
+_c1 = database_callbacks:VariableTarget
+_c2 = _c1 + 4
+
+commentset _c1, old1
+commentset _c2, old2
+dbreset
+
+dbreentrantcommentset _c1, reentrant
+commentclear
+
+// Both removals must reach every plugin before the reentrant add.
+assertopsize 3
+assertlastop mod.hash(mod.base(_c1)), (_c1-mod.base(_c1)), c, a, 0, reentrant

--- a/src/tests/database_callbacks/test.db-load-reentrant.txt
+++ b/src/tests/database_callbacks/test.db-load-reentrant.txt
@@ -1,0 +1,13 @@
+init tests/database_callbacks.exe
+
+_c1 = database_callbacks:VariableTarget
+_c2 = _c1 + 4
+
+commentset _c1, saved
+dbloadcommentset _c2, regular
+
+stop
+init tests/database_callbacks.exe
+
+// A regular mutation from CB_DBLOADOPERATION must remain CB_DBOPERATION.
+assertdbloadcommentset


### PR DESCRIPTION
## Summary

Keep the active database callback batcher available while a batch is delivered, but isolate the in-flight operations and strings with `swap`.

Reentrant database operations of the same callback type therefore append to fresh member containers and are delivered by the next flush-loop iteration after the current callback completes. A small `mFlushing` guard prevents a threshold-triggered recursive flush.

Operations of the opposite callback type bypass the active batch and dispatch immediately under their requested type.

This does not introduce a global callback queue, writer serialization, cross-thread ordering guarantees, or public API/ABI changes.

## Deliberate limitations

- Cross-type reentrant ordering is not guaranteed.
- A same-thread, same-type bulk mutation performed reentrantly during callback delivery can exceed the normal 8,096-operation batch threshold. It is delivered after the in-flight callback completes rather than being split into pending chunks.

## Verification

- Native MSVC x86 and x64 builds
- All 16 database callback tests on x86/x64 with TitanEngine and GleeBug
- Same-type batched reentrancy regression
- Cross-type database-load classification regression