### PR TITLE
Fix crash on long UTF-8 mapped filenames

### DIFF
--- a/src/dbg/memory.cpp
+++ b/src/dbg/memory.cpp
@@ -85,10 +85,8 @@ static std::vector<MEMPAGE> QueryMemPages()
                     {
                         auto bFileNameOnly = false; //TODO: setting for this
                         auto fileStart = wcsrchr(szMappedName, L'\\');
-                        if(bFileNameOnly && fileStart)
-                            strcpy_s(curPage.info, StringUtils::Utf16ToUtf8(fileStart + 1).c_str());
-                        else
-                            strcpy_s(curPage.info, StringUtils::Utf16ToUtf8(szMappedName).c_str());
+                        const auto mappedName = StringUtils::Utf16ToUtf8(bFileNameOnly && fileStart ? fileStart + 1 : szMappedName);
+                        strncpy_s(curPage.info, mappedName.c_str(), _TRUNCATE);
                     }
                 }
 


### PR DESCRIPTION
Fixes a memory map crash caused by Unicode heavy mapped file paths;

`GetMappedFileNameW` returns a UTF-16 path which is converted to UTF-8 and copied into the fixed-size `MEMPAGE::info` buffer, the UTF-8 representation can exceed the buffer even when the UTF-16 path fits in `szMappedName`, causing `strcpy_s` to terminate x64dbg with `FAST_FAIL_INVALID_ARG`.

The copy now uses `strncpy_s` with `_TRUNCATE`, so the converted path fits and remains null-termed.

Crash:
<img width="806" height="404" alt="Medal-SIKU_D01-M09-Y2026_a10d4591e" src="https://github.com/user-attachments/assets/6dd424b4-e168-441d-884a-3645229f511f" />

Post-fix:
<img width="413" height="123" alt="DbgX Shell-SIKU_D01-M09-Y2026_8e2d6167c" src="https://github.com/user-attachments/assets/7cc91109-c101-49bd-b38b-8fec78deeac4" />