### PR TITLE
docs: fix typo occured -> occurred

### DIFF
--- a/docs/developers/functions/bridge/BridgeInit.md
+++ b/docs/developers/functions/bridge/BridgeInit.md
@@ -12,7 +12,7 @@ This function has no parameters.
 
 ## Return Value
 
-Returns 0 if successful, otherwise a string indicating the error that occured.
+Returns 0 if successful, otherwise a string indicating the error that occurred.
 
 ## Example
 


### PR DESCRIPTION
Corrects a single misspelling of `occured` in `docs/developers/functions/bridge/BridgeInit.md`.

Documentation only, no behaviour change.