### PR TITLE
ElfBug: all-stop mode so a reported stop freezes every thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .idea/
 build*/
 cmake-build*/
+dist/
 
 # Extensions/files
 *.sdf

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
@@ -33,26 +33,26 @@ namespace ElfBug
             ScopedSteppingOff & operator=(const ScopedSteppingOff &) = delete;
         };
 
-        bool sweepShouldQueue(const int signal)
+        bool sweepShouldQueue(const int signal, const bool hardware)
         {
             switch(signal)
             {
             case SIGSTOP:
+                return false;
             case SIGSEGV:
             case SIGBUS:
             case SIGFPE:
             case SIGILL:
             case SIGSYS:
             case SIGTRAP:
-                return false;
+                return !hardware;
             default:
                 return true;
             }
         }
     }
 
-    void Debugger::repairStoppedThread(Thread* thread, const int status)
-    {
+    void Debugger::repairStoppedThread(Thread* thread, const int status) const {
         if(!thread)
             return;
 
@@ -60,9 +60,15 @@ namespace ElfBug
 
         const int sig = WSTOPSIG(status);
 
-        // Nothing else records it, so queue it for the resume to forward.
-        if(sweepShouldQueue(sig))
-            thread->setPendingSignal(sig);
+        // si_code is positive when the kernel raised the signal and zero or negative for
+        // kill, tkill and sigqueue. Queue conservatively when it cannot be read.
+        siginfo_t info{};
+        const bool haveInfo = ptrace(PTRACE_GETSIGINFO, thread->tid, nullptr, &info) != -1;
+        const bool hardware = haveInfo && info.si_code > 0;
+
+        // Nothing else records it, so queue it for pauseAndResume to report and forward.
+        if(sweepShouldQueue(sig, hardware))
+            thread->setPendingSignal(sig, haveInfo ? reinterpret_cast<ptr>(info.si_addr) : 0, true);
 
         if(!mProcess || sig != SIGTRAP)
             return;
@@ -267,8 +273,15 @@ namespace ElfBug
         switch(sig)
         {
         case SIGTRAP:
-            handleSigtrap(pid, status);
+        {
+            siginfo_t info{};
+            if(((status >> 16) & 0xffff) == 0 &&
+                    ptrace(PTRACE_GETSIGINFO, pid, nullptr, &info) != -1 && info.si_code <= 0)
+                reportSignal(pid, sig);
+            else
+                handleSigtrap(pid, status);
             break;
+        }
 
         case SIGSTOP:
         {
@@ -334,35 +347,37 @@ namespace ElfBug
         }
 
         default:
-        {
-            ptr faultAddr = 0;
-            siginfo_t sigInfo;
-            if(ptrace(PTRACE_GETSIGINFO, pid, nullptr, &sigInfo) != -1)
-                faultAddr = reinterpret_cast<ptr>(sigInfo.si_addr);
-            if(mThread)
-            {
-                mThread->registers.Read();
-                mPendingSignal = sig;
-                abandonSingleStep(pid);
-                cancelStepOverIfOwner(pid);
-                stopAllThreads(pid);
-                beginPause();
-                cbExceptionEvent(sig, faultAddr);
-                if(!pauseAndResume(pid))
-                    break;
-            }
-            else
-            {
-                cbExceptionEvent(sig, faultAddr);
-                if(ptrace(PTRACE_CONT, pid, nullptr,
-                          reinterpret_cast<void*>(static_cast<uintptr_t>(sig))) == -1)
-                {
-                    if(errno != ESRCH)
-                        cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
-                }
-            }
+            reportSignal(pid, sig);
             break;
         }
+    }
+
+    void Debugger::reportSignal(const pid_t pid, const int sig)
+    {
+        ptr faultAddr = 0;
+        siginfo_t sigInfo;
+        if(ptrace(PTRACE_GETSIGINFO, pid, nullptr, &sigInfo) != -1)
+            faultAddr = reinterpret_cast<ptr>(sigInfo.si_addr);
+        if(mThread)
+        {
+            mThread->registers.Read();
+            mPendingSignal = sig;
+            abandonSingleStep(pid);
+            cancelStepOverIfOwner(pid);
+            stopAllThreads(pid);
+            beginPause();
+            cbExceptionEvent(sig, faultAddr);
+            pauseAndResume(pid);
+        }
+        else
+        {
+            cbExceptionEvent(sig, faultAddr);
+            if(ptrace(PTRACE_CONT, pid, nullptr,
+                      reinterpret_cast<void*>(static_cast<uintptr_t>(sig))) == -1)
+            {
+                if(errno != ESRCH)
+                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
         }
     }
 

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
@@ -52,7 +52,8 @@ namespace ElfBug
         }
     }
 
-    void Debugger::repairStoppedThread(Thread* thread, const int status) const {
+    void Debugger::repairStoppedThread(Thread* thread, const int status) const
+    {
         if(!thread)
             return;
 

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
@@ -4,9 +4,241 @@
 #include <cerrno>
 #include <cstring>
 #include <csignal>
+#include <vector>
+#include <unistd.h>
 
 namespace ElfBug
 {
+    namespace
+    {
+        // stepPastBreakpointByte can re-enter itself through the stop it reports, so the
+        // previous tid has to come back rather than be cleared.
+        struct ScopedSteppingOff
+        {
+            pid_t & slot;
+            const pid_t previous;
+
+            ScopedSteppingOff(pid_t & steppingOff, const pid_t tid)
+                : slot(steppingOff), previous(steppingOff)
+            {
+                slot = tid;
+            }
+
+            ~ScopedSteppingOff()
+            {
+                slot = previous;
+            }
+
+            ScopedSteppingOff(const ScopedSteppingOff &) = delete;
+            ScopedSteppingOff & operator=(const ScopedSteppingOff &) = delete;
+        };
+
+        bool sweepShouldQueue(const int signal)
+        {
+            switch(signal)
+            {
+            case SIGSTOP:
+            case SIGSEGV:
+            case SIGBUS:
+            case SIGFPE:
+            case SIGILL:
+            case SIGSYS:
+            case SIGTRAP:
+                return false;
+            default:
+                return true;
+            }
+        }
+    }
+
+    void Debugger::repairStoppedThread(Thread* thread, const int status)
+    {
+        if(!thread)
+            return;
+
+        thread->registers.Read();
+
+        const int sig = WSTOPSIG(status);
+
+        // Nothing else records it, so queue it for the resume to forward.
+        if(sweepShouldQueue(sig))
+            thread->setPendingSignal(sig);
+
+        if(!mProcess || sig != SIGTRAP)
+            return;
+        // A ptrace event, not an int3 trap.
+        if(((status >> 16) & 0xffff) != 0)
+            return;
+        if(thread->isSingleStepping())
+            return;
+
+        const ptr bpAddr = thread->registers.Gip() - 1;
+        if(!mProcess->HasBreakpoint(bpAddr))
+            return;
+
+        thread->registers.Gip() = bpAddr;
+        thread->registers.Write();
+        thread->setPendingBreakpoint(bpAddr);
+    }
+
+    bool Debugger::swallowPendingSigstop(const pid_t tid)
+    {
+        if(!mProcess)
+            return true;
+
+        Thread* thread = nullptr;
+        {
+            std::shared_lock lock(mProcessMutex);
+            const auto it = mProcess->threads.find(tid);
+            if(it != mProcess->threads.end())
+                thread = it->second.get();
+        }
+        if(!thread || !thread->pendingSigstop())
+            return true;
+
+        if(ptrace(PTRACE_CONT, tid, nullptr, nullptr) == -1)
+        {
+            thread->setPendingSigstop(false);
+            return true;
+        }
+
+        int status = 0;
+        pid_t waited = -1;
+        do
+        {
+            waited = waitpid(tid, &status, __WALL);
+        }
+        while(waited == -1 && errno == EINTR);
+
+        if(waited == -1)
+        {
+            thread->setPendingSigstop(false);
+            return true;
+        }
+
+        if(WIFEXITED(status) || WIFSIGNALED(status))
+        {
+            const int code = WIFEXITED(status) ? WEXITSTATUS(status) : -WTERMSIG(status);
+            if(tid == mMainPid.load(std::memory_order_relaxed))
+            {
+                exitProcessEvent(tid, code);
+                mIsRunning.store(false, std::memory_order_release);
+            }
+            else
+            {
+                exitThreadEvent(tid);
+            }
+            return false;
+        }
+
+        if(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP)
+            thread->setPendingSigstop(false);
+        return true;
+    }
+
+    void Debugger::stopAllThreads(const pid_t except)
+    {
+        if(!mProcess)
+            return;
+
+        const pid_t tgid = mMainPid.load(std::memory_order_relaxed);
+        if(tgid <= 0)
+            return;
+
+        for(;;)
+        {
+            std::vector<pid_t> running;
+            {
+                std::shared_lock lock(mProcessMutex);
+                for(const auto & [tid, thread] : mProcess->threads)
+                {
+                    if(tid != except && thread->isRunning())
+                        running.push_back(tid);
+                }
+            }
+
+            if(running.empty())
+                return;
+
+            for(const pid_t tid : running)
+            {
+                Thread* thread = nullptr;
+                {
+                    std::shared_lock lock(mProcessMutex);
+                    const auto it = mProcess->threads.find(tid);
+                    if(it != mProcess->threads.end())
+                        thread = it->second.get();
+                }
+                if(!thread)
+                    continue;
+
+                if(tgkill(tgid, tid, SIGSTOP) == -1)
+                {
+                    if(errno != ESRCH)
+                        cbInternalError("tgkill failed: " + std::string(strerror(errno)));
+                    thread->setRunning(false);
+                    continue;
+                }
+
+                int status = 0;
+                pid_t waited = -1;
+                do
+                {
+                    waited = waitpid(tid, &status, __WALL);
+                }
+                while(waited == -1 && errno == EINTR);
+
+                if(waited == -1)
+                {
+                    thread->setRunning(false);
+                    continue;
+                }
+
+                if(WIFEXITED(status) || WIFSIGNALED(status))
+                {
+                    exitThreadEvent(tid);
+                    continue;
+                }
+
+                const int event = (status >> 16) & 0xffff;
+                if(WSTOPSIG(status) == SIGTRAP && event != 0)
+                {
+                    if(event == PTRACE_EVENT_CLONE)
+                    {
+                        unsigned long newTid = 0;
+                        if(ptrace(PTRACE_GETEVENTMSG, tid, nullptr, &newTid) == -1)
+                            cbInternalError("PTRACE_GETEVENTMSG failed: " + std::string(strerror(errno)));
+                        else
+                            createThreadEvent(static_cast<pid_t>(newTid));
+                    }
+                    else if(event == PTRACE_EVENT_EXEC)
+                    {
+                        onExec();
+                    }
+
+                    if(ptrace(PTRACE_CONT, tid, nullptr, nullptr) == -1)
+                    {
+                        if(errno != ESRCH)
+                            cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                        thread->setRunning(false);
+                    }
+                    else if(event == PTRACE_EVENT_EXIT)
+                    {
+                        thread->setRunning(false);
+                    }
+                    continue;
+                }
+
+                thread->setRunning(false);
+
+                const bool ownReason = WSTOPSIG(status) != SIGSTOP;
+                thread->setPendingSigstop(ownReason);
+                if(ownReason)
+                    repairStoppedThread(thread, status);
+            }
+        }
+    }
+
     void Debugger::handleSignal(const pid_t pid, const int status)
     {
         const int sig = WSTOPSIG(status);
@@ -23,6 +255,15 @@ namespace ElfBug
             }
         }
 
+        const bool wasRunning = mThread && mThread->isRunning();
+
+        if(mThread)
+        {
+            mThread->setRunning(false);
+            if(sig == SIGSTOP)
+                mThread->setPendingSigstop(false);
+        }
+
         switch(sig)
         {
         case SIGTRAP:
@@ -34,13 +275,12 @@ namespace ElfBug
             if(mPauseRequested.load(std::memory_order_acquire))
             {
                 mPauseRequested.store(false, std::memory_order_release);
-                // TODO: all-stop mode - send tgkill(mMainPid, tid, SIGSTOP)
-                // to every other thread and waitpid each
                 if(mThread)
                 {
                     mThread->registers.Read();
                     abandonSingleStep(pid);
                     cancelStepOverIfOwner(pid);
+                    stopAllThreads(pid);
                     beginPause();
                     cbPaused();
 
@@ -50,23 +290,45 @@ namespace ElfBug
                 else
                 {
                     if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                        cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                    {
+                        if(errno != ESRCH)
+                            cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                    }
+                    else
+                        mUnregisteredRunning.insert(pid);
                 }
             }
             else if(mThread && mThread->isSingleStepping())
             {
-                // Not ours: the step is still owed, so resume it rather than run free.
-                if(!mThread->StepInto())
+                // Not our SIGSTOP: the step is still owed, so re-issue it.
+                if(mThread->StepInto())
+                {
+                    mThread->setRunning(true);
+                }
+                else
                 {
                     abandonSingleStep(pid);
                     if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                        cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                    {
+                        if(errno != ESRCH)
+                            cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                    }
+                    else
+                        mThread->setRunning(true);
                 }
             }
-            else
+
+            else if(!mAllStopped || wasRunning || pid == mSteppingOff || !mThread)
             {
                 if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                {
+                    if(errno != ESRCH)
+                        cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                }
+                else if(mThread)
+                    mThread->setRunning(true);
+                else
+                    mUnregisteredRunning.insert(pid);
             }
             break;
         }
@@ -83,6 +345,7 @@ namespace ElfBug
                 mPendingSignal = sig;
                 abandonSingleStep(pid);
                 cancelStepOverIfOwner(pid);
+                stopAllThreads(pid);
                 beginPause();
                 cbExceptionEvent(sig, faultAddr);
                 if(!pauseAndResume(pid))
@@ -93,7 +356,10 @@ namespace ElfBug
                 cbExceptionEvent(sig, faultAddr);
                 if(ptrace(PTRACE_CONT, pid, nullptr,
                           reinterpret_cast<void*>(static_cast<uintptr_t>(sig))) == -1)
-                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                {
+                    if(errno != ESRCH)
+                        cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                }
             }
             break;
         }
@@ -105,6 +371,8 @@ namespace ElfBug
         if(!mProcess || !mThread)
             return false;
 
+        const ScopedSteppingOff scopedSteppingOff(mSteppingOff, pid);
+
         ptr next = 0;
         const bool stepsPushf = mProcess->ClassifyStepOverAt(addr, next) == StepOverKind::Pushf;
 
@@ -114,6 +382,13 @@ namespace ElfBug
         // The pending signal rides the step; otherwise the faulting instruction is retried.
         const int sig = mPendingSignal;
         mPendingSignal = 0;
+
+        if(!swallowPendingSigstop(pid))
+        {
+            if(lifted && mProcess)
+                mProcess->RearmBreakpointByte(addr);
+            return false;
+        }
 
         if(!mThread->StepInto(sig))
         {
@@ -127,6 +402,10 @@ namespace ElfBug
             {
                 if(errno != ESRCH)
                     cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
+            else
+            {
+                mThread->setRunning(true);
             }
             return false;
         }
@@ -149,6 +428,10 @@ namespace ElfBug
                 if(errno != ESRCH)
                     cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
             }
+            else
+            {
+                mThread->setRunning(true);
+            }
             return false;
         }
 
@@ -156,6 +439,9 @@ namespace ElfBug
 
         if(WIFEXITED(stepStatus) || WIFSIGNALED(stepStatus))
         {
+            if(lifted && mProcess)
+                mProcess->RearmBreakpointByte(addr);
+
             const int code = WIFEXITED(stepStatus) ? WEXITSTATUS(stepStatus) : -WTERMSIG(stepStatus);
             if(pid == mMainPid.load(std::memory_order_relaxed))
             {
@@ -184,6 +470,10 @@ namespace ElfBug
                     if(errno != ESRCH)
                         cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
                 }
+                else
+                {
+                    mThread->setRunning(true);
+                }
                 return false;
             }
 
@@ -201,9 +491,8 @@ namespace ElfBug
 
             if(stepSig != SIGTRAP)
             {
-                // Not the step's trap: report it like any other stop instead of forwarding it blind.
-                // A handled signal leaves the step at the handler entry with the byte re-armed,
-                // so the breakpoint fires again when the handler returns to the instruction.
+                // Not the step's trap: report it like any other stop. The byte is re-armed,
+                // so the breakpoint fires again when a handler returns to the instruction.
                 handleSignal(pid, stepStatus);
                 return false;
             }
@@ -234,7 +523,12 @@ namespace ElfBug
             onExec();
             // TODO: re-exec handling - re-detect arch and reject if no longer x86_64, clear breakpoints, refresh memory map, fire callback
             if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            {
+                if(errno != ESRCH)
+                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
+            else if(mThread)
+                mThread->setRunning(true);
             break;
         }
 
@@ -257,6 +551,7 @@ namespace ElfBug
             if(wasStepping && mThread)
             {
                 mThread->registers.Read();
+                stopAllThreads(pid);
                 beginPause();
                 cbStep();
                 pauseAndResume(pid);
@@ -264,7 +559,12 @@ namespace ElfBug
             }
 
             if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            {
+                if(errno != ESRCH)
+                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
+            else if(mThread)
+                mThread->setRunning(true);
             break;
         }
 
@@ -272,8 +572,12 @@ namespace ElfBug
         {
             abandonSingleStep(pid);
             // Notification only; exit is emitted via WIFEXITED/WIFSIGNALED in debugLoop.
+            // Left marked stopped: it owes no stop, so a sweep would block in waitpid.
             if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            {
+                if(errno != ESRCH)
+                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
             break;
         }
 
@@ -282,7 +586,10 @@ namespace ElfBug
             if(!mThread)
             {
                 if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                {
+                    if(errno != ESRCH)
+                        cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                }
                 break;
             }
 
@@ -300,6 +607,7 @@ namespace ElfBug
                 if(stepsPushf)
                     maskPushedTrapFlag();
                 restoreSourceByte(pid);
+                stopAllThreads(pid);
                 beginPause();
                 cbStep();
                 if(!pauseAndResume(pid))
@@ -338,6 +646,7 @@ namespace ElfBug
 
                         restoreSourceByte(pid);
 
+                        stopAllThreads(pid);
                         beginPause();
                         // Not ours: the user's own breakpoint fired at the target.
                         if(!planted)
@@ -353,12 +662,19 @@ namespace ElfBug
                         if(!stepPastBreakpointByte(pid, bpAddr))
                         {
                             cancelStepOver(pid);
+                            // An armed run is still inside a frozen window; this is the last
+                            // chance to lift it.
+                            abandonFreeze(pid);
                             break;
                         }
                         if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
                         {
                             if(errno != ESRCH)
                                 cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                        }
+                        else
+                        {
+                            mThread->setRunning(true);
                         }
                         break;
                     }
@@ -370,6 +686,7 @@ namespace ElfBug
                     mThread->registers.Write();
 
                     cancelStepOverIfOwner(pid);
+                    stopAllThreads(pid);
                     beginPause();
                     dispatchBreakpoint(bpAddr);
                     // The 0xCC stays armed with RIP on it; the next resume steps past it.
@@ -384,7 +701,12 @@ namespace ElfBug
             restoreSourceByte(pid);
 
             if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
-                cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            {
+                if(errno != ESRCH)
+                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
+            else
+                mThread->setRunning(true);
             break;
         }
         }

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Thread.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Thread.cpp
@@ -7,11 +7,20 @@ namespace ElfBug
         if(!mProcess)
             return;
 
+        // Already resumed if its own SIGSTOP was seen before this clone notification.
+        const bool alreadyRunning = mUnregisteredRunning.erase(tid) > 0;
+
+        bool inserted = false;
         {
             std::unique_lock lock(mProcessMutex);
-            mProcess->threads.emplace(tid, std::make_unique<Thread>(tid));
+            const auto result = mProcess->threads.emplace(tid, std::make_unique<Thread>(tid));
+            inserted = result.second;
+            if(alreadyRunning)
+                result.first->second->setRunning(true);
         }
-        cbCreateThreadEvent(tid);
+
+        if(inserted)
+            cbCreateThreadEvent(tid);
     }
 
     void Debugger::exitThreadEvent(const pid_t tid)

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
@@ -44,8 +44,7 @@ namespace ElfBug
         mPaused.store(true, std::memory_order_release);
     }
 
-    Thread* Debugger::findPendingBreakpointThread()
-    {
+    Thread* Debugger::findPendingBreakpointThread() const {
         if(!mProcess)
             return nullptr;
 
@@ -53,6 +52,19 @@ namespace ElfBug
         for(const auto & [tid, thread] : mProcess->threads)
         {
             if(thread->hasPendingBreakpoint())
+                return thread.get();
+        }
+        return nullptr;
+    }
+
+    Thread* Debugger::findPendingSignalThread() const {
+        if(!mProcess)
+            return nullptr;
+
+        std::shared_lock lock(mProcessMutex);
+        for(const auto & [tid, thread] : mProcess->threads)
+        {
+            if(thread->pendingSignal() != 0 && thread->pendingSignalUnreported())
                 return thread.get();
         }
         return nullptr;
@@ -111,7 +123,7 @@ namespace ElfBug
             }
 
             mPendingSignal = thread->pendingSignal();
-            thread->setPendingSignal(0);
+            thread->clearPendingSignal();
 
             const bool stepped = stepPastBreakpointByte(tid, rip);
             mPendingSignal = 0;
@@ -144,7 +156,7 @@ namespace ElfBug
 
             // The only delivery this queued signal will ever get.
             const int sig = thread->pendingSignal();
-            thread->setPendingSignal(0);
+            thread->clearPendingSignal();
 
             if(ptrace(PTRACE_CONT, tid, nullptr,
                       reinterpret_cast<void*>(static_cast<uintptr_t>(sig))) == -1)
@@ -187,7 +199,8 @@ namespace ElfBug
     {
         std::unique_lock lock(mPauseMutex);
 
-        while(mPaused.load(std::memory_order_acquire) && mIsRunning.load(std::memory_order_acquire))
+        while(mPaused.load(std::memory_order_acquire) && mIsRunning.load(std::memory_order_acquire) &&
+                !mStopRequested.load(std::memory_order_acquire))
         {
             if(mPauseCv.wait_for(lock, std::chrono::milliseconds(10)) == std::cv_status::timeout)
                 cbPauseTick();
@@ -199,7 +212,8 @@ namespace ElfBug
             return false;
 
         if(!mStepPending.load(std::memory_order_acquire) &&
-                !mStepOverPending.load(std::memory_order_acquire))
+                !mStepOverPending.load(std::memory_order_acquire) &&
+                !mStopRequested.load(std::memory_order_acquire))
         {
             while(Thread* queued = findPendingBreakpointThread())
             {
@@ -215,7 +229,7 @@ namespace ElfBug
                     std::shared_lock processLock(mProcessMutex);
                     const auto it = mProcess->threads.find(pid);
                     if(it != mProcess->threads.end())
-                        it->second->setPendingSignal(mPendingSignal);
+                        it->second->setPendingSignal(mPendingSignal, 0, false);
                 }
                 mPendingSignal = 0;
 
@@ -225,6 +239,31 @@ namespace ElfBug
                 }
                 beginPause();
                 dispatchBreakpoint(address);
+                return pauseAndResume(queuedTid);
+            }
+
+            while(Thread* queued = findPendingSignalThread())
+            {
+                const int signal = queued->pendingSignal();
+                const ptr address = queued->pendingSignalAddress();
+                const pid_t queuedTid = queued->tid;
+                queued->clearPendingSignal();
+
+                if(mPendingSignal != 0)
+                {
+                    std::shared_lock processLock(mProcessMutex);
+                    const auto it = mProcess->threads.find(pid);
+                    if(it != mProcess->threads.end())
+                        it->second->setPendingSignal(mPendingSignal, 0, false);
+                }
+                mPendingSignal = signal;
+
+                {
+                    std::unique_lock processLock(mProcessMutex);
+                    mThread = queued;
+                }
+                beginPause();
+                cbExceptionEvent(signal, address);
                 return pauseAndResume(queuedTid);
             }
         }

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
@@ -44,7 +44,8 @@ namespace ElfBug
         mPaused.store(true, std::memory_order_release);
     }
 
-    Thread* Debugger::findPendingBreakpointThread() const {
+    Thread* Debugger::findPendingBreakpointThread() const
+    {
         if(!mProcess)
             return nullptr;
 
@@ -57,7 +58,8 @@ namespace ElfBug
         return nullptr;
     }
 
-    Thread* Debugger::findPendingSignalThread() const {
+    Thread* Debugger::findPendingSignalThread() const
+    {
         if(!mProcess)
             return nullptr;
 

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
@@ -6,15 +6,181 @@
 #include <cerrno>
 #include <cstring>
 #include <chrono>
+#include <vector>
+#include <algorithm>
 
 namespace ElfBug
 {
+    namespace
+    {
+        struct ScopedExcept
+        {
+            std::vector<pid_t> & stack;
+
+            ScopedExcept(std::vector<pid_t> & excepts, const pid_t tid)
+                : stack(excepts)
+            {
+                stack.push_back(tid);
+            }
+
+            ~ScopedExcept()
+            {
+                stack.pop_back();
+            }
+
+            ScopedExcept(const ScopedExcept &) = delete;
+            ScopedExcept & operator=(const ScopedExcept &) = delete;
+        };
+    }
+
     // Publishes mPaused=true under the mutex before the event callback fires,
     // so a concurrent Continue()/Stop() can't race past and strand pauseAndResume().
     void Debugger::beginPause()
     {
+        // Every caller reports from a frozen process; only resumeAllThreads lifts it.
+        mAllStopped = true;
+
         std::lock_guard lock(mPauseMutex);
         mPaused.store(true, std::memory_order_release);
+    }
+
+    Thread* Debugger::findPendingBreakpointThread()
+    {
+        if(!mProcess)
+            return nullptr;
+
+        std::shared_lock lock(mProcessMutex);
+        for(const auto & [tid, thread] : mProcess->threads)
+        {
+            if(thread->hasPendingBreakpoint())
+                return thread.get();
+        }
+        return nullptr;
+    }
+
+    void Debugger::resumeAllThreads(const pid_t except)
+    {
+        mAllStopped = false;
+
+        if(!mProcess)
+            return;
+
+        const ScopedExcept scopedExcept(mResumeExcept, except);
+
+        std::vector<pid_t> stopped;
+        {
+            std::shared_lock lock(mProcessMutex);
+            for(const auto & [tid, thread] : mProcess->threads)
+            {
+                if(tid == except || thread->isRunning())
+                    continue;
+                if(std::find(mResumeExcept.begin(), mResumeExcept.end(), tid) != mResumeExcept.end())
+                    continue;
+                stopped.push_back(tid);
+            }
+        }
+
+        // Pass one: every thread steps off its own breakpoint while the rest stay frozen.
+        for(const pid_t tid : stopped)
+        {
+            if(!mProcess || !mIsRunning.load(std::memory_order_acquire))
+                return;
+
+            Thread* thread = nullptr;
+            {
+                std::shared_lock lock(mProcessMutex);
+                const auto it = mProcess->threads.find(tid);
+                if(it != mProcess->threads.end())
+                    thread = it->second.get();
+            }
+            if(!thread || thread->isRunning())
+                continue;
+
+            if(!thread->registers.Read())
+                continue;
+
+            const ptr rip = thread->registers.Gip();
+            if(!mProcess->HasBreakpoint(rip))
+                continue;
+
+            Thread* previous = nullptr;
+            {
+                std::unique_lock lock(mProcessMutex);
+                previous = mThread;
+                mThread = thread;
+            }
+
+            mPendingSignal = thread->pendingSignal();
+            thread->setPendingSignal(0);
+
+            const bool stepped = stepPastBreakpointByte(tid, rip);
+            mPendingSignal = 0;
+
+            if(!stepped && (!mProcess || !mIsRunning.load(std::memory_order_acquire)))
+                return;
+
+            {
+                std::unique_lock lock(mProcessMutex);
+                mThread = previous;
+            }
+        }
+
+        // Pass two: only now is anything actually running.
+        for(const pid_t tid : stopped)
+        {
+            if(!mProcess || !mIsRunning.load(std::memory_order_acquire))
+                return;
+
+            Thread* thread = nullptr;
+            {
+                std::shared_lock lock(mProcessMutex);
+                const auto it = mProcess->threads.find(tid);
+                if(it != mProcess->threads.end())
+                    thread = it->second.get();
+            }
+            // Pass one can leave a thread running, and it is no longer in ptrace-stop.
+            if(!thread || thread->isRunning())
+                continue;
+
+            // The only delivery this queued signal will ever get.
+            const int sig = thread->pendingSignal();
+            thread->setPendingSignal(0);
+
+            if(ptrace(PTRACE_CONT, tid, nullptr,
+                      reinterpret_cast<void*>(static_cast<uintptr_t>(sig))) == -1)
+            {
+                if(errno != ESRCH)
+                    cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+                continue;
+            }
+            thread->setRunning(true);
+        }
+    }
+
+    void Debugger::abandonFreeze(const pid_t except)
+    {
+        if(!mAllStopped)
+            return;
+
+        if(mProcess)
+        {
+            bool anyRunning = false;
+            {
+                std::shared_lock lock(mProcessMutex);
+                for(const auto & [tid, thread] : mProcess->threads)
+                {
+                    if(thread->isRunning())
+                    {
+                        anyRunning = true;
+                        break;
+                    }
+                }
+            }
+            if(anyRunning)
+                return;
+        }
+
+        resumeAllThreads(except);
     }
 
     bool Debugger::pauseAndResume(const pid_t pid)
@@ -32,6 +198,37 @@ namespace ElfBug
         if(!mIsRunning.load(std::memory_order_acquire))
             return false;
 
+        if(!mStepPending.load(std::memory_order_acquire) &&
+                !mStepOverPending.load(std::memory_order_acquire))
+        {
+            while(Thread* queued = findPendingBreakpointThread())
+            {
+                const ptr address = queued->pendingBreakpoint();
+                const pid_t queuedTid = queued->tid;
+                queued->clearPendingBreakpoint();
+
+                if(!mProcess || !mProcess->HasBreakpoint(address))
+                    continue;
+
+                if(mPendingSignal != 0)
+                {
+                    std::shared_lock processLock(mProcessMutex);
+                    const auto it = mProcess->threads.find(pid);
+                    if(it != mProcess->threads.end())
+                        it->second->setPendingSignal(mPendingSignal);
+                }
+                mPendingSignal = 0;
+
+                {
+                    std::unique_lock processLock(mProcessMutex);
+                    mThread = queued;
+                }
+                beginPause();
+                dispatchBreakpoint(address);
+                return pauseAndResume(queuedTid);
+            }
+        }
+
         bool stepOverRequested = mStepOverPending.exchange(false, std::memory_order_acq_rel);
 
         const bool stepIntoRequested = mStepPending.load(std::memory_order_acquire);
@@ -45,9 +242,8 @@ namespace ElfBug
             ptr next = 0;
             const bool repeats = mProcess->ClassifyStepOverAt(rip, next) == StepOverKind::Rep;
 
-            // Stepping off would consume the user's step, and for a repeated instruction
-            // it only runs one iteration and leaves RIP in place, so the resume would
-            // trap again immediately. Lift the byte instead and re-arm at the next stop.
+            // Stepping off would consume the user's step, and a rep only advances one
+            // iteration, leaving RIP on the byte. Lift it and re-arm at the next stop.
             if(stepIntoRequested || repeats)
             {
                 if(mProcess->DisarmBreakpointByte(rip))
@@ -55,6 +251,7 @@ namespace ElfBug
             }
             else if(!stepPastBreakpointByte(pid, rip))
             {
+                abandonFreeze(pid);
                 return false;
             }
         }
@@ -67,6 +264,7 @@ namespace ElfBug
             switch(armStepOver(pid))
             {
             case StepOverArm::Consumed:
+                abandonFreeze(pid);
                 return false;
 
             case StepOverArm::Armed:
@@ -79,6 +277,10 @@ namespace ElfBug
                     if(errno != ESRCH)
                         cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
                     cancelStepOver(pid);
+                }
+                else
+                {
+                    mThread->setRunning(true);
                 }
                 return true;
             }
@@ -96,9 +298,17 @@ namespace ElfBug
             ptr next = 0;
             const bool stepsPushf = mProcess &&
                                     mProcess->ClassifyStepOverAt(mThread->registers.Gip(), next) == StepOverKind::Pushf;
+            // Otherwise the step is spent delivering the SIGSTOP.
+            if(!swallowPendingSigstop(pid))
+            {
+                restoreSourceByte(pid);
+                abandonFreeze(pid);
+                return false;
+            }
             if(mThread->StepInto(sig))
             {
                 mThread->setStepsPushf(stepsPushf);
+                mThread->setRunning(true);
             }
             else
             {
@@ -113,6 +323,15 @@ namespace ElfBug
                         if(errno != ESRCH)
                             cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
                     }
+                    else
+                    {
+                        mThread->setRunning(true);
+                    }
+                }
+                else
+                {
+                    restoreSourceByte(pid);
+                    abandonFreeze(pid);
                 }
             }
         }
@@ -120,11 +339,20 @@ namespace ElfBug
         {
             const int sig = mPendingSignal;
             mPendingSignal = 0;
+
+            resumeAllThreads(pid);
+            if(!mProcess || !mIsRunning.load(std::memory_order_acquire))
+                return false;
+
             if(ptrace(PTRACE_CONT, pid, nullptr,
                       reinterpret_cast<void*>(static_cast<uintptr_t>(sig))) == -1)
             {
                 if(errno != ESRCH)
                     cbInternalError("PTRACE_CONT failed: " + std::string(strerror(errno)));
+            }
+            else if(mThread)
+            {
+                mThread->setRunning(true);
             }
         }
         return true;

--- a/src/cross/ElfBug/ElfBug/core/Debugger.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.cpp
@@ -38,6 +38,7 @@ namespace ElfBug
         mUnregisteredRunning.clear();
         mAllStopped = false;
         mPauseRequested.store(false, std::memory_order_release);
+        mStopRequested.store(false, std::memory_order_release);
         mPendingSignal = 0;
 
         if(!szFilePath)
@@ -290,7 +291,7 @@ namespace ElfBug
             for(const auto & [tid, thread] : mProcess->threads)
             {
                 thread->clearPendingBreakpoint();
-                thread->setPendingSignal(0);
+                thread->clearPendingSignal();
             }
         }
 
@@ -389,6 +390,7 @@ namespace ElfBug
 
         {
             std::lock_guard lock(mPauseMutex);
+            mStopRequested.store(true, std::memory_order_release);
             mPaused.store(false, std::memory_order_release);
         }
         mPauseCv.notify_one();

--- a/src/cross/ElfBug/ElfBug/core/Debugger.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.cpp
@@ -8,6 +8,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstring>
+#include <ranges>
 
 namespace ElfBug
 {
@@ -35,6 +36,8 @@ namespace ElfBug
         mStepOverPending.store(false, std::memory_order_release);
         mStepOver = {};
         mSourceRearms.clear();
+        mUnregisteredRunning.clear();
+        mAllStopped = false;
         mPauseRequested.store(false, std::memory_order_release);
         mPendingSignal = 0;
 
@@ -278,6 +281,19 @@ namespace ElfBug
         // exec killed every other thread and replaced the image, so every entry is stale.
         // A worker's exec is reported under the leader's tid, so the owner is not checked.
         mSourceRearms.clear();
+        mUnregisteredRunning.clear();
+
+        mAllStopped = false;
+
+        if(mProcess)
+        {
+            std::shared_lock lock(mProcessMutex);
+            for(const auto &thread: mProcess->threads | std::views::values)
+            {
+                thread->clearPendingBreakpoint();
+                thread->setPendingSignal(0);
+            }
+        }
 
         if(mStepOver.active)
         {

--- a/src/cross/ElfBug/ElfBug/core/Debugger.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.cpp
@@ -8,7 +8,6 @@
 #include <csignal>
 #include <cstdio>
 #include <cstring>
-#include <ranges>
 
 namespace ElfBug
 {
@@ -288,7 +287,7 @@ namespace ElfBug
         if(mProcess)
         {
             std::shared_lock lock(mProcessMutex);
-            for(const auto &thread: mProcess->threads | std::views::values)
+            for(const auto & [tid, thread] : mProcess->threads)
             {
                 thread->clearPendingBreakpoint();
                 thread->setPendingSignal(0);

--- a/src/cross/ElfBug/ElfBug/core/Debugger.h
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.h
@@ -7,6 +7,7 @@
 #include <condition_variable>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <ElfBug/types/ElfBug.h>
 #include <ElfBug/types/Global.h>
@@ -67,6 +68,13 @@ namespace ElfBug
         // The image was replaced: drop step state without writing anything back.
         void onExec();
 
+        void stopAllThreads(pid_t except);
+        bool swallowPendingSigstop(pid_t tid);
+        void resumeAllThreads(pid_t except);
+        void abandonFreeze(pid_t except);
+        Thread* findPendingBreakpointThread();
+        void repairStoppedThread(Thread* thread, int status);
+
         struct StepOverRequest
         {
             bool active = false;
@@ -105,6 +113,10 @@ namespace ElfBug
         StepOverRequest mStepOver;
         // Lifted breakpoint bytes, re-armed when the lifting thread next stops.
         std::unordered_map<pid_t, ptr> mSourceRearms;
+        std::vector<pid_t> mResumeExcept;
+        std::unordered_set<pid_t> mUnregisteredRunning;
+        bool mAllStopped = false;
+        pid_t mSteppingOff = 0;
         std::atomic<bool> mPauseRequested{false};
         std::atomic<pid_t> mMainPid{0};
         int mPendingSignal = 0;

--- a/src/cross/ElfBug/ElfBug/core/Debugger.h
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.h
@@ -72,8 +72,10 @@ namespace ElfBug
         bool swallowPendingSigstop(pid_t tid);
         void resumeAllThreads(pid_t except);
         void abandonFreeze(pid_t except);
-        Thread* findPendingBreakpointThread();
-        void repairStoppedThread(Thread* thread, int status);
+        Thread* findPendingBreakpointThread() const;
+        Thread* findPendingSignalThread() const;
+        void repairStoppedThread(Thread* thread, int status) const;
+        void reportSignal(pid_t pid, int sig);
 
         struct StepOverRequest
         {
@@ -118,6 +120,7 @@ namespace ElfBug
         bool mAllStopped = false;
         pid_t mSteppingOff = 0;
         std::atomic<bool> mPauseRequested{false};
+        std::atomic<bool> mStopRequested{false};
         std::atomic<pid_t> mMainPid{0};
         int mPendingSignal = 0;
         std::mutex mPauseMutex;

--- a/src/cross/ElfBug/ElfBug/thread/Thread.h
+++ b/src/cross/ElfBug/ElfBug/thread/Thread.h
@@ -24,6 +24,32 @@ namespace ElfBug
         void setStepsPushf(const bool stepsPushf) { mStepsPushf = stepsPushf; }
         [[nodiscard]] bool stepsPushf() const { return mStepsPushf; }
 
+        // Constructed stopped: a clone is reported to us already stopped, and the main
+        // thread stops on exec.
+        void setRunning(const bool running) { mRunning = running; }
+        [[nodiscard]] bool isRunning() const { return mRunning; }
+
+        // Set when our SIGSTOP was still queued because the thread stopped for its own
+        // reason first. It must be consumed before this thread is single-stepped.
+        void setPendingSigstop(const bool pending) { mPendingSigstop = pending; }
+        [[nodiscard]] bool pendingSigstop() const { return mPendingSigstop; }
+
+        // A breakpoint this thread hit just before the sweep froze it. Reported on the
+        // next resume instead of being absorbed.
+        void setPendingBreakpoint(const ptr address)
+        {
+            mHasPendingBreakpoint = true;
+            mPendingBreakpoint = address;
+        }
+        void clearPendingBreakpoint() { mHasPendingBreakpoint = false; mPendingBreakpoint = 0; }
+        [[nodiscard]] bool hasPendingBreakpoint() const { return mHasPendingBreakpoint; }
+        [[nodiscard]] ptr pendingBreakpoint() const { return mPendingBreakpoint; }
+
+        // A signal the sweep read off the wait status, forwarded on the resume that
+        // unfreezes the thread. 0 means none.
+        void setPendingSignal(const int signal) { mPendingSignal = signal; }
+        [[nodiscard]] int pendingSignal() const { return mPendingSignal; }
+
         // TODO: implement via PTRACE_POKEUSER on debug register offsets
         [[nodiscard]] bool GetFreeHardwareBreakpointSlot(const HardwareSlot & slot) const;
         bool SetHardwareBreakpoint(ptr address, HardwareSlot slot, HardwareType type = HardwareType::Execute, HardwareSize size = HardwareSize::Byte, bool singleshot = false);
@@ -33,5 +59,10 @@ namespace ElfBug
     private:
         bool mIsSingleStepping = false;
         bool mStepsPushf = false;
+        bool mRunning = false;
+        bool mPendingSigstop = false;
+        bool mHasPendingBreakpoint = false;
+        ptr mPendingBreakpoint = 0;
+        int mPendingSignal = 0;
     };
 }

--- a/src/cross/ElfBug/ElfBug/thread/Thread.h
+++ b/src/cross/ElfBug/ElfBug/thread/Thread.h
@@ -46,9 +46,17 @@ namespace ElfBug
         [[nodiscard]] ptr pendingBreakpoint() const { return mPendingBreakpoint; }
 
         // A signal the sweep read off the wait status, forwarded on the resume that
-        // unfreezes the thread. 0 means none.
-        void setPendingSignal(const int signal) { mPendingSignal = signal; }
+        // unfreezes the thread. 0 means none. Unreported until pauseAndResume reports it.
+        void setPendingSignal(const int signal, const ptr address, const bool unreported)
+        {
+            mPendingSignal = signal;
+            mPendingSignalAddress = address;
+            mPendingSignalUnreported = unreported;
+        }
+        void clearPendingSignal() { setPendingSignal(0, 0, false); }
         [[nodiscard]] int pendingSignal() const { return mPendingSignal; }
+        [[nodiscard]] ptr pendingSignalAddress() const { return mPendingSignalAddress; }
+        [[nodiscard]] bool pendingSignalUnreported() const { return mPendingSignalUnreported; }
 
         // TODO: implement via PTRACE_POKEUSER on debug register offsets
         [[nodiscard]] bool GetFreeHardwareBreakpointSlot(const HardwareSlot & slot) const;
@@ -64,5 +72,7 @@ namespace ElfBug
         bool mHasPendingBreakpoint = false;
         ptr mPendingBreakpoint = 0;
         int mPendingSignal = 0;
+        ptr mPendingSignalAddress = 0;
+        bool mPendingSignalUnreported = false;
     };
 }

--- a/src/cross/ElfBug/tests/CMakeLists.txt
+++ b/src/cross/ElfBug/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ add_dependencies(ElfBug_tests
     elfbug_fixture_exec_target
     elfbug_fixture_threads_spin
     elfbug_fixture_exit_race
+    elfbug_fixture_signal_race
 )
 
 # Target: elfbug_fixture_end_immediately
@@ -430,4 +431,41 @@ set_target_properties(elfbug_fixture_exit_race PROPERTIES
 get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
 if(NOT CMKR_VS_STARTUP_PROJECT)
 	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_exit_race)
+endif()
+
+# Target: elfbug_fixture_signal_race
+set(elfbug_fixture_signal_race_SOURCES
+	cmake.toml
+	"targets/signal_race.cpp"
+)
+
+add_executable(elfbug_fixture_signal_race)
+
+target_sources(elfbug_fixture_signal_race PRIVATE ${elfbug_fixture_signal_race_SOURCES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${elfbug_fixture_signal_race_SOURCES})
+
+target_compile_options(elfbug_fixture_signal_race PRIVATE
+	-g
+	-O0
+	-pie
+)
+
+target_link_options(elfbug_fixture_signal_race PRIVATE
+	-pie
+)
+
+target_link_libraries(elfbug_fixture_signal_race PRIVATE
+	pthread
+)
+
+set_target_properties(elfbug_fixture_signal_race PROPERTIES
+	OUTPUT_NAME
+		signal_race
+	RUNTIME_OUTPUT_DIRECTORY
+		"${CMAKE_BINARY_DIR}/tests/targets"
+)
+
+get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
+if(NOT CMKR_VS_STARTUP_PROJECT)
+	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_signal_race)
 endif()

--- a/src/cross/ElfBug/tests/CMakeLists.txt
+++ b/src/cross/ElfBug/tests/CMakeLists.txt
@@ -86,6 +86,8 @@ add_dependencies(ElfBug_tests
     elfbug_fixture_multi_threaded
     elfbug_fixture_step_over_targets
     elfbug_fixture_exec_target
+    elfbug_fixture_threads_spin
+    elfbug_fixture_exit_race
 )
 
 # Target: elfbug_fixture_end_immediately
@@ -354,4 +356,78 @@ set_target_properties(elfbug_fixture_exec_target PROPERTIES
 get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
 if(NOT CMKR_VS_STARTUP_PROJECT)
 	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_exec_target)
+endif()
+
+# Target: elfbug_fixture_threads_spin
+set(elfbug_fixture_threads_spin_SOURCES
+	cmake.toml
+	"targets/threads_spin.cpp"
+)
+
+add_executable(elfbug_fixture_threads_spin)
+
+target_sources(elfbug_fixture_threads_spin PRIVATE ${elfbug_fixture_threads_spin_SOURCES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${elfbug_fixture_threads_spin_SOURCES})
+
+target_compile_options(elfbug_fixture_threads_spin PRIVATE
+	-g
+	-O0
+	-pie
+)
+
+target_link_options(elfbug_fixture_threads_spin PRIVATE
+	-pie
+)
+
+target_link_libraries(elfbug_fixture_threads_spin PRIVATE
+	pthread
+)
+
+set_target_properties(elfbug_fixture_threads_spin PROPERTIES
+	OUTPUT_NAME
+		threads_spin
+	RUNTIME_OUTPUT_DIRECTORY
+		"${CMAKE_BINARY_DIR}/tests/targets"
+)
+
+get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
+if(NOT CMKR_VS_STARTUP_PROJECT)
+	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_threads_spin)
+endif()
+
+# Target: elfbug_fixture_exit_race
+set(elfbug_fixture_exit_race_SOURCES
+	cmake.toml
+	"targets/exit_race.cpp"
+)
+
+add_executable(elfbug_fixture_exit_race)
+
+target_sources(elfbug_fixture_exit_race PRIVATE ${elfbug_fixture_exit_race_SOURCES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${elfbug_fixture_exit_race_SOURCES})
+
+target_compile_options(elfbug_fixture_exit_race PRIVATE
+	-g
+	-O0
+	-pie
+)
+
+target_link_options(elfbug_fixture_exit_race PRIVATE
+	-pie
+)
+
+target_link_libraries(elfbug_fixture_exit_race PRIVATE
+	pthread
+)
+
+set_target_properties(elfbug_fixture_exit_race PROPERTIES
+	OUTPUT_NAME
+		exit_race
+	RUNTIME_OUTPUT_DIRECTORY
+		"${CMAKE_BINARY_DIR}/tests/targets"
+)
+
+get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
+if(NOT CMKR_VS_STARTUP_PROJECT)
+	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_exit_race)
 endif()

--- a/src/cross/ElfBug/tests/cmake.toml
+++ b/src/cross/ElfBug/tests/cmake.toml
@@ -34,6 +34,8 @@ add_dependencies(ElfBug_tests
     elfbug_fixture_multi_threaded
     elfbug_fixture_step_over_targets
     elfbug_fixture_exec_target
+    elfbug_fixture_threads_spin
+    elfbug_fixture_exit_race
 )
 """
 
@@ -89,4 +91,18 @@ properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"
 type = "elfbug_fixture"
 sources = ["targets/exec_target.cpp"]
 properties.OUTPUT_NAME = "exec_target"
+properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"
+
+[target.elfbug_fixture_threads_spin]
+type = "elfbug_fixture"
+sources = ["targets/threads_spin.cpp"]
+link-libraries = ["pthread"]
+properties.OUTPUT_NAME = "threads_spin"
+properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"
+
+[target.elfbug_fixture_exit_race]
+type = "elfbug_fixture"
+sources = ["targets/exit_race.cpp"]
+link-libraries = ["pthread"]
+properties.OUTPUT_NAME = "exit_race"
 properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"

--- a/src/cross/ElfBug/tests/cmake.toml
+++ b/src/cross/ElfBug/tests/cmake.toml
@@ -36,6 +36,7 @@ add_dependencies(ElfBug_tests
     elfbug_fixture_exec_target
     elfbug_fixture_threads_spin
     elfbug_fixture_exit_race
+    elfbug_fixture_signal_race
 )
 """
 
@@ -105,4 +106,11 @@ type = "elfbug_fixture"
 sources = ["targets/exit_race.cpp"]
 link-libraries = ["pthread"]
 properties.OUTPUT_NAME = "exit_race"
+properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"
+
+[target.elfbug_fixture_signal_race]
+type = "elfbug_fixture"
+sources = ["targets/signal_race.cpp"]
+link-libraries = ["pthread"]
+properties.OUTPUT_NAME = "signal_race"
 properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"

--- a/src/cross/ElfBug/tests/targets/exit_race.cpp
+++ b/src/cross/ElfBug/tests/targets/exit_race.cpp
@@ -1,0 +1,53 @@
+// One worker calls _exit while the others hot-loop through a breakpoint site, so a stop
+// sweep runs with the leader already dying.
+#include <pthread.h>
+#include <unistd.h>
+#include <ctime>
+
+extern "C"
+{
+    // The debugger writes 1 here to start the exit.
+    volatile int er_exit_now = 0;
+    // Breakpoint site: the spinners pass through it constantly.
+    void er_hot();
+}
+
+extern "C" void er_hot()
+{
+}
+
+namespace
+{
+    void nap()
+    {
+        timespec ts{0, 100000};
+        nanosleep(&ts, nullptr);
+    }
+
+    void* exiter(void*)
+    {
+        while(er_exit_now == 0)
+            nap();
+        _exit(7);
+        return nullptr;
+    }
+
+    void* spinner(void*)
+    {
+        for(;;)
+            er_hot();
+        return nullptr;
+    }
+}
+
+int main()
+{
+    pthread_t threads[4];
+    pthread_create(&threads[0], nullptr, exiter, nullptr);
+    for(int i = 1; i < 4; ++i)
+        pthread_create(&threads[i], nullptr, spinner, nullptr);
+
+    for(;;)
+        nap();
+    return 0;
+}

--- a/src/cross/ElfBug/tests/targets/signal_race.cpp
+++ b/src/cross/ElfBug/tests/targets/signal_race.cpp
@@ -1,0 +1,83 @@
+// Two spinners hot-loop through a breakpoint site, so every hit sweeps the others, while
+// a third thread raises a signal at itself in a tight loop. Whichever raise the sweep
+// absorbs instead of the main loop is the case under test.
+#include <pthread.h>
+#include <csignal>
+#include <ctime>
+#include <unistd.h>
+
+extern "C"
+{
+    // The debugger writes the signal and quota, then sets sr_go.
+    volatile int sr_signal = 0;
+    volatile int sr_quota = 0;
+    volatile int sr_go = 0;
+    // Raises that returned, handler runs seen, and set once every raise has returned.
+    volatile int sr_raised = 0;
+    volatile int sr_handled = 0;
+    volatile int sr_done = 0;
+    // Breakpoint site: the spinners pass through it constantly.
+    void sr_hot();
+}
+
+extern "C" void sr_hot()
+{
+}
+
+namespace
+{
+    void onSignal(int)
+    {
+        sr_handled = sr_handled + 1;
+    }
+
+    void nap()
+    {
+        constexpr timespec ts{0, 100000};
+        nanosleep(&ts, nullptr);
+    }
+
+    // raise() returns only after the handler ran, or at once if the debugger suppressed
+    // the signal, so sr_raised counts attempts and sr_handled counts deliveries.
+    void* raiser(void*)
+    {
+        while(sr_go == 0)
+            nap();
+        while(sr_raised < sr_quota)
+        {
+            raise(sr_signal);
+            sr_raised = sr_raised + 1;
+        }
+        sr_done = 1;
+        for(;;)
+            nap();
+        return nullptr;
+    }
+
+    void* spinner(void*)
+    {
+        for(;;)
+            sr_hot();
+        return nullptr;
+    }
+}
+
+int main()
+{
+    struct sigaction sa = {};
+    sa.sa_handler = onSignal;
+    sigaction(SIGUSR1, &sa, nullptr);
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGTRAP, &sa, nullptr);
+
+    // Spinners first: waitpid(-1) walks tracees in attach order, so their traps are seen
+    // before the raiser's stop and the sweep is what finds it.
+    pthread_t threads[3];
+    for(int i = 0; i < 2; ++i)
+        pthread_create(&threads[i], nullptr, spinner, nullptr);
+    pthread_create(&threads[2], nullptr, raiser, nullptr);
+
+    for(;;)
+        nap();
+    return 0;
+}

--- a/src/cross/ElfBug/tests/targets/threads_spin.cpp
+++ b/src/cross/ElfBug/tests/targets/threads_spin.cpp
@@ -1,0 +1,105 @@
+// Long-lived workers, so a test can tell a frozen tracee from a running one by watching
+// the counters. Each worker writes only its own slot.
+#include <pthread.h>
+#include <csignal>
+#include <ctime>
+#include <sys/mman.h>
+#include <unistd.h>
+
+extern "C"
+{
+    volatile unsigned long long ts_counters[4] = {0, 0, 0, 0};
+    // The debugger writes 1 here to let the tracee exit cleanly.
+    volatile int ts_stop = 0;
+    // Breakpoint site: every worker passes through it exactly once.
+    void ts_worker_started(int index);
+    // Breakpoint site on the main thread, which touches no counter.
+    void ts_tick();
+
+    // The debugger writes 1 here to make the main thread fault once per loop.
+    volatile int ts_fault_armed = 0;
+    // Points at a page the main loop keeps read-only while the fault is armed.
+    void* ts_fault_target = nullptr;
+    void ts_fault();
+    // Labels the faulting store, so a breakpoint can sit on it and the step off that byte
+    // is what faults.
+    void ts_fault_site();
+}
+
+asm(R"(
+    .text
+
+    .globl ts_fault
+    .type  ts_fault, @function
+ts_fault:
+    movq    ts_fault_target(%rip), %rax
+    .globl ts_fault_site
+ts_fault_site:
+    movl    $1, (%rax)
+    ret
+)");
+
+extern "C" void ts_worker_started(const int index)
+{
+    (void)index;
+}
+
+extern "C" void ts_tick()
+{
+}
+
+namespace
+{
+    void* worker(void* arg)
+    {
+        const auto index = static_cast<int>(reinterpret_cast<long>(arg));
+        ts_worker_started(index);
+        while(ts_stop == 0)
+            ts_counters[index] = ts_counters[index] + 1;
+        return nullptr;
+    }
+}
+
+namespace
+{
+    long pageSize = 4096;
+
+    // Make the store land on retry, so a reported fault does not kill the tracee.
+    void onFault(int)
+    {
+        mprotect(ts_fault_target, static_cast<size_t>(pageSize), PROT_READ | PROT_WRITE);
+    }
+}
+
+int main()
+{
+    pageSize = sysconf(_SC_PAGESIZE);
+    if(pageSize <= 0)
+        pageSize = 4096;
+    ts_fault_target = mmap(nullptr, static_cast<size_t>(pageSize), PROT_READ,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    struct sigaction sa = {};
+    sa.sa_handler = onFault;
+    sigaction(SIGSEGV, &sa, nullptr);
+
+    pthread_t threads[4];
+    for(long i = 0; i < 4; ++i)
+        pthread_create(&threads[i], nullptr, worker, reinterpret_cast<void*>(i));
+
+    while(ts_stop == 0)
+    {
+        ts_tick();
+        if(ts_fault_armed)
+        {
+            mprotect(ts_fault_target, static_cast<size_t>(pageSize), PROT_READ);
+            ts_fault();
+        }
+        timespec ts{0, 1000000};
+        nanosleep(&ts, nullptr);
+    }
+
+    for(auto & t : threads)
+        pthread_join(t, nullptr);
+    return 0;
+}

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -2175,3 +2175,162 @@ TEST_CASE("A process exit racing the stop sweep is still reported", "[multithrea
         REQUIRE(dbg.count(EventType::InternalError) == 0);
     }
 }
+
+namespace
+{
+    struct SignalRaceResult
+    {
+        int raised = 0;
+        int handled = 0;
+        std::size_t reported = 0;
+    };
+
+    // The raiser sits in signal-delivery-stop almost constantly, so the sweep run by every
+    // spinner hit absorbs a share of its raises that the main loop would otherwise report.
+    SignalRaceResult RunSignalRace(const int signal, const int quota)
+    {
+        using namespace ElfBug::test;
+        RecordingDebugger dbg;
+        const std::string path = FIXTURE("signal_race");
+        REQUIRE(dbg.Init(path.c_str()));
+
+        struct Sites
+        {
+            std::optional<ElfBug::ptr> hot;
+            std::optional<ElfBug::ptr> signal;
+            std::optional<ElfBug::ptr> quota;
+            std::optional<ElfBug::ptr> go;
+            std::optional<ElfBug::ptr> raised;
+            std::optional<ElfBug::ptr> handled;
+            std::optional<ElfBug::ptr> done;
+        };
+
+        std::promise<Sites> promise;
+        auto future = promise.get_future();
+        dbg.OnSystemBreakpoint([&]
+        {
+            Sites s;
+            const pid_t pid = dbg.process()->pid;
+            s.hot = ResolveRuntimeAddress(path, pid, "sr_hot");
+            s.signal = ResolveRuntimeAddress(path, pid, "sr_signal");
+            s.quota = ResolveRuntimeAddress(path, pid, "sr_quota");
+            s.go = ResolveRuntimeAddress(path, pid, "sr_go");
+            s.raised = ResolveRuntimeAddress(path, pid, "sr_raised");
+            s.handled = ResolveRuntimeAddress(path, pid, "sr_handled");
+            s.done = ResolveRuntimeAddress(path, pid, "sr_done");
+            if(s.hot)
+                dbg.process()->SetBreakpoint(*s.hot, false, ElfBug::SoftwareType::ShortInt3);
+            promise.set_value(s);
+        });
+
+        dbg.StartOnThread();
+        dbg.WaitForSystemBreakpoint();
+        const auto s = future.get();
+        REQUIRE(s.hot.has_value());
+        REQUIRE(s.signal.has_value());
+        REQUIRE(s.quota.has_value());
+        REQUIRE(s.go.has_value());
+        REQUIRE(s.raised.has_value());
+        REQUIRE(s.handled.has_value());
+        REQUIRE(s.done.has_value());
+
+        REQUIRE(dbg.process()->MemWrite(*s.signal, &signal, sizeof(signal)));
+        REQUIRE(dbg.process()->MemWrite(*s.quota, &quota, sizeof(quota)));
+
+        // Stop on a spinner first, so every raise below happens under a sweeping process.
+        dbg.Continue();
+        dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+        constexpr int go = 1;
+        REQUIRE(dbg.process()->MemWrite(*s.go, &go, sizeof(go)));
+
+        int done = 0;
+        for(int round = 0; round < 4000 && done == 0; ++round)
+        {
+            dbg.Continue();
+            dbg.WaitForAny({EventType::Breakpoint, EventType::Exception}, std::chrono::seconds(10));
+            REQUIRE(dbg.process()->MemRead(*s.done, &done, sizeof(done)));
+        }
+
+        SignalRaceResult r;
+        REQUIRE(dbg.process()->MemRead(*s.raised, &r.raised, sizeof(r.raised)));
+        REQUIRE(dbg.process()->MemRead(*s.handled, &r.handled, sizeof(r.handled)));
+        CAPTURE(r.raised, r.handled);
+        REQUIRE(done == 1);
+        for(const auto & e : dbg.events())
+        {
+            if(e.type == EventType::Exception && e.signal == signal)
+                ++r.reported;
+        }
+
+        // Checked before Stop so a wedged debugger cannot hide the numbers.
+        REQUIRE(r.raised == quota);
+        REQUIRE(r.handled == r.raised);
+        REQUIRE(r.reported == static_cast<std::size_t>(r.raised));
+
+        // Stop() races an in-flight stop: a spinner trapping after the kill is sent would
+        // pause a tracer that then never returns to waitpid. Disarm the site first.
+        REQUIRE(dbg.process()->DeleteBreakpoint(*s.hot));
+        dbg.Stop();
+        dbg.WaitForExit();
+        dbg.JoinThread();
+        REQUIRE(dbg.count(EventType::InternalError) == 0);
+        return r;
+    }
+}
+
+// A queued signal the sweep absorbs is delivered on the resume, but nothing reports it, so
+// whether the user sees a SIGUSR1 depends on which waitpid happened to win.
+TEST_CASE("Signals absorbed by the stop sweep are still reported", "[multithread][exception]")
+{
+    RunSignalRace(SIGUSR1, 200);
+}
+
+// A hardware fault re-raises itself when the instruction runs again, so dropping it is free.
+// A raised SIGSEGV does not, so dropping it on the resume loses it for good.
+TEST_CASE("Raised fatal signals absorbed by the stop sweep are still delivered", "[multithread][exception]")
+{
+    RunSignalRace(SIGSEGV, 200);
+}
+
+// int3 and single-step traps are the debugger's own, but a SIGTRAP the tracee raised at
+// itself is a plain signal, and continuing it with signal 0 loses it exactly like SIGSEGV.
+TEST_CASE("A raised SIGTRAP is delivered and reported", "[multithread][exception]")
+{
+    RunSignalRace(SIGTRAP, 200);
+}
+
+TEST_CASE("Stop while a hot-path breakpoint is armed still reports the exit", "[multithread][process]")
+{
+    using namespace ElfBug::test;
+
+    for(int attempt = 0; attempt < 5; ++attempt)
+    {
+        RecordingDebugger dbg;
+        const std::string path = FIXTURE("exit_race");
+        REQUIRE(dbg.Init(path.c_str()));
+
+        std::promise<std::optional<ElfBug::ptr>> promise;
+        auto future = promise.get_future();
+        dbg.OnSystemBreakpoint([&]
+        {
+            const auto hot = ResolveRuntimeAddress(path, dbg.process()->pid, "er_hot");
+            if(hot)
+                dbg.process()->SetBreakpoint(*hot, false, ElfBug::SoftwareType::ShortInt3);
+            promise.set_value(hot);
+        });
+
+        dbg.StartOnThread();
+        dbg.WaitForSystemBreakpoint();
+        REQUIRE(future.get().has_value());
+
+        dbg.Continue();
+        dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+
+        REQUIRE(dbg.Stop());
+        const auto exit_ev = dbg.WaitFor(EventType::ExitProcess, std::chrono::seconds(10));
+        dbg.JoinThread();
+
+        REQUIRE(exit_ev.exitCode == -SIGKILL);
+        REQUIRE(dbg.count(EventType::InternalError) == 0);
+    }
+}

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -1450,19 +1450,16 @@ TEST_CASE("Breakpoint on a hot path does not lose thread-creation events", "[mul
     dbg.StartOnThread();
     dbg.WaitForSystemBreakpoint();
 
-    // The first worker to arrive always traps. A later one can run through while that
-    // thread steps off the lifted byte (no all-stop yet), so resume on every hit until
-    // exit rather than demanding five.
-    dbg.Continue();
-    dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
-
-    Event exit_ev;
-    do
+    // Every worker must report: all-stop closes the window where one could run past a
+    // breakpoint another thread has lifted.
+    for(int i = 0; i < 5; ++i)
     {
         dbg.Continue();
-        exit_ev = dbg.WaitForAny({EventType::Breakpoint, EventType::ExitProcess}, std::chrono::seconds(20));
+        dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
     }
-    while(exit_ev.type != EventType::ExitProcess);
+
+    dbg.Continue();
+    const auto exit_ev = dbg.WaitFor(EventType::ExitProcess, std::chrono::seconds(20));
 
     std::set<pid_t> createdTids;
     for(const auto & e : dbg.events())
@@ -1471,8 +1468,7 @@ TEST_CASE("Breakpoint on a hot path does not lose thread-creation events", "[mul
 
     REQUIRE(exit_ev.exitCode == 5);
     REQUIRE(createdTids.size() == 5);
-    REQUIRE(dbg.count(EventType::Breakpoint) >= 1);
-    REQUIRE(dbg.count(EventType::Breakpoint) <= 5);
+    REQUIRE(dbg.count(EventType::Breakpoint) == 5);
     REQUIRE(dbg.count(EventType::InternalError) == 0);
 }
 
@@ -1768,4 +1764,414 @@ TEST_CASE("MemRead never returns a breakpoint byte while breakpoints change", "[
     dbg.Continue();
     dbg.WaitForExit();
     dbg.JoinThread();
+}
+
+TEST_CASE("threads_spin starts four long-lived workers", "[multithread]")
+{
+    using namespace ElfBug::test;
+    RecordingDebugger dbg;
+    const std::string path = FIXTURE("threads_spin");
+    REQUIRE(dbg.Init(path.c_str()));
+
+    dbg.StartOnThread();
+    dbg.WaitForSystemBreakpoint();
+    dbg.Continue();
+
+    for(int i = 0; i < 4; ++i)
+        dbg.WaitFor(EventType::CreateThread, std::chrono::seconds(10));
+
+    dbg.Stop();
+    dbg.WaitForExit();
+    dbg.JoinThread();
+    REQUIRE(dbg.count(EventType::InternalError) == 0);
+}
+
+namespace
+{
+    // Sum of the fixture's per-worker counters. Each worker writes only its own slot.
+    std::uint64_t ReadSpinCounters(const ElfBug::Process* process, const ElfBug::ptr base)
+    {
+        std::uint64_t slots[4] = {};
+        if(!process->MemRead(base, slots, sizeof(slots)))
+            return 0;
+        return slots[0] + slots[1] + slots[2] + slots[3];
+    }
+}
+
+TEST_CASE("All threads freeze when Pause stops the process", "[multithread]")
+{
+    using namespace ElfBug::test;
+    RecordingDebugger dbg;
+    const std::string path = FIXTURE("threads_spin");
+    REQUIRE(dbg.Init(path.c_str()));
+
+    dbg.StartOnThread();
+    dbg.WaitForSystemBreakpoint();
+    dbg.Continue();
+
+    for(int i = 0; i < 4; ++i)
+        dbg.WaitFor(EventType::CreateThread, std::chrono::seconds(10));
+
+    const auto counters = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_counters");
+    REQUIRE(counters.has_value());
+
+    dbg.Pause();
+    dbg.WaitForPaused();
+
+    // Pause() signals the whole process, so any thread can take the SIGSTOP, but that one
+    // sits in signal-delivery-stop and stopAllThreads freezes the rest: no counter may move.
+    std::uint64_t before[4] = {};
+    std::uint64_t after[4] = {};
+    REQUIRE(dbg.process()->MemRead(*counters, before, sizeof(before)));
+    REQUIRE(ReadSpinCounters(dbg.process(), *counters) == before[0] + before[1] + before[2] + before[3]);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    REQUIRE(dbg.process()->MemRead(*counters, after, sizeof(after)));
+
+    for(int i = 0; i < 4; ++i)
+        REQUIRE(after[i] == before[i]);
+
+    dbg.Stop();
+    dbg.WaitForExit();
+    dbg.JoinThread();
+}
+
+TEST_CASE("Continue resumes every thread", "[multithread]")
+{
+    using namespace ElfBug::test;
+    RecordingDebugger dbg;
+    const std::string path = FIXTURE("threads_spin");
+    REQUIRE(dbg.Init(path.c_str()));
+
+    std::promise<std::optional<ElfBug::ptr>> promise;
+    auto future = promise.get_future();
+    dbg.OnSystemBreakpoint([&]
+    {
+        const auto started = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_worker_started");
+        if(started)
+            dbg.process()->SetBreakpoint(*started, true, ElfBug::SoftwareType::ShortInt3);
+        promise.set_value(ResolveRuntimeAddress(path, dbg.process()->pid, "ts_counters"));
+    });
+
+    dbg.StartOnThread();
+    dbg.WaitForSystemBreakpoint();
+    const auto counters = future.get();
+    REQUIRE(counters.has_value());
+
+    dbg.Continue();
+    dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+
+    // All-stop is in effect: the reporting thread is stopped and the sweep froze the
+    // rest, so not one worker's counter may move.
+    std::uint64_t stopped[4] = {};
+    std::uint64_t stillStopped[4] = {};
+    REQUIRE(dbg.process()->MemRead(*counters, stopped, sizeof(stopped)));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    REQUIRE(dbg.process()->MemRead(*counters, stillStopped, sizeof(stillStopped)));
+
+    for(int i = 0; i < 4; ++i)
+        REQUIRE(stillStopped[i] == stopped[i]);
+
+    // The singleshot breakpoint is gone, so nothing stops the tracee again. Every slot
+    // has to advance on its own: a sum grows even when a single thread was resumed.
+    dbg.Continue();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::uint64_t running[4] = {};
+    REQUIRE(dbg.process()->MemRead(*counters, running, sizeof(running)));
+
+    for(int i = 0; i < 4; ++i)
+        REQUIRE(running[i] > stopped[i]);
+
+    dbg.Stop();
+    dbg.WaitForExit();
+    dbg.JoinThread();
+}
+
+// Four workers reach the same breakpoint at once. Whichever the sweep freezes mid-hit
+// must still be reported rather than absorbed.
+TEST_CASE("Breakpoints absorbed by the stop sweep are still reported", "[multithread]")
+{
+    using namespace ElfBug::test;
+    RecordingDebugger dbg;
+    const std::string path = FIXTURE("threads_spin");
+    REQUIRE(dbg.Init(path.c_str()));
+
+    std::promise<std::optional<ElfBug::ptr>> promise;
+    auto future = promise.get_future();
+    dbg.OnSystemBreakpoint([&]
+    {
+        const auto started = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_worker_started");
+        if(started)
+            dbg.process()->SetBreakpoint(*started, false, ElfBug::SoftwareType::ShortInt3);
+        promise.set_value(started);
+    });
+
+    dbg.StartOnThread();
+    dbg.WaitForSystemBreakpoint();
+    REQUIRE(future.get().has_value());
+
+    // ts_worker_started runs exactly once per worker, so exactly four hits exist.
+    for(int i = 0; i < 4; ++i)
+    {
+        dbg.Continue();
+        dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+    }
+
+    REQUIRE(dbg.count(EventType::Breakpoint) == 4);
+
+    dbg.Stop();
+    dbg.WaitForExit();
+    dbg.JoinThread();
+    REQUIRE(dbg.count(EventType::InternalError) == 0);
+}
+
+namespace
+{
+    enum class StepShape
+    {
+        Into,
+        Over
+    };
+
+    // Freeze on the main thread with every worker spinning, take one step, prove no worker
+    // moved. Stepping a worker instead would advance the counter the guard reads.
+    void RequireOtherThreadsFrozenAcrossStep(const StepShape shape)
+    {
+        using namespace ElfBug::test;
+        RecordingDebugger dbg;
+        const std::string path = FIXTURE("threads_spin");
+        REQUIRE(dbg.Init(path.c_str()));
+
+        struct Sites
+        {
+            std::optional<ElfBug::ptr> tick;
+            std::optional<ElfBug::ptr> counters;
+        };
+
+        std::promise<Sites> promise;
+        auto future = promise.get_future();
+        dbg.OnSystemBreakpoint([&]
+        {
+            Sites s;
+            s.tick = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_tick");
+            s.counters = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_counters");
+            if(s.tick)
+                dbg.process()->SetBreakpoint(*s.tick, false, ElfBug::SoftwareType::ShortInt3);
+            promise.set_value(s);
+        });
+
+        dbg.StartOnThread();
+        dbg.WaitForSystemBreakpoint();
+        const auto s = future.get();
+        REQUIRE(s.tick.has_value());
+        REQUIRE(s.counters.has_value());
+
+        std::uint64_t before[4] = {};
+        std::uint64_t after[4] = {};
+
+        // Each round gives the workers real running time. Stepping at the first stop would
+        // prove nothing: the counters are all zero there.
+        int spinning = 0;
+        for(int round = 0; round < 50 && spinning < 4; ++round)
+        {
+            dbg.Continue();
+            dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+
+            spinning = 0;
+            if(dbg.process()->MemRead(*s.counters, before, sizeof(before)))
+                for(const auto counter : before)
+                    if(counter > 0)
+                        ++spinning;
+        }
+
+        // Without threads that were running, the comparison below proves nothing.
+        REQUIRE(spinning == 4);
+
+        // A failed read looks exactly like a frozen process, so require the read too.
+        REQUIRE(dbg.process()->MemRead(*s.counters, before, sizeof(before)));
+
+        if(shape == StepShape::Over)
+            dbg.StepOver();
+        else
+            dbg.StepInto();
+        dbg.WaitForStep();
+
+        // Nothing lifts the freeze when a step reports, so the counters must not have moved.
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        REQUIRE(dbg.process()->MemRead(*s.counters, after, sizeof(after)));
+        for(int i = 0; i < 4; ++i)
+            REQUIRE(after[i] == before[i]);
+
+        dbg.Stop();
+        dbg.WaitForExit();
+        dbg.JoinThread();
+        REQUIRE(dbg.count(EventType::InternalError) == 0);
+    }
+}
+
+// Freeze-on-step policy: a failure here means stepping now resumes the whole process.
+TEST_CASE("Other threads do not run across a step", "[multithread][step]")
+{
+    RequireOtherThreadsFrozenAcrossStep(StepShape::Into);
+}
+
+// Same policy through the StepOver entry point. ts_tick's prologue classifies as
+// StepOverKind::None, so this covers the request path, not StepOverArm::Armed.
+TEST_CASE("Other threads do not run across a step-over", "[multithread][stepover]")
+{
+    RequireOtherThreadsFrozenAcrossStep(StepShape::Over);
+}
+
+// abandonFreeze must not fire on a step that is still in flight: the fault is reported from
+// inside a step-off, and answering it with StepInto holds the freeze on purpose.
+TEST_CASE("A step answering a fault reported mid-step-off keeps the other threads frozen",
+          "[multithread][step][exception]")
+{
+    using namespace ElfBug::test;
+    RecordingDebugger dbg;
+    const std::string path = FIXTURE("threads_spin");
+    REQUIRE(dbg.Init(path.c_str()));
+
+    struct Sites
+    {
+        std::optional<ElfBug::ptr> tick;
+        std::optional<ElfBug::ptr> fault;
+        std::optional<ElfBug::ptr> armed;
+        std::optional<ElfBug::ptr> counters;
+    };
+
+    std::promise<Sites> promise;
+    auto future = promise.get_future();
+    dbg.OnSystemBreakpoint([&]
+    {
+        Sites s;
+        s.tick = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_tick");
+        s.fault = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_fault_site");
+        s.armed = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_fault_armed");
+        s.counters = ResolveRuntimeAddress(path, dbg.process()->pid, "ts_counters");
+        if(s.tick)
+            dbg.process()->SetBreakpoint(*s.tick, false, ElfBug::SoftwareType::ShortInt3);
+        promise.set_value(s);
+    });
+
+    dbg.StartOnThread();
+    dbg.WaitForSystemBreakpoint();
+    const auto s = future.get();
+    REQUIRE(s.tick.has_value());
+    REQUIRE(s.fault.has_value());
+    REQUIRE(s.armed.has_value());
+    REQUIRE(s.counters.has_value());
+
+    std::uint64_t before[4] = {};
+    std::uint64_t after[4] = {};
+
+    // The fault is still disarmed, so these rounds only stop on ts_tick.
+    int spinning = 0;
+    for(int round = 0; round < 50 && spinning < 4; ++round)
+    {
+        dbg.Continue();
+        dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+
+        spinning = 0;
+        if(dbg.process()->MemRead(*s.counters, before, sizeof(before)))
+            for(const auto counter : before)
+                if(counter > 0)
+                    ++spinning;
+    }
+    REQUIRE(spinning == 4);
+
+    // Arm the fault and move the breakpoint onto the faulting store itself.
+    const int armed = 1;
+    REQUIRE(dbg.process()->MemWrite(*s.armed, &armed, sizeof(armed)));
+    REQUIRE(dbg.process()->DeleteBreakpoint(*s.tick));
+    REQUIRE(dbg.process()->SetBreakpoint(*s.fault, false, ElfBug::SoftwareType::ShortInt3));
+
+    dbg.Continue();
+    dbg.WaitForBreakpointAt(*s.fault, std::chrono::seconds(10));
+
+    // Stepping off the byte executes the store, which faults from inside
+    // stepPastBreakpointByte and returns false to a caller that must not read it as stranded.
+    dbg.Continue();
+    dbg.WaitForException(SIGSEGV, std::chrono::seconds(10));
+
+    REQUIRE(dbg.process()->MemRead(*s.counters, before, sizeof(before)));
+
+    // Answer the fault with a step, not a continue. A continue routes through
+    // resumeAllThreads and clears the freeze before the abandon path is ever reached.
+    dbg.StepInto();
+    dbg.WaitForStep();
+
+    REQUIRE(dbg.process()->MemRead(*s.counters, after, sizeof(after)));
+    for(int i = 0; i < 4; ++i)
+        REQUIRE(after[i] == before[i]);
+
+    dbg.Stop();
+    dbg.WaitForExit();
+    dbg.JoinThread();
+    REQUIRE(dbg.count(EventType::InternalError) == 0);
+}
+
+// A thread that already reported PTRACE_EVENT_EXIT owes the sweep no stop, so treating it
+// as running costs a waitpid that never returns. Regressions hang this test, not fail it.
+TEST_CASE("A process exit racing the stop sweep is still reported", "[multithread][process]")
+{
+    using namespace ElfBug::test;
+
+    // A race by nature: the sweep only meets the dying leader if a spinner's trap is
+    // dispatched while the exit is in flight, so run several passes to make that land.
+    for(int attempt = 0; attempt < 8; ++attempt)
+    {
+        RecordingDebugger dbg;
+        const std::string path = FIXTURE("exit_race");
+        REQUIRE(dbg.Init(path.c_str()));
+
+        struct Sites
+        {
+            std::optional<ElfBug::ptr> hot;
+            std::optional<ElfBug::ptr> exitNow;
+        };
+
+        std::promise<Sites> promise;
+        auto future = promise.get_future();
+        dbg.OnSystemBreakpoint([&]
+        {
+            Sites s;
+            s.hot = ResolveRuntimeAddress(path, dbg.process()->pid, "er_hot");
+            s.exitNow = ResolveRuntimeAddress(path, dbg.process()->pid, "er_exit_now");
+            if(s.hot)
+                dbg.process()->SetBreakpoint(*s.hot, false, ElfBug::SoftwareType::ShortInt3);
+            promise.set_value(s);
+        });
+
+        dbg.StartOnThread();
+        dbg.WaitForSystemBreakpoint();
+        const auto s = future.get();
+        REQUIRE(s.hot.has_value());
+        REQUIRE(s.exitNow.has_value());
+
+        // Stop on a spinner first, so the exit below starts from a frozen process with
+        // the leader registered, running, and about to be swept.
+        dbg.Continue();
+        dbg.WaitFor(EventType::Breakpoint, std::chrono::seconds(10));
+
+        const int go = 1;
+        REQUIRE(dbg.process()->MemWrite(*s.exitNow, &go, sizeof(go)));
+
+        // The spinners keep trapping while the exit runs, so each of these rounds is
+        // another chance for a sweep to land on the dying leader.
+        Event last;
+        for(int round = 0; round < 400; ++round)
+        {
+            dbg.Continue();
+            last = dbg.WaitForAny({EventType::Breakpoint, EventType::ExitProcess},
+                                  std::chrono::seconds(10));
+            if(last.type == EventType::ExitProcess)
+                break;
+        }
+
+        dbg.JoinThread();
+
+        REQUIRE(last.type == EventType::ExitProcess);
+        REQUIRE(last.exitCode == 7);
+        REQUIRE(dbg.count(EventType::InternalError) == 0);
+    }
 }


### PR DESCRIPTION
When the debugger stops for a breakpoint, step, pause or signal, it now freezes every _other_ thread in the process until you continue, instead of leaving them running.