### PR TITLE
Fix patch list visibility when reopening the dialog

### DIFF
--- a/src/gui/Src/Gui/PatchDialog.cpp
+++ b/src/gui/Src/Gui/PatchDialog.cpp
@@ -158,6 +158,9 @@ void PatchDialog::updatePatches()
     if(mPatches.size())
         ui->listModules->item(0)->setSelected(true); //select first module
 
+    // QListWidget can retain an explicitly hidden state after the dialog is closed
+    // with a patch selected. Make sure the refreshed list is shown again.
+    ui->listPatches->setVisible(true);
     mIsWorking = false;
 }
 


### PR DESCRIPTION
### Motivation
- Restore the patches QListWidget visibility after refreshing patches because selecting a patch then closing the dialog could leave the list hidden when the dialog is reopened.

### Description
- Call `ui->listPatches->setVisible(true);` at the end of `PatchDialog::updatePatches()` with a short comment to ensure the refreshed list is shown again.

### Testing
- Ran `git diff --check --ignore-space-at-eol` (passed) and attempted `cmake -S . -B /tmp/x64dbg-build` which could not complete because required Git submodules are uninitialized; no further automated tests were available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ad9a81bb48333b4d2fbb90b607a24)

Closes #3934