### PR TITLE
ElfBug: show signal stops, thread events and the stopping thread in the GUI

### DIFF
--- a/src/cross/CMakeLists.txt
+++ b/src/cross/CMakeLists.txt
@@ -286,7 +286,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${ElfBug_SOURCES})
 
 	target_compile_features(ElfBug PUBLIC
-		cxx_std_17
+		cxx_std_20
 	)
 
 	target_include_directories(ElfBug PUBLIC

--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
@@ -240,6 +240,14 @@ struct ElfBugDebugger : ElfBug::Debugger
         }
     }
 
+    pid_t currentTid() const
+    {
+        std::shared_lock lock(mProcessMutex);
+        if(!active.load(std::memory_order_acquire) || !mThread)
+            return 0;
+        return mThread->tid;
+    }
+
     bool readRegisters(ElfBugRegisters* out) const
     {
         std::shared_lock lock(mProcessMutex);
@@ -309,6 +317,18 @@ protected:
             cb.onExitProcess(exitCode, cb.userdata);
     }
 
+    void cbCreateThreadEvent(const pid_t tid) override
+    {
+        if(cb.onCreateThread)
+            cb.onCreateThread(tid, cb.userdata);
+    }
+
+    void cbExitThreadEvent(const pid_t tid) override
+    {
+        if(cb.onExitThread)
+            cb.onExitThread(tid, cb.userdata);
+    }
+
     void cbSystemBreakpoint() override
     {
         if(mThread)
@@ -346,6 +366,14 @@ protected:
             cb.onPaused(cb.userdata);
     }
 
+    void cbExceptionEvent(const int signal, const ElfBug::ptr address) override
+    {
+        processPendingBreakpoints();
+        refreshMemoryMap();
+        if(cb.onException)
+            cb.onException(signal, address, cb.userdata);
+    }
+
     void cbPauseTick() override
     {
         processPendingBreakpoints();
@@ -374,7 +402,7 @@ extern "C" {
         return dbg;
     }
 
-    void ElfBugDestroy(ElfBugDebugger* dbg)
+    void ElfBugDestroy(const ElfBugDebugger* dbg)
     {
         if(!dbg)
             return;
@@ -442,6 +470,13 @@ extern "C" {
         if(!dbg)
             return 0;
         return dbg->activePid.load(std::memory_order_acquire);
+    }
+
+    pid_t ElfBugGetCurrentTid(const ElfBugDebugger* dbg)
+    {
+        if(!dbg)
+            return 0;
+        return dbg->currentTid();
     }
 
     ElfBugArch ElfBugGetArch(const ElfBugDebugger* dbg)
@@ -616,7 +651,7 @@ extern "C" {
         }
 
         std::lock_guard lock(dbg->bpDataMutex);
-        return dbg->breakpointAddrs.count(addr) > 0;
+        return dbg->breakpointAddrs.contains(addr);
     }
 
 } // extern "C"

--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.cpp
@@ -243,7 +243,7 @@ struct ElfBugDebugger : ElfBug::Debugger
     pid_t currentTid() const
     {
         std::shared_lock lock(mProcessMutex);
-        if(!active.load(std::memory_order_acquire) || !mThread)
+        if(!active.load(std::memory_order_acquire) || !IsPaused() || !mThread)
             return 0;
         return mThread->tid;
     }

--- a/src/cross/ElfBug/ElfBug/api/elfbug_api.h
+++ b/src/cross/ElfBug/ElfBug/api/elfbug_api.h
@@ -36,10 +36,14 @@ typedef struct
 
 typedef void (*ElfBugCbCreateProcess)(pid_t pid, uint64_t entryPoint, void* userdata);
 typedef void (*ElfBugCbExitProcess)(int exitCode, void* userdata);
+typedef void (*ElfBugCbCreateThread)(pid_t tid, void* userdata);
+typedef void (*ElfBugCbExitThread)(pid_t tid, void* userdata);
 typedef void (*ElfBugCbSystemBreakpoint)(void* userdata);
 typedef void (*ElfBugCbBreakpoint)(uint64_t address, void* userdata);
 typedef void (*ElfBugCbStep)(void* userdata);
 typedef void (*ElfBugCbPaused)(void* userdata);
+// Signal delivery stop. `address` is si_addr for faults, 0 otherwise.
+typedef void (*ElfBugCbException)(int signal, uint64_t address, void* userdata);
 typedef void (*ElfBugCbError)(const char* error, void* userdata);
 typedef void (*ElfBugCbDebugString)(const char* text, void* userdata);
 
@@ -47,17 +51,20 @@ typedef struct
 {
     ElfBugCbCreateProcess onCreateProcess;
     ElfBugCbExitProcess onExitProcess;
+    ElfBugCbCreateThread onCreateThread;
+    ElfBugCbExitThread onExitThread;
     ElfBugCbSystemBreakpoint onSystemBreakpoint;
     ElfBugCbBreakpoint onBreakpoint;
     ElfBugCbStep onStep;
     ElfBugCbPaused onPaused;
+    ElfBugCbException onException;
     ElfBugCbError onError;
     ElfBugCbDebugString onDebugString;
     void* userdata;
 } ElfBugCallbacks;
 
 ELFBUG_EXPORT ElfBugDebugger* ElfBugCreate(const ElfBugCallbacks* callbacks);
-ELFBUG_EXPORT void ElfBugDestroy(ElfBugDebugger* dbg);
+ELFBUG_EXPORT void ElfBugDestroy(const ElfBugDebugger* dbg);
 
 ELFBUG_EXPORT bool ElfBugInit(ElfBugDebugger* dbg, const char* path);
 ELFBUG_EXPORT void ElfBugStart(ElfBugDebugger* dbg);      // Blocks - runs debug loop
@@ -69,6 +76,8 @@ ELFBUG_EXPORT bool ElfBugStop(ElfBugDebugger* dbg);        // Thread-safe
 
 ELFBUG_EXPORT bool ElfBugGetRegisters(const ElfBugDebugger* dbg, ElfBugRegisters* regs);
 ELFBUG_EXPORT pid_t ElfBugGetPid(const ElfBugDebugger* dbg);
+// Thread the last stop was reported on. 0 while running or before the first stop.
+ELFBUG_EXPORT pid_t ElfBugGetCurrentTid(const ElfBugDebugger* dbg);
 ELFBUG_EXPORT ElfBugArch ElfBugGetArch(const ElfBugDebugger* dbg);
 
 ELFBUG_EXPORT bool ElfBugMemRead(const ElfBugDebugger* dbg, uint64_t addr, void* dest, uint64_t size);

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
@@ -62,14 +62,15 @@ namespace ElfBug
         const int sig = WSTOPSIG(status);
 
         // si_code is positive when the kernel raised the signal and zero or negative for
-        // kill, tkill and sigqueue. Queue conservatively when it cannot be read.
+        // kill, tkill and sigqueue. Unreadable means the thread already left this stop
+        // (exit_group kicked it out), so there is nothing left to forward.
         siginfo_t info{};
         const bool haveInfo = ptrace(PTRACE_GETSIGINFO, thread->tid, nullptr, &info) != -1;
         const bool hardware = haveInfo && info.si_code > 0;
 
         // Nothing else records it, so queue it for pauseAndResume to report and forward.
-        if(sweepShouldQueue(sig, hardware))
-            thread->setPendingSignal(sig, haveInfo ? reinterpret_cast<ptr>(info.si_addr) : 0, true);
+        if(haveInfo && sweepShouldQueue(sig, hardware))
+            thread->setPendingSignal(sig, reinterpret_cast<ptr>(info.si_addr), true);
 
         if(!mProcess || sig != SIGTRAP)
             return;
@@ -85,6 +86,7 @@ namespace ElfBug
 
         thread->registers.Gip() = bpAddr;
         thread->registers.Write();
+        thread->setAtBreakpoint(true);
         thread->setPendingBreakpoint(bpAddr);
     }
 
@@ -601,6 +603,20 @@ namespace ElfBug
         {
             if(!mThread)
             {
+                mUnregisteredRunning.erase(pid);
+                createThreadEvent(pid);
+                {
+                    std::shared_lock lock(mProcessMutex);
+                    if(mProcess)
+                    {
+                        const auto it = mProcess->threads.find(pid);
+                        if(it != mProcess->threads.end())
+                            mThread = it->second.get();
+                    }
+                }
+            }
+            if(!mThread)
+            {
                 if(ptrace(PTRACE_CONT, pid, nullptr, nullptr) == -1)
                 {
                     if(errno != ESRCH)
@@ -659,6 +675,7 @@ namespace ElfBug
 
                         if(planted)
                             mProcess->DeleteBreakpoint(target);
+                        mThread->setAtBreakpoint(!planted);
 
                         restoreSourceByte(pid);
 
@@ -700,6 +717,7 @@ namespace ElfBug
                 {
                     mThread->registers.Gip() = bpAddr;
                     mThread->registers.Write();
+                    mThread->setAtBreakpoint(true);
 
                     cancelStepOverIfOwner(pid);
                     stopAllThreads(pid);

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.Signal.cpp
@@ -33,6 +33,25 @@ namespace ElfBug
             ScopedSteppingOff & operator=(const ScopedSteppingOff &) = delete;
         };
 
+        // si_addr only means something for kernel-raised faults; for kill and tkill the
+        // same union bytes hold the sender's pid and uid.
+        ptr faultAddress(const int signal, const siginfo_t & info)
+        {
+            if(info.si_code <= 0)
+                return 0;
+            switch(signal)
+            {
+            case SIGSEGV:
+            case SIGBUS:
+            case SIGILL:
+            case SIGFPE:
+            case SIGTRAP:
+                return reinterpret_cast<ptr>(info.si_addr);
+            default:
+                return 0;
+            }
+        }
+
         bool sweepShouldQueue(const int signal, const bool hardware)
         {
             switch(signal)
@@ -70,7 +89,7 @@ namespace ElfBug
 
         // Nothing else records it, so queue it for pauseAndResume to report and forward.
         if(haveInfo && sweepShouldQueue(sig, hardware))
-            thread->setPendingSignal(sig, reinterpret_cast<ptr>(info.si_addr), true);
+            thread->setPendingSignal(sig, faultAddress(sig, info), true);
 
         if(!mProcess || sig != SIGTRAP)
             return;
@@ -360,7 +379,7 @@ namespace ElfBug
         ptr faultAddr = 0;
         siginfo_t sigInfo;
         if(ptrace(PTRACE_GETSIGINFO, pid, nullptr, &sigInfo) != -1)
-            faultAddr = reinterpret_cast<ptr>(sigInfo.si_addr);
+            faultAddr = faultAddress(sig, sigInfo);
         if(mThread)
         {
             mThread->registers.Read();

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
@@ -208,6 +208,10 @@ namespace ElfBug
                 cbPauseTick();
         }
 
+        // A resume can wake the wait before the tick that would apply a request queued
+        // just before it. Tick once more while still stopped.
+        cbPauseTick();
+
         lock.unlock();
 
         if(!mIsRunning.load(std::memory_order_acquire))

--- a/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.Loop.cpp
@@ -113,8 +113,10 @@ namespace ElfBug
             if(!thread->registers.Read())
                 continue;
 
+            // A thread frozen just before the byte has not hit it; stepping it off would
+            // skip the hit. Only a rewound thread owes a step.
             const ptr rip = thread->registers.Gip();
-            if(!mProcess->HasBreakpoint(rip))
+            if(!thread->atBreakpoint() || !mProcess->HasBreakpoint(rip))
                 continue;
 
             Thread* previous = nullptr;
@@ -280,7 +282,7 @@ namespace ElfBug
 
         // A breakpoint hit leaves its 0xCC armed with RIP on it; every resume except a
         // step-over must step past that byte first.
-        if(!stepOverRequested && mThread && mProcess &&
+        if(!stepOverRequested && mThread && mProcess && mThread->atBreakpoint() &&
                 mProcess->HasBreakpoint(mThread->registers.Gip()))
         {
             const ptr rip = mThread->registers.Gip();

--- a/src/cross/ElfBug/ElfBug/core/Debugger.h
+++ b/src/cross/ElfBug/ElfBug/core/Debugger.h
@@ -33,6 +33,8 @@ namespace ElfBug
         bool Stop();
         void Detach();
 
+        [[nodiscard]] bool IsPaused() const { return mPaused.load(std::memory_order_acquire); }
+
     protected:
         virtual void cbCreateProcessEvent(pid_t pid, ptr entryPoint);
         virtual void cbExitProcessEvent(int exitCode);

--- a/src/cross/ElfBug/ElfBug/thread/Thread.cpp
+++ b/src/cross/ElfBug/ElfBug/thread/Thread.cpp
@@ -15,6 +15,7 @@ namespace ElfBug
                   reinterpret_cast<void*>(static_cast<uintptr_t>(signal))) == -1)
             return false;
         mIsSingleStepping = true;
+        mAtBreakpoint = false;
         return true;
     }
 }

--- a/src/cross/ElfBug/ElfBug/thread/Thread.h
+++ b/src/cross/ElfBug/ElfBug/thread/Thread.h
@@ -26,8 +26,19 @@ namespace ElfBug
 
         // Constructed stopped: a clone is reported to us already stopped, and the main
         // thread stops on exec.
-        void setRunning(const bool running) { mRunning = running; }
+        void setRunning(const bool running)
+        {
+            mRunning = running;
+            if(running)
+                mAtBreakpoint = false;
+        }
         [[nodiscard]] bool isRunning() const { return mRunning; }
+
+        // RIP was rewound onto an armed breakpoint this thread hit. Only such a thread is
+        // stepped off the byte on resume; one frozen just before the byte has not hit it
+        // and must trap when it runs. Cleared by anything that lets the thread run.
+        void setAtBreakpoint(const bool at) { mAtBreakpoint = at; }
+        [[nodiscard]] bool atBreakpoint() const { return mAtBreakpoint; }
 
         // Set when our SIGSTOP was still queued because the thread stopped for its own
         // reason first. It must be consumed before this thread is single-stepped.
@@ -68,6 +79,7 @@ namespace ElfBug
         bool mIsSingleStepping = false;
         bool mStepsPushf = false;
         bool mRunning = false;
+        bool mAtBreakpoint = false;
         bool mPendingSigstop = false;
         bool mHasPendingBreakpoint = false;
         ptr mPendingBreakpoint = 0;

--- a/src/cross/ElfBug/tests/CMakeLists.txt
+++ b/src/cross/ElfBug/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ add_dependencies(ElfBug_tests
     elfbug_fixture_threads_spin
     elfbug_fixture_exit_race
     elfbug_fixture_signal_race
+    elfbug_fixture_clone_trap
 )
 
 # Target: elfbug_fixture_end_immediately
@@ -472,4 +473,37 @@ set_target_properties(elfbug_fixture_signal_race PROPERTIES
 get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
 if(NOT CMKR_VS_STARTUP_PROJECT)
 	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_signal_race)
+endif()
+
+# Target: elfbug_fixture_clone_trap
+set(elfbug_fixture_clone_trap_SOURCES
+	cmake.toml
+	"targets/clone_trap.cpp"
+)
+
+add_executable(elfbug_fixture_clone_trap)
+
+target_sources(elfbug_fixture_clone_trap PRIVATE ${elfbug_fixture_clone_trap_SOURCES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${elfbug_fixture_clone_trap_SOURCES})
+
+target_compile_options(elfbug_fixture_clone_trap PRIVATE
+	-g
+	-O0
+	-pie
+)
+
+target_link_options(elfbug_fixture_clone_trap PRIVATE
+	-pie
+)
+
+set_target_properties(elfbug_fixture_clone_trap PROPERTIES
+	OUTPUT_NAME
+		clone_trap
+	RUNTIME_OUTPUT_DIRECTORY
+		"${CMAKE_BINARY_DIR}/tests/targets"
+)
+
+get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
+if(NOT CMKR_VS_STARTUP_PROJECT)
+	set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT elfbug_fixture_clone_trap)
 endif()

--- a/src/cross/ElfBug/tests/CMakeLists.txt
+++ b/src/cross/ElfBug/tests/CMakeLists.txt
@@ -58,6 +58,10 @@ target_compile_definitions(ElfBug_tests PRIVATE
 	"ELFBUG_TESTS_TARGETS_DIR=\"${CMAKE_BINARY_DIR}/tests/targets\""
 )
 
+target_compile_features(ElfBug_tests PRIVATE
+	cxx_std_20
+)
+
 target_link_libraries(ElfBug_tests PRIVATE
 	ElfBug
 	Catch2::Catch2WithMain

--- a/src/cross/ElfBug/tests/cmake.toml
+++ b/src/cross/ElfBug/tests/cmake.toml
@@ -19,6 +19,7 @@ headers = [
     "SymbolHelper.h",
 ]
 link-libraries = ["ElfBug", "Catch2::Catch2WithMain"]
+compile-features = ["cxx_std_20"]
 compile-definitions = ['ELFBUG_TESTS_TARGETS_DIR="${CMAKE_BINARY_DIR}/tests/targets"']
 properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests"
 cmake-after = """

--- a/src/cross/ElfBug/tests/cmake.toml
+++ b/src/cross/ElfBug/tests/cmake.toml
@@ -38,6 +38,7 @@ add_dependencies(ElfBug_tests
     elfbug_fixture_threads_spin
     elfbug_fixture_exit_race
     elfbug_fixture_signal_race
+    elfbug_fixture_clone_trap
 )
 """
 
@@ -114,4 +115,10 @@ type = "elfbug_fixture"
 sources = ["targets/signal_race.cpp"]
 link-libraries = ["pthread"]
 properties.OUTPUT_NAME = "signal_race"
+properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"
+
+[target.elfbug_fixture_clone_trap]
+type = "elfbug_fixture"
+sources = ["targets/clone_trap.cpp"]
+properties.OUTPUT_NAME = "clone_trap"
 properties.RUNTIME_OUTPUT_DIRECTORY = "${CMAKE_BINARY_DIR}/tests/targets"

--- a/src/cross/ElfBug/tests/targets/clone_trap.cpp
+++ b/src/cross/ElfBug/tests/targets/clone_trap.cpp
@@ -1,0 +1,53 @@
+// Raw clone threads whose first instruction is the breakpoint site, so the child's trap
+// follows its initial stop within one instruction and can reach waitpid before the
+// parent's clone event.
+#include <sched.h>
+#include <sys/mman.h>
+
+extern "C"
+{
+    volatile int ct_done = 0;
+    // Breakpoint site: the instruction both the parent and the new child return to.
+    void ct_site();
+    void ct_spawn(void* stackTop);
+}
+
+asm(R"(
+    .text
+
+    .globl ct_spawn
+    .type  ct_spawn, @function
+ct_spawn:
+    movq    %rdi, %rsi
+    movq    $0x50f00, %rdi
+    xorq    %rdx, %rdx
+    xorq    %r10, %r10
+    xorq    %r8, %r8
+    movq    $56, %rax
+    syscall
+    .globl ct_site
+ct_site:
+    testq   %rax, %rax
+    jnz     1f
+    lock incl ct_done(%rip)
+    movq    $60, %rax
+    xorq    %rdi, %rdi
+    syscall
+1:
+    ret
+)");
+
+int main()
+{
+    for(int i = 0; i < 32; ++i)
+    {
+        const long size = 64 * 1024;
+        void* stack = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+        if(stack == MAP_FAILED)
+            return 1;
+        ct_spawn(static_cast<char*>(stack) + size);
+        while(ct_done <= i)
+            sched_yield();
+    }
+    return 0;
+}

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -2115,6 +2115,43 @@ TEST_CASE("A step answering a fault reported mid-step-off keeps the other thread
 
 // A thread that already reported PTRACE_EVENT_EXIT owes the sweep no stop, so treating it
 // as running costs a waitpid that never returns. Regressions hang this test, not fail it.
+// waitpid can report the new thread's own stops before the parent's clone event, so the
+// first thing the core hears from a thread may be its breakpoint hit.
+TEST_CASE("A breakpoint hit before the thread's clone event is still a breakpoint", "[multithread][breakpoint]")
+{
+    using namespace ElfBug::test;
+    RecordingDebugger dbg;
+    const std::string path = FIXTURE("clone_trap");
+    REQUIRE(dbg.Init(path.c_str()));
+
+    dbg.OnSystemBreakpoint([&]
+    {
+        const auto site = ResolveRuntimeAddress(path, dbg.process()->pid, "ct_site");
+        if(site)
+            dbg.process()->SetBreakpoint(*site, false, ElfBug::SoftwareType::ShortInt3);
+    });
+
+    dbg.StartOnThread();
+    dbg.WaitForSystemBreakpoint();
+
+    Event last;
+    for(int round = 0; round < 1000; ++round)
+    {
+        dbg.Continue();
+        last = dbg.WaitForAny({EventType::Breakpoint, EventType::ExitProcess, EventType::Exception},
+                              std::chrono::seconds(10));
+        if(last.type == EventType::ExitProcess)
+            break;
+    }
+    dbg.JoinThread();
+
+    REQUIRE(last.type == EventType::ExitProcess);
+    REQUIRE(last.exitCode == 0);
+    REQUIRE(dbg.count(EventType::Exception) == 0);
+    REQUIRE(dbg.count(EventType::Breakpoint) == 64);
+    REQUIRE(dbg.count(EventType::InternalError) == 0);
+}
+
 TEST_CASE("A process exit racing the stop sweep is still reported", "[multithread][process]")
 {
     using namespace ElfBug::test;
@@ -2165,7 +2202,7 @@ TEST_CASE("A process exit racing the stop sweep is still reported", "[multithrea
         for(int round = 0; round < 400; ++round)
         {
             dbg.Continue();
-            last = dbg.WaitForAny({EventType::Breakpoint, EventType::ExitProcess},
+            last = dbg.WaitForAny({EventType::Breakpoint, EventType::ExitProcess, EventType::Exception},
                                   std::chrono::seconds(10));
             if(last.type == EventType::ExitProcess)
                 break;
@@ -2175,6 +2212,8 @@ TEST_CASE("A process exit racing the stop sweep is still reported", "[multithrea
 
         REQUIRE(last.type == EventType::ExitProcess);
         REQUIRE(last.exitCode == 7);
+        // The fixture raises nothing: a swept int3 must never come back as a signal.
+        REQUIRE(dbg.count(EventType::Exception) == 0);
         REQUIRE(dbg.count(EventType::InternalError) == 0);
     }
 }

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -2,6 +2,9 @@
 #include "TestHarness.h"
 #include "SymbolHelper.h"
 #include <ElfBug/process/StepOver.h>
+#include <ElfBug/api/elfbug_api.h>
+#include <condition_variable>
+#include <mutex>
 #include <string>
 #include <algorithm>
 #include <atomic>
@@ -2333,4 +2336,225 @@ TEST_CASE("Stop while a hot-path breakpoint is armed still reports the exit", "[
         REQUIRE(exit_ev.exitCode == -SIGKILL);
         REQUIRE(dbg.count(EventType::InternalError) == 0);
     }
+}
+
+namespace
+{
+    // Records what the C API hands its callbacks.
+    struct ApiEvents
+    {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool systemBreakpoint = false;
+        std::optional<std::uint64_t> breakpointAddress;
+        std::optional<int> exceptionSignal;
+        std::uint64_t exceptionAddress = 0;
+        pid_t pid = 0;
+        std::optional<int> exitCode;
+        std::vector<pid_t> createdTids;
+        std::vector<pid_t> exitedTids;
+
+        template<class Pred>
+        bool WaitFor(Pred pred, const std::chrono::milliseconds timeout = std::chrono::seconds(5))
+        {
+            std::unique_lock lock(mutex);
+            return cv.wait_for(lock, timeout, pred);
+        }
+    };
+
+    ElfBugCallbacks MakeApiCallbacks(ApiEvents & events)
+    {
+        ElfBugCallbacks cb = {};
+        cb.userdata = &events;
+        cb.onCreateProcess = [](const pid_t pid, std::uint64_t, void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->pid = pid;
+        };
+        cb.onSystemBreakpoint = [](void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->systemBreakpoint = true;
+            ev->cv.notify_all();
+        };
+        cb.onBreakpoint = [](const std::uint64_t address, void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->breakpointAddress = address;
+            ev->cv.notify_all();
+        };
+        cb.onException = [](const int signal, const std::uint64_t address, void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->exceptionSignal = signal;
+            ev->exceptionAddress = address;
+            ev->cv.notify_all();
+        };
+        cb.onCreateThread = [](const pid_t tid, void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->createdTids.push_back(tid);
+            ev->cv.notify_all();
+        };
+        cb.onExitThread = [](const pid_t tid, void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->exitedTids.push_back(tid);
+            ev->cv.notify_all();
+        };
+        cb.onExitProcess = [](const int exitCode, void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->exitCode = exitCode;
+            ev->cv.notify_all();
+        };
+        return cb;
+    }
+
+    // Drives a fixture through the C API on its own loop thread. A test that fails
+    // mid-run still kills the tracee and joins the loop.
+    struct ApiSession
+    {
+        std::string path;
+        ApiEvents events;
+        ElfBugDebugger* dbg = nullptr;
+        std::thread loop;
+
+        explicit ApiSession(std::string fixturePath)
+            : path(std::move(fixturePath))
+        {
+            const ElfBugCallbacks cb = MakeApiCallbacks(events);
+            dbg = ElfBugCreate(&cb);
+            REQUIRE(dbg != nullptr);
+            REQUIRE(ElfBugInit(dbg, path.c_str()));
+            loop = std::thread([this] { ElfBugStart(dbg); });
+        }
+
+        ~ApiSession()
+        {
+            if(loop.joinable())
+            {
+                ElfBugStop(dbg);
+                loop.join();
+            }
+            ElfBugDestroy(dbg);
+        }
+
+        bool WaitForSystemBreakpoint()
+        {
+            return events.WaitFor([this] { return events.systemBreakpoint; });
+        }
+
+        bool WaitForExit(const std::chrono::milliseconds timeout = std::chrono::seconds(5))
+        {
+            if(!events.WaitFor([this] { return events.exitCode.has_value(); }, timeout))
+                return false;
+            loop.join();
+            return true;
+        }
+
+        std::optional<ElfBug::ptr> Resolve(const std::string & symbol)
+        {
+            std::lock_guard lock(events.mutex);
+            return ElfBug::test::ResolveRuntimeAddress(path, events.pid, symbol);
+        }
+    };
+}
+
+TEST_CASE("C API reports a signal stop with the faulting registers", "[api][exception]")
+{
+    ApiSession s(FIXTURE("segfault"));
+    REQUIRE(s.WaitForSystemBreakpoint());
+    const auto site = s.Resolve("sf_fault_site");
+    REQUIRE(site.has_value());
+
+    ElfBugContinue(s.dbg);
+    REQUIRE(s.events.WaitFor([&] { return s.events.exceptionSignal.has_value(); }));
+
+    ElfBugRegisters regs = {};
+    REQUIRE(ElfBugGetRegisters(s.dbg, &regs));
+    {
+        std::lock_guard lock(s.events.mutex);
+        REQUIRE(*s.events.exceptionSignal == SIGSEGV);
+        REQUIRE(s.events.exceptionAddress == 0);
+    }
+    REQUIRE(regs.rip == *site);
+    REQUIRE(ElfBugMemIsCodePtr(s.dbg, regs.rip));
+
+    ElfBugContinue(s.dbg);
+    REQUIRE(s.WaitForExit());
+    REQUIRE(*s.events.exitCode == -SIGSEGV);
+}
+
+TEST_CASE("C API arms a breakpoint queued right before Continue", "[api][breakpoint]")
+{
+    ApiSession s(FIXTURE("segfault"));
+    REQUIRE(s.WaitForSystemBreakpoint());
+    const auto site = s.Resolve("sf_fault_site");
+    REQUIRE(site.has_value());
+
+    // No delay between the two: the queue must be applied before the resume.
+    REQUIRE(ElfBugSetBreakpoint(s.dbg, *site));
+    ElfBugContinue(s.dbg);
+
+    REQUIRE(s.events.WaitFor([&] { return s.events.breakpointAddress.has_value() || s.events.exceptionSignal.has_value(); }));
+    {
+        std::lock_guard lock(s.events.mutex);
+        REQUIRE(s.events.breakpointAddress == site);
+        REQUIRE_FALSE(s.events.exceptionSignal.has_value());
+    }
+
+    ElfBugContinue(s.dbg);
+    REQUIRE(s.events.WaitFor([&] { return s.events.exceptionSignal.has_value(); }));
+    ElfBugContinue(s.dbg);
+    REQUIRE(s.WaitForExit());
+}
+
+TEST_CASE("C API reports thread creation and exit", "[api][thread]")
+{
+    ApiSession s(FIXTURE("multi_threaded"));
+    REQUIRE(s.WaitForSystemBreakpoint());
+    ElfBugContinue(s.dbg);
+    REQUIRE(s.WaitForExit());
+
+    REQUIRE(*s.events.exitCode == 5);
+    const std::set<pid_t> created(s.events.createdTids.begin(), s.events.createdTids.end());
+    const std::set<pid_t> exited(s.events.exitedTids.begin(), s.events.exitedTids.end());
+    REQUIRE(s.events.createdTids.size() == 5);
+    REQUIRE(s.events.exitedTids.size() == 5);
+    REQUIRE(created.size() == 5);
+    REQUIRE(exited == created);
+    REQUIRE(!created.contains(s.events.pid));
+}
+
+TEST_CASE("C API reports which thread stopped", "[api][thread]")
+{
+    ApiSession s(FIXTURE("threads_spin"));
+    REQUIRE(s.WaitForSystemBreakpoint());
+    REQUIRE(ElfBugGetCurrentTid(s.dbg) == ElfBugGetPid(s.dbg));
+
+    const auto site = s.Resolve("ts_worker_started");
+    REQUIRE(site.has_value());
+    REQUIRE(ElfBugSetBreakpoint(s.dbg, *site));
+
+    ElfBugContinue(s.dbg);
+    REQUIRE(s.events.WaitFor([&] { return s.events.breakpointAddress.has_value(); }, std::chrono::seconds(10)));
+
+    {
+        const pid_t stoppedTid = ElfBugGetCurrentTid(s.dbg);
+        std::lock_guard lock(s.events.mutex);
+        REQUIRE(*s.events.breakpointAddress == *site);
+        REQUIRE(stoppedTid != s.events.pid);
+        REQUIRE(std::find(s.events.createdTids.begin(), s.events.createdTids.end(), stoppedTid) != s.events.createdTids.end());
+    }
+
+    REQUIRE(ElfBugStop(s.dbg));
+    REQUIRE(s.WaitForExit(std::chrono::seconds(10)));
 }

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -2298,11 +2298,18 @@ namespace
         REQUIRE(dbg.process()->MemRead(*s.handled, &r.handled, sizeof(r.handled)));
         CAPTURE(r.raised, r.handled);
         REQUIRE(done == 1);
+        std::size_t withAddress = 0;
         for(const auto & e : dbg.events())
         {
             if(e.type == EventType::Exception && e.signal == signal)
+            {
                 ++r.reported;
+                if(e.address != 0)
+                    ++withAddress;
+            }
         }
+        // raise() is not a fault: si_addr aliases the sender there and must not leak.
+        REQUIRE(withAddress == 0);
 
         // Checked before Stop so a wedged debugger cannot hide the numbers.
         REQUIRE(r.raised == quota);
@@ -2385,6 +2392,7 @@ namespace
         std::mutex mutex;
         std::condition_variable cv;
         bool systemBreakpoint = false;
+        bool paused = false;
         std::optional<std::uint64_t> breakpointAddress;
         std::optional<int> exceptionSignal;
         std::uint64_t exceptionAddress = 0;
@@ -2410,6 +2418,13 @@ namespace
             auto* ev = static_cast<ApiEvents*>(userdata);
             std::lock_guard lock(ev->mutex);
             ev->pid = pid;
+        };
+        cb.onPaused = [](void* userdata)
+        {
+            auto* ev = static_cast<ApiEvents*>(userdata);
+            std::lock_guard lock(ev->mutex);
+            ev->paused = true;
+            ev->cv.notify_all();
         };
         cb.onSystemBreakpoint = [](void* userdata)
         {
@@ -2560,6 +2575,21 @@ TEST_CASE("C API arms a breakpoint queued right before Continue", "[api][breakpo
     REQUIRE(s.events.WaitFor([&] { return s.events.exceptionSignal.has_value(); }));
     ElfBugContinue(s.dbg);
     REQUIRE(s.WaitForExit());
+}
+
+TEST_CASE("C API reports no current thread while the debuggee runs", "[api][thread]")
+{
+    ApiSession s(FIXTURE("run_endlessly"));
+    REQUIRE(s.Started());
+    REQUIRE(s.WaitForSystemBreakpoint());
+    REQUIRE(ElfBugGetCurrentTid(s.dbg) == ElfBugGetPid(s.dbg));
+
+    ElfBugContinue(s.dbg);
+    REQUIRE(ElfBugGetCurrentTid(s.dbg) == 0);
+
+    ElfBugPause(s.dbg);
+    REQUIRE(s.events.WaitFor([&] { return s.events.paused; }));
+    REQUIRE(ElfBugGetCurrentTid(s.dbg) == ElfBugGetPid(s.dbg));
 }
 
 TEST_CASE("C API reports thread creation and exit", "[api][thread]")

--- a/src/cross/ElfBug/tests/tests.cpp
+++ b/src/cross/ElfBug/tests/tests.cpp
@@ -2432,9 +2432,13 @@ namespace
         {
             const ElfBugCallbacks cb = MakeApiCallbacks(events);
             dbg = ElfBugCreate(&cb);
-            REQUIRE(dbg != nullptr);
-            REQUIRE(ElfBugInit(dbg, path.c_str()));
-            loop = std::thread([this] { ElfBugStart(dbg); });
+            if(dbg && ElfBugInit(dbg, path.c_str()))
+                loop = std::thread([this] { ElfBugStart(dbg); });
+        }
+
+        [[nodiscard]] bool Started() const
+        {
+            return loop.joinable();
         }
 
         ~ApiSession()
@@ -2471,6 +2475,7 @@ namespace
 TEST_CASE("C API reports a signal stop with the faulting registers", "[api][exception]")
 {
     ApiSession s(FIXTURE("segfault"));
+    REQUIRE(s.Started());
     REQUIRE(s.WaitForSystemBreakpoint());
     const auto site = s.Resolve("sf_fault_site");
     REQUIRE(site.has_value());
@@ -2496,6 +2501,7 @@ TEST_CASE("C API reports a signal stop with the faulting registers", "[api][exce
 TEST_CASE("C API arms a breakpoint queued right before Continue", "[api][breakpoint]")
 {
     ApiSession s(FIXTURE("segfault"));
+    REQUIRE(s.Started());
     REQUIRE(s.WaitForSystemBreakpoint());
     const auto site = s.Resolve("sf_fault_site");
     REQUIRE(site.has_value());
@@ -2520,6 +2526,7 @@ TEST_CASE("C API arms a breakpoint queued right before Continue", "[api][breakpo
 TEST_CASE("C API reports thread creation and exit", "[api][thread]")
 {
     ApiSession s(FIXTURE("multi_threaded"));
+    REQUIRE(s.Started());
     REQUIRE(s.WaitForSystemBreakpoint());
     ElfBugContinue(s.dbg);
     REQUIRE(s.WaitForExit());
@@ -2531,12 +2538,13 @@ TEST_CASE("C API reports thread creation and exit", "[api][thread]")
     REQUIRE(s.events.exitedTids.size() == 5);
     REQUIRE(created.size() == 5);
     REQUIRE(exited == created);
-    REQUIRE(!created.contains(s.events.pid));
+    REQUIRE(created.count(s.events.pid) == 0);
 }
 
 TEST_CASE("C API reports which thread stopped", "[api][thread]")
 {
     ApiSession s(FIXTURE("threads_spin"));
+    REQUIRE(s.Started());
     REQUIRE(s.WaitForSystemBreakpoint());
     REQUIRE(ElfBugGetCurrentTid(s.dbg) == ElfBugGetPid(s.dbg));
 

--- a/src/cross/cmake.toml
+++ b/src/cross/cmake.toml
@@ -99,7 +99,7 @@ type = "static"
 condition = "linux-x64"
 sources = ["ElfBug/ElfBug/**.cpp"]
 headers = ["ElfBug/ElfBug/**.h"]
-compile-features = ["cxx_std_17"]
+compile-features = ["cxx_std_20"]
 include-directories = ["ElfBug"]
 link-libraries = ["Threads::Threads", "zydis_wrapper"]
 

--- a/src/cross/debugger/core/DbgAdapter.cpp
+++ b/src/cross/debugger/core/DbgAdapter.cpp
@@ -216,11 +216,20 @@ QString DbgAdapter::threadSuffix() const
     return QString(" [thread %1]").arg(ElfBugGetCurrentTid(mDebugger));
 }
 
-void DbgAdapter::emitStoppedState(const QString & reason)
+REGDUMP DbgAdapter::readRegisters() const
 {
     ElfBugRegisters regs = {};
     ElfBugGetRegisters(mDebugger, &regs);
-    auto dump = toRegDump(regs);
+    return toRegDump(regs);
+}
+
+void DbgAdapter::emitStoppedState(const QString & reason)
+{
+    emitStoppedState(reason, readRegisters());
+}
+
+void DbgAdapter::emitStoppedState(const QString & reason, const REGDUMP & dump)
+{
     emit registersUpdated(dump);
     emit stopped(dump.regcontext.cip, reason + threadSuffix());
 }
@@ -254,14 +263,13 @@ void DbgAdapter::onExitThread(const pid_t tid, void* userdata)
 void DbgAdapter::onSystemBreakpoint(void* userdata)
 {
     auto* self = static_cast<DbgAdapter*>(userdata);
-    ElfBugRegisters regs = {};
-    ElfBugGetRegisters(self->mDebugger, &regs);
-    self->mEntryPoint = regs.rip;
+    const REGDUMP dump = self->readRegisters();
+    self->mEntryPoint = dump.regcontext.cip;
 
     emit self->logMessage(QString("[x64dbg] Entry point: 0x%1").arg(self->mEntryPoint, 0, 16));
-    emit self->registersUpdated(toRegDump(regs));
+    emit self->registersUpdated(dump);
     emit self->processCreated(self->mEntryPoint);
-    emit self->stopped(self->mEntryPoint, tr("System breakpoint"));
+    emit self->stopped(self->mEntryPoint, tr("System breakpoint") + self->threadSuffix());
 }
 
 void DbgAdapter::onBreakpoint(const uint64_t address, void* userdata)
@@ -283,26 +291,60 @@ void DbgAdapter::onPaused(void* userdata)
     self->emitStoppedState(tr("Paused"));
 }
 
+// Own table: sigabbrev_np needs glibc 2.32 and the AppImage builds on 2.31.
 static QString signalName(const int signal)
 {
-    const char* abbrev = sigabbrev_np(signal);
-    if(!abbrev)
+    switch(signal)
+    {
+#define SIGNAL_NAME(name) case name: return QStringLiteral(#name);
+        SIGNAL_NAME(SIGHUP)
+        SIGNAL_NAME(SIGINT)
+        SIGNAL_NAME(SIGQUIT)
+        SIGNAL_NAME(SIGILL)
+        SIGNAL_NAME(SIGTRAP)
+        SIGNAL_NAME(SIGABRT)
+        SIGNAL_NAME(SIGBUS)
+        SIGNAL_NAME(SIGFPE)
+        SIGNAL_NAME(SIGKILL)
+        SIGNAL_NAME(SIGUSR1)
+        SIGNAL_NAME(SIGSEGV)
+        SIGNAL_NAME(SIGUSR2)
+        SIGNAL_NAME(SIGPIPE)
+        SIGNAL_NAME(SIGALRM)
+        SIGNAL_NAME(SIGTERM)
+        SIGNAL_NAME(SIGCHLD)
+        SIGNAL_NAME(SIGCONT)
+        SIGNAL_NAME(SIGSTOP)
+        SIGNAL_NAME(SIGTSTP)
+        SIGNAL_NAME(SIGTTIN)
+        SIGNAL_NAME(SIGTTOU)
+        SIGNAL_NAME(SIGURG)
+        SIGNAL_NAME(SIGXCPU)
+        SIGNAL_NAME(SIGXFSZ)
+        SIGNAL_NAME(SIGVTALRM)
+        SIGNAL_NAME(SIGPROF)
+        SIGNAL_NAME(SIGWINCH)
+        SIGNAL_NAME(SIGIO)
+        SIGNAL_NAME(SIGSYS)
+#undef SIGNAL_NAME
+    default:
+        if(signal >= SIGRTMIN && signal <= SIGRTMAX)
+            return QString("SIGRTMIN+%1").arg(signal - SIGRTMIN);
         return QString("signal %1").arg(signal);
-    return QString("SIG%1").arg(abbrev);
+    }
 }
 
 void DbgAdapter::onException(const int signal, const uint64_t address, void* userdata)
 {
     auto* self = static_cast<DbgAdapter*>(userdata);
-    ElfBugRegisters regs = {};
-    ElfBugGetRegisters(self->mDebugger, &regs);
+    const REGDUMP dump = self->readRegisters();
     const QString name = signalName(signal);
 
-    QString msg = QString("[x64dbg] %1 (%2) at 0x%3").arg(name).arg(signal).arg(regs.rip, 0, 16);
+    QString msg = QString("[x64dbg] %1 (%2) at 0x%3").arg(name).arg(signal).arg(dump.regcontext.cip, 0, 16);
     if(address)
         msg += QString(", address 0x%1").arg(address, 0, 16);
     emit self->logMessage(msg + self->threadSuffix());
-    self->emitStoppedState(name);
+    self->emitStoppedState(name, dump);
 }
 
 void DbgAdapter::onError(const char* error, void* userdata)

--- a/src/cross/debugger/core/DbgAdapter.cpp
+++ b/src/cross/debugger/core/DbgAdapter.cpp
@@ -1,5 +1,6 @@
 #include "core/DbgAdapter.h"
 #include <cassert>
+#include <csignal>
 
 static REGDUMP toRegDump(const ElfBugRegisters & regs)
 {
@@ -66,10 +67,13 @@ bool DbgAdapter::loadEngine()
     ElfBugCallbacks cb = {};
     cb.onCreateProcess = &DbgAdapter::onCreateProcess;
     cb.onExitProcess = &DbgAdapter::onExitProcess;
+    cb.onCreateThread = &DbgAdapter::onCreateThread;
+    cb.onExitThread = &DbgAdapter::onExitThread;
     cb.onSystemBreakpoint = &DbgAdapter::onSystemBreakpoint;
     cb.onBreakpoint = &DbgAdapter::onBreakpoint;
     cb.onStep = &DbgAdapter::onStep;
     cb.onPaused = &DbgAdapter::onPaused;
+    cb.onException = &DbgAdapter::onException;
     cb.onError = &DbgAdapter::onError;
     cb.onDebugString = &DbgAdapter::onDebugString;
     cb.userdata = this;
@@ -207,13 +211,18 @@ BPXTYPE DbgAdapter::queryBreakpoint(duint addr)
     return instance->hasBreakpoint(addr) ? bp_normal : bp_none;
 }
 
+QString DbgAdapter::threadSuffix() const
+{
+    return QString(" [thread %1]").arg(ElfBugGetCurrentTid(mDebugger));
+}
+
 void DbgAdapter::emitStoppedState(const QString & reason)
 {
     ElfBugRegisters regs = {};
     ElfBugGetRegisters(mDebugger, &regs);
     auto dump = toRegDump(regs);
     emit registersUpdated(dump);
-    emit stopped(dump.regcontext.cip, reason);
+    emit stopped(dump.regcontext.cip, reason + threadSuffix());
 }
 
 void DbgAdapter::onCreateProcess(const pid_t pid, const uint64_t entryPoint, void* userdata)
@@ -228,6 +237,18 @@ void DbgAdapter::onExitProcess(const int exitCode, void* userdata)
     auto* self = static_cast<DbgAdapter*>(userdata);
     emit self->logMessage(QString("[x64dbg] Process exited: %1").arg(exitCode));
     emit self->processExited(exitCode);
+}
+
+void DbgAdapter::onCreateThread(const pid_t tid, void* userdata)
+{
+    auto* self = static_cast<DbgAdapter*>(userdata);
+    emit self->logMessage(QString("[x64dbg] Thread %1 created").arg(tid));
+}
+
+void DbgAdapter::onExitThread(const pid_t tid, void* userdata)
+{
+    auto* self = static_cast<DbgAdapter*>(userdata);
+    emit self->logMessage(QString("[x64dbg] Thread %1 exited").arg(tid));
 }
 
 void DbgAdapter::onSystemBreakpoint(void* userdata)
@@ -246,7 +267,7 @@ void DbgAdapter::onSystemBreakpoint(void* userdata)
 void DbgAdapter::onBreakpoint(const uint64_t address, void* userdata)
 {
     auto* self = static_cast<DbgAdapter*>(userdata);
-    emit self->logMessage(QString("[x64dbg] Breakpoint hit: 0x%1").arg(address, 0, 16));
+    emit self->logMessage(QString("[x64dbg] Breakpoint hit: 0x%1").arg(address, 0, 16) + self->threadSuffix());
     self->emitStoppedState(QString("Breakpoint at 0x%1").arg(address, 0, 16));
 }
 
@@ -260,6 +281,28 @@ void DbgAdapter::onPaused(void* userdata)
 {
     auto* self = static_cast<DbgAdapter*>(userdata);
     self->emitStoppedState(tr("Paused"));
+}
+
+static QString signalName(const int signal)
+{
+    const char* abbrev = sigabbrev_np(signal);
+    if(!abbrev)
+        return QString("signal %1").arg(signal);
+    return QString("SIG%1").arg(abbrev);
+}
+
+void DbgAdapter::onException(const int signal, const uint64_t address, void* userdata)
+{
+    auto* self = static_cast<DbgAdapter*>(userdata);
+    ElfBugRegisters regs = {};
+    ElfBugGetRegisters(self->mDebugger, &regs);
+    const QString name = signalName(signal);
+
+    QString msg = QString("[x64dbg] %1 (%2) at 0x%3").arg(name).arg(signal).arg(regs.rip, 0, 16);
+    if(address)
+        msg += QString(", address 0x%1").arg(address, 0, 16);
+    emit self->logMessage(msg + self->threadSuffix());
+    self->emitStoppedState(name);
 }
 
 void DbgAdapter::onError(const char* error, void* userdata)

--- a/src/cross/debugger/core/DbgAdapter.h
+++ b/src/cross/debugger/core/DbgAdapter.h
@@ -53,13 +53,17 @@ private:
 
     static void onCreateProcess(pid_t pid, uint64_t entryPoint, void* userdata);
     static void onExitProcess(int exitCode, void* userdata);
+    static void onCreateThread(pid_t tid, void* userdata);
+    static void onExitThread(pid_t tid, void* userdata);
     static void onSystemBreakpoint(void* userdata);
     static void onBreakpoint(uint64_t address, void* userdata);
     static void onStep(void* userdata);
     static void onPaused(void* userdata);
+    static void onException(int signal, uint64_t address, void* userdata);
     static void onError(const char* error, void* userdata);
     static void onDebugString(const char* text, void* userdata);
 
+    [[nodiscard]] QString threadSuffix() const;
     void emitStoppedState(const QString & reason);
 
     ElfBugDebugger* mDebugger = nullptr;

--- a/src/cross/debugger/core/DbgAdapter.h
+++ b/src/cross/debugger/core/DbgAdapter.h
@@ -64,7 +64,9 @@ private:
     static void onDebugString(const char* text, void* userdata);
 
     [[nodiscard]] QString threadSuffix() const;
+    [[nodiscard]] REGDUMP readRegisters() const;
     void emitStoppedState(const QString & reason);
+    void emitStoppedState(const QString & reason, const REGDUMP & dump);
 
     ElfBugDebugger* mDebugger = nullptr;
     duint mEntryPoint = 0;


### PR DESCRIPTION
Adds exception, thread create and thread exit callbacks plus a current tid to the ElfBug C API - now the user can see this information cleanly.